### PR TITLE
Add shift right

### DIFF
--- a/crosstl/src/backend/DirectX/DirectxLexer.py
+++ b/crosstl/src/backend/DirectX/DirectxLexer.py
@@ -35,6 +35,7 @@ TOKENS = [
     ("COLON", r":"),
     ("QUESTION", r"\?"),
     ("SHIFT_LEFT", r"<<"),
+    ("SHIFT_RIGHT",r">>"),
     ("LESS_EQUAL", r"<="),
     ("GREATER_EQUAL", r">="),
     ("LESS_THAN", r"<"),

--- a/crosstl/src/backend/DirectX/DirectxLexer.py
+++ b/crosstl/src/backend/DirectX/DirectxLexer.py
@@ -35,7 +35,7 @@ TOKENS = [
     ("COLON", r":"),
     ("QUESTION", r"\?"),
     ("SHIFT_LEFT", r"<<"),
-    ("SHIFT_RIGHT",r">>"),
+    ("SHIFT_RIGHT", r">>"),
     ("LESS_EQUAL", r"<="),
     ("GREATER_EQUAL", r">="),
     ("LESS_THAN", r"<"),

--- a/crosstl/src/backend/DirectX/DirectxParser.py
+++ b/crosstl/src/backend/DirectX/DirectxParser.py
@@ -239,6 +239,7 @@ class HLSLParser:
                     "ASSIGN_OR",
                     "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "SHIFT_RIGHT",
                     "BITWISE_OR",
                     "BITWISE_XOR",
                 ]:
@@ -259,6 +260,7 @@ class HLSLParser:
                 "ASSIGN_OR",
                 "ASSIGN_AND",
                 "SHIFT_LEFT",
+                "SHIFT_RIGHT",
                 "BITWISE_OR",
                 "BITWISE_XOR",
             ]:
@@ -282,6 +284,7 @@ class HLSLParser:
                     "ASSIGN_OR",
                     "ASSIGN_AND",
                     "SHIFT_LEFT",
+                    "SHIFT_RIGHT",
                     "BITWISE_OR",
                     "BITWISE_XOR",
                 ]:
@@ -413,6 +416,7 @@ class HLSLParser:
             "ASSIGN_OR",
             "ASSIGN_AND",
             "SHIFT_LEFT",
+            "SHIFT_RIGHT",
             "BITWISE_OR",
             "BITWISE_XOR",
         ]:
@@ -454,6 +458,7 @@ class HLSLParser:
         while self.current_token[0] in [
             "LESS_THAN",
             "SHIFT_LEFT",
+            "SHIFT_RIGHT",
             "GREATER_THAN",
             "LESS_EQUAL",
             "GREATER_EQUAL",

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -439,15 +439,15 @@ def test_assignment_ops_codegen():
         }
         
         // Testing SHIFT_RIGHT (>>) operator on some condition
-        if (input.in_position.r == 0.25){
-            uint greenValue = asuint(output.out_color.g);
-            output.greenValue ^= 0x1; 
-            output.out_color.g = asfloat(greenValue)
-            
-            output.greenValue |= 0x4;
-            //Applying shift right operation
-            output.greenValue >> 1; // Shift right by 1
-            output.greenValue &= 0x7;
+        if (input.in_position.r == 0.25) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;
+            output.out_color.r = asfloat(redValue);
+
+            output.redValue |= 0x2;
+            // Applying shift left operation
+            output.redValue >> 1; // Shift left by 1
+            output.redValue &= 0x3;
         } 
         
         // Testing BITWISE_XOR (^) operator on some condition

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -437,7 +437,19 @@ def test_assignment_ops_codegen():
             output.redValue << 1; // Shift left by 1
             output.redValue &= 0x3;
         }
-
+        
+        // Testing SHIFT_RIGHT (>>) operator on some condition
+        if (input.in_position.r == 0.25){
+            uint greenValue = asuint(output.out_color.g);
+            output.greenValue ^= 0x1; 
+            output.out_color.g = asfloat(greenValue)
+            
+            output.greenValue |= 0x4;
+            //Applying shift right operation
+            output.greenValue >> 1; // Shift right by 1
+            output.greenValue &= 0x7;
+        } 
+        
         // Testing BITWISE_XOR (^) operator on some condition
         if (input.in_position.r == 0.5) {
             uint redValue = asuint(output.out_color.r);

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -146,6 +146,20 @@ def test_assignment_ops_tokenization():
 
             redValue &= 0x3;
         }
