### PR TITLE
Add Support for Bitwise XOR opeator(^) Token in Translator Codegen Frontend #108

### DIFF
--- a/crosstl/src/translator/codegen/directx_codegen.py
+++ b/crosstl/src/translator/codegen/directx_codegen.py
@@ -354,7 +354,7 @@ class HLSLCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
-            "BITWISE_XOR" : "^",
+            "BITWISE_XOR": "^",
             "LESS_THAN": "<",
             "GREATER_THAN": ">",
             "ASSIGN_ADD": "+=",

--- a/crosstl/src/translator/codegen/directx_codegen.py
+++ b/crosstl/src/translator/codegen/directx_codegen.py
@@ -354,6 +354,7 @@ class HLSLCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
+            "BITWISE_XOR" : "^",
             "LESS_THAN": "<",
             "GREATER_THAN": ">",
             "ASSIGN_ADD": "+=",

--- a/crosstl/src/translator/codegen/metal_codegen.py
+++ b/crosstl/src/translator/codegen/metal_codegen.py
@@ -414,6 +414,7 @@ class MetalCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
+            "BITWISE_XOR" : "^",
             "LESS_THAN": "<",
             "ASSIGN_ADD": "+=",
             "ASSIGN_SUB": "-=",

--- a/crosstl/src/translator/codegen/metal_codegen.py
+++ b/crosstl/src/translator/codegen/metal_codegen.py
@@ -414,7 +414,7 @@ class MetalCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
-            "BITWISE_XOR" : "^",
+            "BITWISE_XOR": "^",
             "LESS_THAN": "<",
             "ASSIGN_ADD": "+=",
             "ASSIGN_SUB": "-=",

--- a/crosstl/src/translator/codegen/opengl_codegen.py
+++ b/crosstl/src/translator/codegen/opengl_codegen.py
@@ -271,7 +271,7 @@ class GLSLCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
-            "BITWISE_XOR":"^",
+            "BITWISE_XOR": "^",
             "LESS_THAN": "<",
             "ASSIGN_ADD": "+=",
             "ASSIGN_SUB": "-=",

--- a/crosstl/src/translator/codegen/opengl_codegen.py
+++ b/crosstl/src/translator/codegen/opengl_codegen.py
@@ -271,6 +271,7 @@ class GLSLCodeGen:
             "MINUS": "-",
             "MULTIPLY": "*",
             "DIVIDE": "/",
+            "BITWISE_XOR":"^",
             "LESS_THAN": "<",
             "ASSIGN_ADD": "+=",
             "ASSIGN_SUB": "-=",

--- a/crosstl/src/translator/lexer.py
+++ b/crosstl/src/translator/lexer.py
@@ -54,7 +54,6 @@ TOKENS = [
     ("ASSIGN_XOR", r"\^="),
     ("LOGICAL_AND", r"&&"),
     ("LOGICAL_OR", r"\|\|"),
-    # ("XOR", r"\^"),
     ("NOT", r"!"),
     ("ASSIGN_MOD", r"%="),
     ("MOD", r"%"),

--- a/crosstl/src/translator/lexer.py
+++ b/crosstl/src/translator/lexer.py
@@ -54,7 +54,7 @@ TOKENS = [
     ("ASSIGN_XOR", r"\^="),
     ("LOGICAL_AND", r"&&"),
     ("LOGICAL_OR", r"\|\|"),
-    #("XOR", r"\^"),
+    # ("XOR", r"\^"),
     ("NOT", r"!"),
     ("ASSIGN_MOD", r"%="),
     ("MOD", r"%"),

--- a/crosstl/src/translator/lexer.py
+++ b/crosstl/src/translator/lexer.py
@@ -54,7 +54,7 @@ TOKENS = [
     ("ASSIGN_XOR", r"\^="),
     ("LOGICAL_AND", r"&&"),
     ("LOGICAL_OR", r"\|\|"),
-    ("XOR", r"\^"),
+    #("XOR", r"\^"),
     ("NOT", r"!"),
     ("ASSIGN_MOD", r"%="),
     ("MOD", r"%"),

--- a/crosstl/src/translator/parser.py
+++ b/crosstl/src/translator/parser.py
@@ -644,6 +644,7 @@ class Parser:
             "ASSIGN_MOD",
             "BITWISE_SHIFT_RIGHT",
             "BITWISE_SHIFT_LEFT",
+            "BITWISE_XOR",
             "ASSIGN_SHIFT_RIGHT",
         ]:
             return self.parse_assignment(name)
@@ -705,6 +706,7 @@ class Parser:
             "ASSIGN_MOD",
             "BITWISE_SHIFT_RIGHT",
             "BITWISE_SHIFT_LEFT",
+            "BITWISE_XOR",
             "ASSIGN_SHIFT_RIGHT",
         ]:
             op = self.current_token[1]
@@ -736,6 +738,7 @@ class Parser:
             "GREATER_EQUAL",
             "BITWISE_SHIFT_RIGHT",
             "BITWISE_SHIFT_LEFT",
+            "BITWISE_XOR",
             "EQUAL",
             "ASSIGN_AND",
             "ASSIGN_OR",
@@ -795,6 +798,7 @@ class Parser:
             "ASSIGN_MOD",
             "BITWISE_SHIFT_RIGHT",
             "BITWISE_SHIFT_LEFT",
+            "BITWISE_XOR",
             "ASSIGN_SHIFT_RIGHT",
         ]:
             op = self.current_token[0]
