### PR TITLE
Add Support for Bitwise shift opeators

### DIFF
--- a/crosstl/src/translator/codegen/directx_codegen.py
+++ b/crosstl/src/translator/codegen/directx_codegen.py
@@ -371,5 +371,7 @@ class HLSLCodeGen:
             "OR": "||",
             "EQUALS": "=",
             "ASSIGN_SHIFT_LEFT": "<<=",
+            "BITWISE_SHIFT_RIGHT": ">>",
+            "BITWISE_SHIFT_LEFT": "<<",
         }
         return op_map.get(op, op)

--- a/crosstl/src/translator/codegen/metal_codegen.py
+++ b/crosstl/src/translator/codegen/metal_codegen.py
@@ -431,5 +431,7 @@ class MetalCodeGen:
             "OR": "||",
             "EQUALS": "=",
             "ASSIGN_SHIFT_LEFT": "<<=",
+            "BITWISE_SHIFT_RIGHT": ">>",
+            "BITWISE_SHIFT_LEFT": "<<",
         }
         return op_map.get(op, op)

--- a/crosstl/src/translator/codegen/opengl_codegen.py
+++ b/crosstl/src/translator/codegen/opengl_codegen.py
@@ -288,5 +288,7 @@ class GLSLCodeGen:
             "OR": "||",
             "EQUALS": "=",
             "ASSIGN_SHIFT_LEFT": "<<=",
+            "BITWISE_SHIFT_RIGHT": ">>",
+            "BITWISE_SHIFT_LEFT": "<<",
         }
         return op_map.get(op, op)

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -386,6 +386,7 @@ def test_assignment_shift_operators():
     except SyntaxError:
         pytest.fail("Assignment shift parsing not implemented.")
 
+
 def test_bitwise_operators():
     code = """
         shader LightControl {

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -384,7 +384,35 @@ def test_assignment_shift_operators():
         code = generate_code(ast)
         print(code)
     except SyntaxError:
-        pytest.fail("Struct parsing not implemented.")
+        pytest.fail("Assignment shift parsing not implemented.")
+
+def test_bitwise_operators():
+    code = """
+        shader LightControl {
+        vertex {
+            input vec3 position;
+            output int isLightOn;
+            void main() {        
+                    isLightOn = 2 >> 1;
+            }
+        }
+        fragment {
+            input int isLightOn;
+            output vec4 fragColor;
+            void main() {
+                isLightOn = isLightOn << 1;
+            }
+        }
+    }
+
+    """
+    try:
+        tokens = tokenize_code(code)
+        ast = parse_code(tokens)
+        code = generate_code(ast)
+        print(code)
+    except SyntaxError:
+        pytest.fail("Bitwise Shift parsing not implemented.")
 
 
 if __name__ == "__main__":

--- a/tests/test_translator/test_codegen/test_metal_codegen.py
+++ b/tests/test_translator/test_codegen/test_metal_codegen.py
@@ -322,6 +322,33 @@ def test_assignment_shift_operators():
     except SyntaxError:
         pytest.fail("Struct parsing not implemented.")
 
+def test_bitwise_operators():
+    code = """
+        shader LightControl {
+        vertex {
+            input vec3 position;
+            output int isLightOn;
+            void main() {        
+                    isLightOn = 2 >> 1;
+            }
+        }
+        fragment {
+            input int isLightOn;
+            output vec4 fragColor;
+            void main() {
+                isLightOn = isLightOn << 1;
+            }
+        }
+    }
 
+    """
+    try:
+        tokens = tokenize_code(code)
+        ast = parse_code(tokens)
+        code = generate_code(ast)
+        print(code)
+    except SyntaxError:
+        pytest.fail("Bitwise Shift parsing not implemented.")
+        
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_translator/test_codegen/test_metal_codegen.py
+++ b/tests/test_translator/test_codegen/test_metal_codegen.py
@@ -322,6 +322,7 @@ def test_assignment_shift_operators():
     except SyntaxError:
         pytest.fail("Struct parsing not implemented.")
 
+
 def test_bitwise_operators():
     code = """
         shader LightControl {
@@ -349,6 +350,7 @@ def test_bitwise_operators():
         print(code)
     except SyntaxError:
         pytest.fail("Bitwise Shift parsing not implemented.")
-        
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_translator/test_codegen/test_opengl_codegen.py
+++ b/tests/test_translator/test_codegen/test_opengl_codegen.py
@@ -322,6 +322,33 @@ def test_assignment_shift_operators():
     except SyntaxError:
         pytest.fail("Struct parsing not implemented.")
 
+def test_bitwise_operators():
+    code = """
+        shader LightControl {
+        vertex {
+            input vec3 position;
+            output int isLightOn;
+            void main() {        
+                    isLightOn = 2 >> 1;
+            }
+        }
+        fragment {
+            input int isLightOn;
+            output vec4 fragColor;
+            void main() {
+                isLightOn = isLightOn << 1;
+            }
+        }
+    }
 
+    """
+    try:
+        tokens = tokenize_code(code)
+        ast = parse_code(tokens)
+        code = generate_code(ast)
+        print(code)
+    except SyntaxError:
+        pytest.fail("Bitwise Shift parsing not implemented.")
+        
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_translator/test_codegen/test_opengl_codegen.py
+++ b/tests/test_translator/test_codegen/test_opengl_codegen.py
@@ -322,6 +322,7 @@ def test_assignment_shift_operators():
     except SyntaxError:
         pytest.fail("Struct parsing not implemented.")
 
+
 def test_bitwise_operators():
     code = """
         shader LightControl {
@@ -349,6 +350,7 @@ def test_bitwise_operators():
         print(code)
     except SyntaxError:
         pytest.fail("Bitwise Shift parsing not implemented.")
-        
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
### PR Description
Added the translator support for Bitwise Shift Left token ```<<```  and bitwise shift right  ```>>``` Token in Translator Codegen Frontend

Modified the codegen files at translator frontend and added tests
### Related Issue
<!-- Link to the related issue(s) that this PR addresses. Example: #123 -->
Close #110  
Close #111 
### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
        shader LightControl {
        vertex {
            input vec3 position;
            output int isLightOn;
            void main() {        
                    isLightOn = 2 >> 1;
            }
        }
        fragment {
            input int isLightOn;
            output vec4 fragColor;
            void main() {
                isLightOn = isLightOn << 1;
            }
        }
    }
```-->


### Checklist
- [x] Have you added the necessary tests?
- [ ] Only modified the files mentioned in the related issue(s)?
- [x] Are all tests passing?