+        
+        // Testing SHIFT RIGHT (>>) operator on some condition
+        if (input.in_position.r == 0.5) {
+            uint greenValue = asuint(output.out_color.g);
+            output.greenValue ^= 0x1; 
+            output.out_color.g = asfloat(greenValue);
+            output.greenValue |= 0x2;
+            
+            // Applying shift right operation
+            output.greenValue >> 1; // Shift right by 1
+            greenValue |= 0x2;
+            
+            greenValue &= 0x7;
+        }
 
 
         return output;

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -148,17 +148,17 @@ def test_assignment_ops_tokenization():
         }
         
         // Testing SHIFT RIGHT (>>) operator on some condition
-        if (input.in_position.r == 0.5) {
-            uint greenValue = asuint(output.out_color.g);
-            output.greenValue ^= 0x1; 
-            output.out_color.g = asfloat(greenValue);
-            output.greenValue |= 0x2;
-            
-            // Applying shift right operation
-            output.greenValue >> 1; // Shift right by 1
-            greenValue |= 0x2;
-            
-            greenValue &= 0x7;
+        if (input.in_position.r == 0.25) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;
+            output.out_color.r = asfloat(redValue);
+            output.redValue |= 0x2;
+
+            // Applying shift left operation
+            output.redValue >> 1; // Shift left by 1
+            redValue |= 0x2;
+
+            redValue &= 0x3;
         }
 
 

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -202,16 +202,16 @@ def test_assignment_ops_parsing():
             output.redValue &= 0x3;
         }
         
-        // Testing SHIFT_RIGHT (>>) operator on some condition
-        if (input.in_position.g == 0.25) {
-            uint greenValue = asuint(output.out_color.g);
-            output.greenValue ^= 0x1;
-            output.out_color.g = asfloat(greenValue)
-            
-            output.greenValue |= 0x2;
-            // Applying shift right operation
-            output.greenValue >> 1;  // Shift right by 1
-            output.greenValue &= 0x3;
+        // Testing SHIFT_LEFT (>>) operator on some condition
+        if (input.in_position.r == 0.25) {
+            uint redValue = asuint(output.out_color.r);
+            output.redValue ^= 0x1;
+            output.out_color.r = asfloat(redValue);
+
+            output.redValue |= 0x2;
+            // Applying shift left operation
+            output.redValue >> 1; // Shift left by 1
+            output.redValue &= 0x3;
         }
 
         // Testing BITWISE_XOR (^) operator on some condition

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -201,6 +201,18 @@ def test_assignment_ops_parsing():
             output.redValue << 1; // Shift left by 1
             output.redValue &= 0x3;
         }
+        
+        // Testing SHIFT_RIGHT (>>) operator on some condition
+        if (input.in_position.g == 0.25) {
+            uint greenValue = asuint(output.out_color.g);
+            output.greenValue ^= 0x1;
+            output.out_color.g = asfloat(greenValue)
+            
+            output.greenValue |= 0x2;
+            // Applying shift right operation
+            output.greenValue >> 1;  // Shift right by 1
+            output.greenValue &= 0x3;
+        }
 
         // Testing BITWISE_XOR (^) operator on some condition
         if (input.in_position.r == 0.5) {

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -202,7 +202,7 @@ def test_assignment_ops_parsing():
             output.redValue &= 0x3;
         }
         
-        // Testing SHIFT_LEFT (>>) operator on some condition
+        // Testing SHIFT_RIGHT (>>) operator on some condition
         if (input.in_position.r == 0.25) {
             uint redValue = asuint(output.out_color.r);
             output.redValue ^= 0x1;


### PR DESCRIPTION
### PR Description
This PR adds tokenization and parsing support specifically for the shift-right (>>) operator. The changes ensure that this operator is correctly recognized and handled.

### Related Issue
Resolves #182, implementing support for the shift-right operator.

### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            vUV = position.xy * 10.0;
            gl_Position = vec4(position, 1.0);
        }
    }

    // Perlin Noise Function
    float perlinNoise(vec2 p) {
        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
    }

    // Fragment Shader
    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            float noise = perlinNoise(vUV);
            float height = noise * 10.0;
            vec3 color = vec3(height / 10.0, 1.0 - height / 10.0, 0.0);
            fragColor = vec4(color, 1.0);
        }
    }
}
```-->


### Checklist
- [x] Have you added the necessary tests?
- [x] Only modified the files mentioned in the related issue(s)?
- [x] Are all tests passing?


