### PR TITLE
Fixes MetalCrossGL codegen removing @

### DIFF
--- a/crosstl/src/backend/Metal/MetalCrossGLCodeGen.py
+++ b/crosstl/src/backend/Metal/MetalCrossGLCodeGen.py
@@ -242,10 +242,10 @@ class MetalToCrossGLConverter:
                         out = self.map_semantics.get(
                             f"{name}({args[0]})", f"{name}({args[0]})"
                         )
-                        return f"@{out}"
+                        return f"{out}"
                     else:
                         out = self.map_semantics.get(f"{name}", f"{name}")
-                        return f"@{out}"
+                        return f"{out}"
                 else:
                     return ""
         else:


### PR DESCRIPTION
changes removes the @ from variable names when converting `metal` to `crossgl` 
```C
    // Structs
    struct VertexInput {
        vec3 position @Position;
    }

    // Structs
    struct VertexOutput {
        vec4 position @gl_Position;
        vec2 uv ;
    }
```
after changes:
```C
    // Structs
    struct VertexInput {
        vec3 position Position;
    }

    // Structs
    struct VertexOutput {
        vec4 position gl_Position;
        vec2 uv ;
    }
```