### PR TITLE
Add BITWISE_XOR operator support in lexer and parser 

### DIFF
--- a/crosstl/src/backend/DirectX/DirectxLexer.py
+++ b/crosstl/src/backend/DirectX/DirectxLexer.py
@@ -48,6 +48,7 @@ TOKENS = [
     ("ASSIGN_XOR", r"\^="),
     ("ASSIGN_OR", r"\|="),
     ("ASSIGN_AND", r"\&="),
+    ("BITWISE_XOR", r"\^"),
     ("AND", r"&&"),
     ("OR", r"\|\|"),
     ("DOT", r"\."),

--- a/crosstl/src/backend/DirectX/DirectxParser.py
+++ b/crosstl/src/backend/DirectX/DirectxParser.py
@@ -2,8 +2,6 @@ from .DirectxAst import (
     AssignmentNode,
     BinaryOpNode,
     ForNode,
-    WhileNode,
-    DoWhileNode,
     FunctionCallNode,
     FunctionNode,
     IfNode,
@@ -197,10 +195,6 @@ class HLSLParser:
             return self.parse_for_statement()
         elif self.current_token[0] == "RETURN":
             return self.parse_return_statement()
-        elif self.current_token[0] == "WHILE":
-            return self.parse_while_statement()
-        elif self.current_token[0] == "DO":
-            return self.parse_do_while_statement()
         else:
             return self.parse_expression_statement()
 
@@ -237,8 +231,8 @@ class HLSLParser:
                     "DIVIDE_EQUALS",
                     "ASSIGN_XOR",
                     "ASSIGN_OR",
-                    "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "BITWISE_XOR",
                 ]:
                     # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
                     op = self.current_token[1]
@@ -255,8 +249,8 @@ class HLSLParser:
                 "DIVIDE_EQUALS",
                 "ASSIGN_XOR",
                 "ASSIGN_OR",
-                "ASSIGN_AND",
                 "SHIFT_LEFT",
+                "BITWISE_XOR",
             ]:
                 # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
                 op = self.current_token[1]
@@ -276,8 +270,8 @@ class HLSLParser:
                     "DIVIDE_EQUALS",
                     "ASSIGN_XOR",
                     "ASSIGN_OR",
-                    "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "BITWISE_XOR",
                 ]:
                     op = self.current_token[1]
                     self.eat(self.current_token[0])
@@ -352,35 +346,6 @@ class HLSLParser:
 
         return ForNode(init, condition, update, body)
 
-    def parse_while_statement(self):
-        self.eat("WHILE")
-        self.eat("LPAREN")
-
-        # Parse condition
-        condition = self.parse_expression()
-        self.eat("RPAREN")
-
-        # Parse body
-        body = self.parse_block()
-
-        return WhileNode(condition, body)
-
-    def parse_do_while_statement(self):
-        # do token
-        self.eat("DO")
-
-        # parse do block
-        body = self.parse_block()
-
-        # parse while condition
-        self.eat("WHILE")
-        self.eat("LPAREN")
-        condition = self.parse_expression()
-        self.eat("RPAREN")
-        self.eat("SEMICOLON")
-
-        return DoWhileNode(condition, body)
-
     def parse_return_statement(self):
         self.eat("RETURN")
         value = self.parse_expression()
@@ -405,8 +370,7 @@ class HLSLParser:
             "DIVIDE_EQUALS",
             "ASSIGN_XOR",
             "ASSIGN_OR",
-            "ASSIGN_AND",
-            "SHIFT_LEFT",
+            "BITWISE_XOR",
         ]:
             op = self.current_token[1]
             self.eat(self.current_token[0])
@@ -445,7 +409,6 @@ class HLSLParser:
         left = self.parse_additive()
         while self.current_token[0] in [
             "LESS_THAN",
-            "SHIFT_LEFT",
             "GREATER_THAN",
             "LESS_EQUAL",
             "GREATER_EQUAL",

--- a/crosstl/src/backend/DirectX/DirectxParser.py
+++ b/crosstl/src/backend/DirectX/DirectxParser.py
@@ -2,6 +2,8 @@ from .DirectxAst import (
     AssignmentNode,
     BinaryOpNode,
     ForNode,
+    WhileNode,
+    DoWhileNode,
     FunctionCallNode,
     FunctionNode,
     IfNode,
@@ -195,6 +197,10 @@ class HLSLParser:
             return self.parse_for_statement()
         elif self.current_token[0] == "RETURN":
             return self.parse_return_statement()
+        elif self.current_token[0] == "WHILE":
+            return self.parse_while_statement()
+        elif self.current_token[0] == "DO":
+            return self.parse_do_while_statement()
         else:
             return self.parse_expression_statement()
 
@@ -231,6 +237,7 @@ class HLSLParser:
                     "DIVIDE_EQUALS",
                     "ASSIGN_XOR",
                     "ASSIGN_OR",
+                    "ASSIGN_AND",
                     "SHIFT_LEFT",
                     "BITWISE_XOR",
                 ]:
@@ -249,6 +256,7 @@ class HLSLParser:
                 "DIVIDE_EQUALS",
                 "ASSIGN_XOR",
                 "ASSIGN_OR",
+                "ASSIGN_AND",
                 "SHIFT_LEFT",
                 "BITWISE_XOR",
             ]:
