### PR TITLE
#193 - Add support for switch-case statements in DirectX backend

### DIFF
--- a/crosstl/backend/DirectX/DirectxAst.py
+++ b/crosstl/backend/DirectX/DirectxAst.py
@@ -159,3 +159,22 @@ class UnaryOpNode(ASTNode):
 
     def __str__(self):
         return f"({self.op}{self.operand})"
+
+
+class SwitchNode(ASTNode):
+    def __init__(self, condition, cases, default_body=None):
+        self.condition = condition
+        self.cases = cases
+        self.default_body = default_body
+
+    def __repr__(self):
+        return f"SwitchNode(condition={self.condition}, cases={self.cases}, default_body={self.default_body})"
+
+
+class CaseNode(ASTNode):
+    def __init__(self, value, body):
+        self.value = value
+        self.body = body
+
+    def __repr__(self):
+        return f"CaseNode(value={self.value}, body={self.body})"

--- a/crosstl/backend/DirectX/DirectxAst.py
+++ b/crosstl/backend/DirectX/DirectxAst.py
@@ -170,8 +170,8 @@ class IncludeNode(ASTNode):
 
     def __str__(self):
         return f"#include {self.path}"
-      
-      
+
+
 class SwitchNode(ASTNode):
     def __init__(self, condition, cases, default_body=None):
         self.condition = condition

--- a/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
+++ b/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
@@ -146,6 +146,8 @@ class HLSLToCrossGLConverter:
                 code += self.generate_do_while_loop(stmt, indent, is_main)
             elif isinstance(stmt, IfNode):
                 code += self.generate_if_statement(stmt, indent, is_main)
+            elif isinstance(stmt, SwitchNode):
+                code += self.generate_switch_statement(stmt, indent)
         return code
 
     def generate_for_loop(self, node, indent, is_main):
@@ -248,3 +250,18 @@ class HLSLToCrossGLConverter:
             return f"@ {self.semantic_map.get(semantic, semantic)}"
         else:
             return ""
+
+    def generate_switch_statement(self, node, indent=1):
+        code = "    " * indent + f"switch ({self.generate_expression(node.condition)}) {{\n"
+
+        for case in node.cases:
+            code += "    " * (indent + 1) + f"case {self.generate_expression(case.value)}:\n"
+            code += self.generate_function_body(case.body, indent + 2)
+            code += "    " * (indent + 2) + "break;\n"
+
+        if node.default_body:
+            code += "    " * (indent + 1) + "default:\n"
+            code += self.generate_function_body(node.default_body, indent + 2)
+
+        code += "    " * indent + "}\n"
+        return code

--- a/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
+++ b/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
@@ -252,10 +252,16 @@ class HLSLToCrossGLConverter:
             return ""
 
     def generate_switch_statement(self, node, indent=1):
-        code = "    " * indent + f"switch ({self.generate_expression(node.condition)}) {{\n"
+        code = (
+            "    " * indent
+            + f"switch ({self.generate_expression(node.condition)}) {{\n"
+        )
 
         for case in node.cases:
-            code += "    " * (indent + 1) + f"case {self.generate_expression(case.value)}:\n"
+            code += (
+                "    " * (indent + 1)
+                + f"case {self.generate_expression(case.value)}:\n"
+            )
             code += self.generate_function_body(case.body, indent + 2)
             code += "    " * (indent + 2) + "break;\n"
 