@@ -960,6 +964,7 @@ class Parser:
             "ASSIGN_MOD",
             "BITWISE_SHIFT_RIGHT",
             "BITWISE_SHIFT_LEFT",
+            "BITWISE_XOR",
             "ASSIGN_SHIFT_RIGHT",
         ]:
             op = self.current_token[0]

--- a/tests/test_translator/test_parser.py
+++ b/tests/test_translator/test_parser.py
@@ -416,7 +416,7 @@ def test_assign_ops():
     except SyntaxError:
         pytest.fail("Assignment Operator parsing not implemented.")
 
-        
+
 def test_bitwise_operators():
     code = """
         shader LightControl {
@@ -443,7 +443,7 @@ def test_bitwise_operators():
     except SyntaxError:
         pytest.fail("Bitwise Shift not working")
 
-        
+
 def test_xor_operator():
     code = """
     shader XorTestShader {
@@ -477,6 +477,6 @@ def test_xor_operator():
     except SyntaxError:
         pytest.fail("Bitwise XOR not working")
 
-  
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_translator/test_parser.py
+++ b/tests/test_translator/test_parser.py
@@ -442,3 +442,37 @@ def test_bitwise_operators():
         parse_code(tokens)
     except SyntaxError:
         pytest.fail("Bitwise Shift not working")
+
+
+def test_xor_operator():
+    code = """
+    shader XorTestShader {
+    vertex {
+        input vec3 position;
+        output vec2 vUV;
+
+        void main() {
+            // Perform XOR on the x and y components of the position
+            vUV.x = float(int(position.x) ^ 3);  // XOR with 3
+            vUV.y = float(int(position.y) ^ 5);  // XOR with 5
+            gl_Position = vec4(position, 1.0);
+        }
+    }
+
+    fragment {
+        input vec2 vUV;
+        output vec4 fragColor;
+
+        void main() {
+            // Use XOR in fragment shader
+            float result = float(int(vUV.x) ^ int(vUV.y));
+            fragColor = vec4(result / 10.0, 1.0 - result / 10.0, 0.0, 1.0);
+        }
+    }
+    }
+    """
+    try:
+        tokens = tokenize_code(code)
+        parse_code(tokens)
+    except SyntaxError:
+        pytest.fail("Bitwise XOR not working")


### PR DESCRIPTION
### PR Description
This PR implements support for the Bitwise Operator (^) token in the CrossGL project, addressing issue #108  . The token is now properly translated across the DirectX, Metal, and OpenGL backends.

### Related Issue
#108 

### shader Sample

```crossgl
shader XorTestShader {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            // Perform XOR on the x and y components of the position
            vUV.x = float(int(position.x) ^ 3);  // XOR with 3
            vUV.y = float(int(position.y) ^ 5);  // XOR with 5
            gl_Position = vec4(position, 1.0);
        }
    }

    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            // Use XOR in fragment shader
            float result = float(int(vUV.x) ^ int(vUV.y));
            fragColor = vec4(result / 10.0, 1.0 - result / 10.0, 0.0, 1.0);
        }
    }
    }
```


### Checklist
- [X] Have you added the necessary tests?
- [ ] Only modified the files mentioned in the related issue(s)?
- [X] Are all tests passing?

For supporting bit-wise operator support maybe `crosstl/src/translator/parser.py ` needs to be modified
