### PR TITLE
#178 BITWISE_AND: &

### DIFF
--- a/crosstl/src/backend/DirectX/DirectxLexer.py
+++ b/crosstl/src/backend/DirectX/DirectxLexer.py
@@ -50,6 +50,7 @@ TOKENS = [
     ("ASSIGN_OR", r"\|="),
     ("ASSIGN_AND", r"\&="),
     ("BITWISE_XOR", r"\^"),
+    ("BITWISE_AND", r"\&"),
     ("AND", r"&&"),
     ("OR", r"\|\|"),
     ("BITWISE_OR", r"\|"),

--- a/crosstl/src/backend/DirectX/DirectxParser.py
+++ b/crosstl/src/backend/DirectX/DirectxParser.py
@@ -240,7 +240,8 @@ class HLSLParser:
                     "ASSIGN_AND",
                     "SHIFT_LEFT",
                     "SHIFT_RIGHT",
-                    "BITWISE_OR",
+                    "BITWISE_OR", 
+                    "BITWISE_AND",
                     "BITWISE_XOR",
                 ]:
                     # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
@@ -262,6 +263,7 @@ class HLSLParser:
                 "SHIFT_LEFT",
                 "SHIFT_RIGHT",
                 "BITWISE_OR",
+                "BITWISE_AND",
                 "BITWISE_XOR",
             ]:
                 # Handle assignment operators (e.g., =, +=, -=, ^=, etc.)
@@ -286,6 +288,7 @@ class HLSLParser:
                     "SHIFT_LEFT",
                     "SHIFT_RIGHT",
                     "BITWISE_OR",
+                    "BITWISE_AND",
                     "BITWISE_XOR",
                 ]:
                     op = self.current_token[1]
@@ -418,6 +421,7 @@ class HLSLParser:
             "SHIFT_LEFT",
             "SHIFT_RIGHT",
             "BITWISE_OR",
+            "BITWISE_AND",
             "BITWISE_XOR",
         ]:
             op = self.current_token[1]


### PR DESCRIPTION
This PR introduces support for the BITWISE_AND (&) operator in the DirectX backend of the CrossTL ecosystem. Changes have been made to the DirectxLexer.py to add the bitwise operator and DirectxParser.py is made to parses the added operator for seamless translation between HLSL and CrossGL.

### PR Description
<!-- Provide a brief summary of the changes you have made. Explain the purpose and motivation behind these changes. -->

### Related Issue
<!-- Link to the related issue(s) that this PR addresses. Example: #123 -->

### shader Sample
<!-- Provide a shader sample or snippet on which you have tested your changes. like

```crossgl
shader PerlinNoise {
    vertex {
        input vec3 position;
        output vec2 vUV;

        void main() {
            vUV = position.xy * 10.0;
            gl_Position = vec4(position, 1.0);
        }
    }

    // Perlin Noise Function
    float perlinNoise(vec2 p) {
        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
    }

    // Fragment Shader
    fragment {
        input vec2 vUV;
        output vec4 fragColor;

        void main() {
            float noise = perlinNoise(vUV);
            float height = noise * 10.0;
            vec3 color = vec3(height / 10.0, 1.0 - height / 10.0, 0.0);
            fragColor = vec4(color, 1.0);
        }
    }
}
```-->


### Checklist
- [ ] Have you added the necessary tests?
- [ ] Only modified the files mentioned in the related issue(s)?
- [ ] Are all tests passing?




<!-- BOT_STATE: {} -->