### PR TITLE
Added support for #include

### DIFF
--- a/crosstl/backend/DirectX/DirectxAst.py
+++ b/crosstl/backend/DirectX/DirectxAst.py
@@ -160,6 +160,7 @@ class UnaryOpNode(ASTNode):
     def __str__(self):
         return f"({self.op}{self.operand})"
 
+
 class IncludeNode(ASTNode):
     def __init__(self, path):
         self.path = path

--- a/crosstl/backend/DirectX/DirectxAst.py
+++ b/crosstl/backend/DirectX/DirectxAst.py
@@ -159,3 +159,13 @@ class UnaryOpNode(ASTNode):
 
     def __str__(self):
         return f"({self.op}{self.operand})"
+
+class IncludeNode(ASTNode):
+    def __init__(self, path):
+        self.path = path
+
+    def __repr__(self):
+        return f"IncludeNode(path={self.path})"
+
+    def __str__(self):
+        return f"#include {self.path}"

--- a/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
+++ b/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
@@ -70,6 +70,8 @@ class HLSLToCrossGLConverter:
                 for member in node.members:
                     code += f"        {self.map_type(member.vtype)} {member.name} {self.map_semantic(member.semantic)};\n"
                 code += "    }\n"
+            elif isinstance(node, IncludeNode):
+                code += f"    #include {node.path}\n"
         # Generate global variables
         for node in ast.global_variables:
             code += f"    {self.map_type(node.vtype)} {node.name};\n"

--- a/crosstl/backend/DirectX/DirectxLexer.py
+++ b/crosstl/backend/DirectX/DirectxLexer.py
@@ -61,7 +61,7 @@ TOKENS = [
     ("MINUS", r"-"),
     ("EQUALS", r"="),
     ("WHITESPACE", r"\s+"),
-    ("STRING", r"\"[^\"]*\""), # Added for string literals
+    ("STRING", r"\"[^\"]*\""),  # Added for string literals
 ]
 
 KEYWORDS = {
@@ -97,10 +97,10 @@ class HLSLLexer:
         pos = 0
         while pos < len(self.code):
             match = None
-            
+
             for token_type, pattern in TOKENS:
                 regex = re.compile(pattern)
-                
+
                 match = regex.match(self.code, pos)
                 if match:
                     text = match.group(0)

--- a/crosstl/backend/DirectX/DirectxLexer.py
+++ b/crosstl/backend/DirectX/DirectxLexer.py
@@ -3,6 +3,7 @@ import re
 TOKENS = [
     ("COMMENT_SINGLE", r"//.*"),
     ("COMMENT_MULTI", r"/\*[\s\S]*?\*/"),
+    ("INCLUDE", r"\#include\b"),
     ("STRUCT", r"\bstruct\b"),
     ("CBUFFER", r"\bcbuffer\b"),
     ("TEXTURE2D", r"\bTexture2D\b"),
@@ -60,6 +61,7 @@ TOKENS = [
     ("MINUS", r"-"),
     ("EQUALS", r"="),
     ("WHITESPACE", r"\s+"),
+    ("STRING", r"\"[^\"]*\""), # Added for string literals
 ]
 
 KEYWORDS = {
@@ -95,8 +97,10 @@ class HLSLLexer:
         pos = 0
         while pos < len(self.code):
             match = None
+            
             for token_type, pattern in TOKENS:
                 regex = re.compile(pattern)
+                
                 match = regex.match(self.code, pos)
                 if match:
                     text = match.group(0)

--- a/crosstl/backend/DirectX/DirectxParser.py
+++ b/crosstl/backend/DirectX/DirectxParser.py
@@ -14,6 +14,7 @@ from .DirectxAst import (
     UnaryOpNode,
     VariableNode,
     VectorConstructorNode,
+    IncludeNode,
 )
 from .DirectxLexer import HLSLLexer
 
@@ -66,10 +67,19 @@ class HLSLParser:
                     functions.append(self.parse_function())
                 else:
                     global_variables.append(self.parse_global_variable())
+            elif self.current_token[0] == "INCLUDE":
+                structs.append(self.parse_include())
+
             else:
                 self.eat(self.current_token[0])  # Skip unknown tokens
 
         return ShaderNode(structs, functions, global_variables, cbuffers)
+
+    def parse_include(self):
+        self.eat("INCLUDE")
+        path = self.current_token[1]
+        self.eat("STRING")
+        return IncludeNode(path)
 
     def is_function(self):
         current_pos = self.pos

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -498,5 +498,48 @@ def test_bitwise_ops_codgen():
         pytest.fail("bitwise_op parsing or codegen not implemented.")
 
 
+
+def test_include_codegen():
+    code = """
+    #include "common.hlsl"
+    struct VSInput {
+    float4 position : POSITION;
+    float4 color : TEXCOORD0;
+    };
+
+    struct VSOutput {
+        float4 out_position : TEXCOORD0;
+    };
+
+    VSOutput VSMain(VSInput input) {
+        VSOutput output;
+        output.out_position =  input.position;
+        return output;
+    }
+
+    struct PSInput {
+        float4 in_position : TEXCOORD0;
+    };
+
+    struct PSOutput {
+        float4 out_color : SV_TARGET0;
+    };
+
+    PSOutput PSMain(PSInput input) {
+        PSOutput output;
+        output.out_color =  input.in_position;
+        return output;
+    }
+    """
+    try:
+        tokens = tokenize_code(code)
+        ast = parse_code(tokens)
+        generated_code = generate_code(ast)
+        print(generated_code)
+    except SyntaxError:
+        pytest.fail("Include statement failed to parse or generate code.")
+
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -498,7 +498,6 @@ def test_bitwise_ops_codgen():
         pytest.fail("bitwise_op parsing or codegen not implemented.")
 
 
-
 def test_include_codegen():
     code = """
     #include "common.hlsl"
@@ -538,7 +537,6 @@ def test_include_codegen():
         print(generated_code)
     except SyntaxError:
         pytest.fail("Include statement failed to parse or generate code.")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Description
Added include preprocessing step in lexer , parser and integrated it successfully to codegen

### Related Issue
This PR is related to #196 
Closes #196 

### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            vUV = position.xy * 10.0;
            gl_Position = vec4(position, 1.0);
        }
    }

    // Perlin Noise Function
    float perlinNoise(vec2 p) {
        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
    }

    // Fragment Shader
    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            float noise = perlinNoise(vUV);
            float height = noise * 10.0;
            vec3 color = vec3(height / 10.0, 1.0 - height / 10.0, 0.0);
            fragColor = vec4(color, 1.0);
        }
    }
}
```-->


### Checklist
- [x] Have you added the necessary tests?
- [x] Only modified the files mentioned in the related issue(s)?
- [x] Are all tests passing?




<!-- BOT_STATE: {} -->