### PR TITLE
#190 STATIC: static

### DIFF
--- a/crosstl/src/translator/lexer.py
+++ b/crosstl/src/translator/lexer.py
@@ -73,7 +73,7 @@ TOKENS = [
     ("BITWISE_OR", r"\|"),
     ("BITWISE_XOR", r"\^"),
     ("BITWISE_NOT", r"~"),
-    ("STATIC", r"\bstatic\b")
+    ("STATIC", r"\bstatic\b"),
 ]
 
 KEYWORDS = {

--- a/crosstl/src/translator/lexer.py
+++ b/crosstl/src/translator/lexer.py
@@ -73,6 +73,7 @@ TOKENS = [
     ("BITWISE_OR", r"\|"),
     ("BITWISE_XOR", r"\^"),
     ("BITWISE_NOT", r"~"),
+    ("STATIC", r"\bstatic\b")
 ]
 
 KEYWORDS = {
@@ -85,6 +86,7 @@ KEYWORDS = {
     "for": "FOR",
     "return": "RETURN",
     "const": "CONST",
+    "static": "STATIC",
 }
 
 


### PR DESCRIPTION
### PR Description
This PR adds support for the static keyword to the lexer.py to properly identify and tokenize it as a dedicated keyword. Previously, the lexer.py treated static as a generic identifier, which could lead to incorrect tokenization of shader code using static variables.

Closes #190 

### Related Issue

### shader Sample



### Checklist
- [x] Have you added the necessary tests?
- [x] Only modified the files mentioned in the related issue(s)?
- [ ] Are all tests passing?




<!-- BOT_STATE: {} -->