### PR TITLE
Add BITWISE_OR operator support in lexer and parser

### DIFF
--- a/crosstl/src/backend/DirectX/DirectxLexer.py
+++ b/crosstl/src/backend/DirectX/DirectxLexer.py
@@ -50,6 +50,7 @@ TOKENS = [
     ("ASSIGN_AND", r"\&="),
     ("AND", r"&&"),
     ("OR", r"\|\|"),
+    ("BITWISE_OR", r"\|"),
     ("DOT", r"\."),
     ("MULTIPLY", r"\*"),
     ("DIVIDE", r"/"),

--- a/crosstl/src/backend/DirectX/DirectxParser.py
+++ b/crosstl/src/backend/DirectX/DirectxParser.py
@@ -239,6 +239,7 @@ class HLSLParser:
                     "ASSIGN_OR",
                     "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "BITWISE_OR",
                 ]:
                     # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
                     op = self.current_token[1]
@@ -257,6 +258,7 @@ class HLSLParser:
                 "ASSIGN_OR",
                 "ASSIGN_AND",
                 "SHIFT_LEFT",
+                "BITWISE_OR",
             ]:
                 # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
                 op = self.current_token[1]
@@ -278,6 +280,7 @@ class HLSLParser:
                     "ASSIGN_OR",
                     "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "BITWISE_OR",
                 ]:
                     op = self.current_token[1]
                     self.eat(self.current_token[0])
@@ -407,6 +410,7 @@ class HLSLParser:
             "ASSIGN_OR",
             "ASSIGN_AND",
             "SHIFT_LEFT",
+            "BITWISE_OR",
         ]:
             op = self.current_token[1]
             self.eat(self.current_token[0])

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -403,6 +403,14 @@ def test_else_if_codegen():
     except SyntaxError:
         pytest.fail("Else_if statement parsing or code generation not implemented.")
 
+def test_bitwise_or_codegen():
+    code = """
+    uint val = 0x01;
+    val = val | 0x02;
+    """
+    generated_code = codegen.generate(code)
+    assert "| 0x02" in generated_code
+
 
 def test_assignment_ops_parsing():
     code = """

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -147,6 +147,15 @@ def test_assignment_ops_tokenization():
             redValue &= 0x3;
         }
 
+        // Testing BITWISE_XOR (^) operator on some condition
+        if (input.in_position.r == 0.5) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;  
+            // BITWISE_XOR operation
+            output.out_color.r = asfloat(redValue);
+        }
+
+
 
         return output;
     }
@@ -155,6 +164,14 @@ def test_assignment_ops_tokenization():
         tokenize_code(code)
     except SyntaxError:
         pytest.fail("assign_op tokenization is not implemented.")
+
+def test_bitwise_or_tokenization():
+    code = """
+    uint val = 0x01;
+    val = val | 0x02;
+    """
+    tokens = lexer.tokenize(code)
+    assert ("BITWISE_OR", "|") in tokens
 
 
 if __name__ == "__main__":

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -205,7 +205,19 @@ def test_assignment_ops_parsing():
 
         return output;
     }
+
     """
+
+    def test_bitwise_or_parsing():
+    code = """
+    uint val = 0x01;
+    if (val | 0x02) {
+        // Test case for bitwise OR
+    }
+    """
+    parsed_output = parser.parse(code)
+    assert "BITWISE_OR" in parsed_output
+
     try:
         tokens = tokenize_code(code)
         parse_code(tokens)


### PR DESCRIPTION
### PR Description
Add BITWISE_OR operator support in lexer and parser

### Related Issue
#179 

### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            vUV = position.xy * 10.0;
            gl_Position = vec4(position, 1.0);
        }
    }

    // Perlin Noise Function
    float perlinNoise(vec2 p) {
        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
    }

    // Fragment Shader
    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            float noise = perlinNoise(vUV);
            float height = noise * 10.0;
            vec3 color = vec3(height / 10.0, 1.0 - height / 10.0, 0.0);
            fragColor = vec4(color, 1.0);
        }
    }
}
```-->


### Checklist
- [ ] Have you added the necessary tests?
- [ ] Only modified the files mentioned in the related issue(s)?
- [ ] Are all tests passing?