@@ -270,6 +278,7 @@ class HLSLParser:
                     "DIVIDE_EQUALS",
                     "ASSIGN_XOR",
                     "ASSIGN_OR",
+                    "ASSIGN_AND",
                     "SHIFT_LEFT",
                     "BITWISE_XOR",
                 ]:
@@ -346,6 +355,35 @@ class HLSLParser:
 
         return ForNode(init, condition, update, body)
 
+    def parse_while_statement(self):
+        self.eat("WHILE")
+        self.eat("LPAREN")
+
+        # Parse condition
+        condition = self.parse_expression()
+        self.eat("RPAREN")
+
+        # Parse body
+        body = self.parse_block()
+
+        return WhileNode(condition, body)
+
+    def parse_do_while_statement(self):
+        # do token
+        self.eat("DO")
+
+        # parse do block
+        body = self.parse_block()
+
+        # parse while condition
+        self.eat("WHILE")
+        self.eat("LPAREN")
+        condition = self.parse_expression()
+        self.eat("RPAREN")
+        self.eat("SEMICOLON")
+
+        return DoWhileNode(condition, body)
+
     def parse_return_statement(self):
         self.eat("RETURN")
         value = self.parse_expression()
@@ -370,6 +408,8 @@ class HLSLParser:
             "DIVIDE_EQUALS",
             "ASSIGN_XOR",
             "ASSIGN_OR",
+            "ASSIGN_AND",
+            "SHIFT_LEFT",
             "BITWISE_XOR",
         ]:
             op = self.current_token[1]
@@ -409,9 +449,11 @@ class HLSLParser:
         left = self.parse_additive()
         while self.current_token[0] in [
             "LESS_THAN",
+            "SHIFT_LEFT",
             "GREATER_THAN",
             "LESS_EQUAL",
             "GREATER_EQUAL",
+            "BITWISE_XOR",
         ]:
             op = self.current_token[1]
             self.eat(self.current_token[0])

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -438,6 +438,15 @@ def test_assignment_ops_parsing():
             output.redValue &= 0x3;
         }
 
+        // Testing BITWISE_XOR (^) operator on some condition
+        if (input.in_position.r == 0.5) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;  
+            // BITWISE_XOR operation
+            output.out_color.r = asfloat(redValue);
+        }
+
+
 
         return output;
     }

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -441,7 +441,7 @@ def test_assignment_ops_parsing():
         // Testing BITWISE_XOR (^) operator on some condition
         if (input.in_position.r == 0.5) {
             uint redValue = asuint(output.out_color.r);
-            output.redValue ^= 0x1;  
+            output.redValue ^ 0x1;  
             // BITWISE_XOR operation
             output.out_color.r = asfloat(redValue);
         }

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -205,7 +205,7 @@ def test_assignment_ops_parsing():
         // Testing BITWISE_XOR (^) operator on some condition
         if (input.in_position.r == 0.5) {
             uint redValue = asuint(output.out_color.r);
-            output.redValue ^= 0x1;  // BITWISE_XOR operation
+            output.redValue ^ 0x1;  // BITWISE_XOR operation
             output.out_color.r = asfloat(redValue);
         }
 

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -202,6 +202,14 @@ def test_assignment_ops_parsing():
             output.redValue &= 0x3;
         }
 
+        // Testing BITWISE_XOR (^) operator on some condition
+        if (input.in_position.r == 0.5) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;  // BITWISE_XOR operation
+            output.out_color.r = asfloat(redValue);
+        }
+
+
 
         return output;
     }


### PR DESCRIPTION
### PR Description
Add BITWISE_XOR operator support in lexer and parser #180

### Related Issue
close #180 

### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            vUV = position.xy * 10.0;
            gl_Position = vec4(position, 1.0);
        }
    }

    // Perlin Noise Function
    float perlinNoise(vec2 p) {
        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
    }

    // Fragment Shader
    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            float noise = perlinNoise(vUV);
            float height = noise * 10.0;
            vec3 color = vec3(height / 10.0, 1.0 - height / 10.0, 0.0);
            fragColor = vec4(color, 1.0);
        }
    }
}
```-->


### Checklist
- [x] Have you added the necessary tests?
- [x] Only modified the files mentioned in the related issue(s)?
- [x] Are all tests passing?