--- a/crosstl/backend/DirectX/DirectxLexer.py
+++ b/crosstl/backend/DirectX/DirectxLexer.py
@@ -61,7 +61,7 @@ TOKENS = [
     ("MINUS", r"-"),
     ("EQUALS", r"="),
     ("WHITESPACE", r"\s+"),
-    ("STRING", r"\"[^\"]*\""), 
+    ("STRING", r"\"[^\"]*\""),
     ("SWITCH", r"\bswitch\b"),
     ("CASE", r"\bcase\b"),
     ("DEFAULT", r"\bdefault\b"),

--- a/crosstl/backend/DirectX/DirectxLexer.py
+++ b/crosstl/backend/DirectX/DirectxLexer.py
@@ -60,6 +60,10 @@ TOKENS = [
     ("MINUS", r"-"),
     ("EQUALS", r"="),
     ("WHITESPACE", r"\s+"),
+    ("SWITCH", r"\bswitch\b"),
+    ("CASE", r"\bcase\b"),
+    ("DEFAULT", r"\bdefault\b"),
+    ("BREAK", r"\bbreak\b"),
 ]
 
 KEYWORDS = {
@@ -82,6 +86,10 @@ KEYWORDS = {
     "while": "WHILE",
     "do": "DO",
     "register": "REGISTER",
+    "switch": "SWITCH",
+    "case": "CASE",
+    "default": "DEFAULT",
+    "break": "BREAK",
 }
 
 

--- a/crosstl/backend/DirectX/DirectxParser.py
+++ b/crosstl/backend/DirectX/DirectxParser.py
@@ -15,7 +15,7 @@ from .DirectxAst import (
     VariableNode,
     VectorConstructorNode,
     SwitchNode,
-    CaseNode
+    CaseNode,
 )
 from .DirectxLexer import HLSLLexer
 

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -498,5 +498,41 @@ def test_bitwise_ops_codgen():
         pytest.fail("bitwise_op parsing or codegen not implemented.")
 
 
+def test_switch_case_codegen():
+    code = """
+    struct PSInput {
+        float4 in_position : TEXCOORD0;
+        int value : SV_InstanceID;
+    };
+
+    struct PSOutput {
+        float4 out_color : SV_Target;
+    };
+
+    PSOutput PSMain(PSInput input) {
+        PSOutput output;
+        switch (input.value) {
+            case 1:
+                output.out_color = float4(1.0, 0.0, 0.0, 1.0);
+                break;
+            case 2:
+                output.out_color = float4(0.0, 1.0, 0.0, 1.0);
+                break;
+            default:
+                output.out_color = float4(0.0, 0.0, 1.0, 1.0);
+                break;
+        }
+        return output;
+    }
+    """
+    try:
+        tokens = tokenize_code(code)
+        ast = parse_code(tokens)
+        generated_code = generate_code(ast)
+        print(generated_code)
+    except SyntaxError:
+        pytest.fail("Switch-case parsing or code generation not implemented.")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -537,8 +537,8 @@ def test_include_codegen():
         print(generated_code)
     except SyntaxError:
         pytest.fail("Include statement failed to parse or generate code.")
-        
-        
+
+
 def test_switch_case_codegen():
     code = """
     struct PSInput {

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -202,8 +202,8 @@ def test_logical_and_tokenization():
         tokenize_code(code)
     except SyntaxError:
         pytest.fail("logical_and tokenization is not implemented.")
-        
-        
+
+
 def test_switch_case_tokenization():
     code = """
     PSOutput PSMain(PSInput input) {

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -182,5 +182,29 @@ def test_bitwise_or_tokenization():
         pytest.fail("bitwise_op tokenization is not implemented.")
 
 
+def test_switch_case_tokenization():
+    code = """
+    PSOutput PSMain(PSInput input) {
+        PSOutput output;
+        switch (input.value) {
+            case 1:
+                output.out_color = float4(1.0, 0.0, 0.0, 1.0);
+                break;
+            case 2:
+                output.out_color = float4(0.0, 1.0, 0.0, 1.0);
+                break;
+            default:
+                output.out_color = float4(0.0, 0.0, 1.0, 1.0);
+                break;
+        }
+        return output;
+    }
+    """
+    try:
+        tokenize_code(code)
+    except SyntaxError:
+        pytest.fail("switch-case tokenization not implemented.")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_backend/test_directx/test_lexer.py
+++ b/tests/test_backend/test_directx/test_lexer.py
@@ -191,8 +191,8 @@ def test_logical_or_tokenization():
         tokenize_code(code)
     except SyntaxError:
         pytest.fail("logical_or tokenization is not implemented.")
-        
-        
+
+
 def test_switch_case_tokenization():
     code = """
     PSOutput PSMain(PSInput input) {

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -257,5 +257,30 @@ def test_bitwise_ops_parsing():
         pytest.fail("bitwise_op parsing not implemented.")
 
 
+def test_switch_case_parsing():
+    code = """
+    PSOutput PSMain(PSInput input) {
+        PSOutput output;
+        switch (input.value) {
+            case 1:
+                output.out_color = float4(1.0, 0.0, 0.0, 1.0);
+                break;
+            case 2:
+                output.out_color = float4(0.0, 1.0, 0.0, 1.0);
+                break;
+            default:
+                output.out_color = float4(0.0, 0.0, 1.0, 1.0);
+                break;
+        }
+        return output;
+    }
+    """
+    try:
+        tokens = tokenize_code(code)
+        parse_code(tokens)
+    except SyntaxError:
+        pytest.fail("switch-case parsing not implemented.")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -305,8 +305,8 @@ def test_logical_and_ops_parsing():
         parse_code(tokens)
     except SyntaxError:
         pytest.fail("logical_and_ops not implemented.")
-        
-        
+
+
 def test_switch_case_parsing():
     code = """
     PSOutput PSMain(PSInput input) {

--- a/tests/test_backend/test_directx/test_parser.py
+++ b/tests/test_backend/test_directx/test_parser.py
@@ -280,8 +280,8 @@ def test_logical_or_ops_parsing():
         parse_code(tokens)
     except SyntaxError:
         pytest.fail("logical_or_ops not implemented.")
-        
-      
+
+
 def test_switch_case_parsing():
     code = """
     PSOutput PSMain(PSInput input) {


### PR DESCRIPTION
### PR Description

- Updated DirectxLexer.py to tokenize `switch`, `case`, and `default` keywords.
- Modified DirectxParser.py to parse `switch-case` constructs into `SwitchNode` and `CaseNode` AST representations.
- Added `SwitchNode` and `CaseNode` to DirectxAst.py to model the syntax tree for switch-case statements.
- Enhanced DirectxCrossGLCodeGen.py to generate GLSL code for `switch-case` constructs.

### Related Issue

Closes #193

### shader Sample

shader SwitchCaseSample {
    fragment {
        input int value;
        output vec4 color;

        void main() {
            switch (value) {
                case 1:
                    color = vec4(1.0, 0.0, 0.0, 1.0);
                    break;
                case 2:
                    color = vec4(0.0, 1.0, 0.0, 1.0);
                    break;
                default:
                    color = vec4(0.0, 0.0, 1.0, 1.0);
                    break;
            }
        }
    }
}

- Created and updated tests:
  - `test_lexer.py` to validate tokenization of `switch-case` statements.
  - `test_parser.py` to verify parsing of `switch-case` constructs.
  - `test_codegen.py` to ensure correct GLSL code generation for `switch-case`.


### Checklist
- [done] Have you added the necessary tests?
- [done] Only modified the files mentioned in the related issue(s)?
- [done] Are all tests passing?




<!-- BOT_STATE: {} -->