### PR TITLE
Add V3 target/source backend structure

### DIFF
--- a/crosstl/translator/codegen/__init__.py
+++ b/crosstl/translator/codegen/__init__.py
@@ -14,6 +14,7 @@ from .registry import (
     get_codegen,
     normalize_backend_name,
     register_backend,
+    source_backend_names,
 )
 from .rust_codegen import RustCodeGen
 from .SPIRV_codegen import VulkanSPIRVCodeGen
@@ -110,6 +111,7 @@ if _SlangCodeGen is not None:
     )
 
 __all__ = [
+    "BackendSpec",
     "CudaCodeGen",
     "HLSLCodeGen",
     "GLSLCodeGen",
@@ -122,7 +124,9 @@ __all__ = [
     "get_codegen",
     "get_backend_extension",
     "normalize_backend_name",
+    "register_backend",
     "backend_names",
+    "source_backend_names",
 ]
 
 if "_SlangCodeGen" in globals() and _SlangCodeGen is not None:

--- a/crosstl/translator/codegen/registry.py
+++ b/crosstl/translator/codegen/registry.py
@@ -22,6 +22,15 @@ class BackendSpec:
     aliases: Sequence[str] = ()
     file_extensions: Sequence[str] = ()
     format_backend: str | None = None
+    source_name: str | None = None
+    has_source_frontend: bool = True
+
+    @property
+    def source_registry_name(self) -> str | None:
+        """Return the native source frontend name paired with this target."""
+        if not self.has_source_frontend:
+            return None
+        return self.source_name or self.name
 
 
 class BackendRegistry:
@@ -97,6 +106,14 @@ class BackendRegistry:
         """Return registered canonical backend names in sorted order."""
         return sorted(self._by_name.keys())
 
+    def source_backend_names(self) -> Sequence[str]:
+        """Return targets that also have native source frontends."""
+        return sorted(
+            name
+            for name, spec in self._by_name.items()
+            if spec.source_registry_name is not None
+        )
+
     def aliases(self) -> dict[str, str]:
         """Return a copy of the alias-to-backend mapping."""
         return dict(self._by_alias)
@@ -127,6 +144,11 @@ def get_backend(name: str) -> BackendSpec | None:
 def backend_names() -> Sequence[str]:
     """Return registered backend names from the global registry."""
     return BACKEND_REGISTRY.names()
+
+
+def source_backend_names() -> Sequence[str]:
+    """Return registered targets that also have native source frontends."""
+    return BACKEND_REGISTRY.source_backend_names()
 
 
 def get_backend_extension(name: str) -> str | None:

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -20,17 +20,17 @@ implicitly supported.
    "?", "unknown", "Not audited yet. Do not treat this as supported."
 
 .. csv-table:: Backend inventory
-   :header: "Backend", "Ext", "Target generator", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
+   :header: "Backend", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1071", "291", "Microsoft Learn HLSL reference; HLSL specification project"
-   "OpenGL / GLSL", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1167", "177", "GLSL 4.60 specification; OpenGL registry"
-   "Metal", ".metal", "crosstl/translator/codegen/metal_codegen.py", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "962", "492", "Apple Metal resources; Metal Shading Language specification"
-   "Vulkan SPIR-V", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "972", "36", "SPIR-V unified grammar; Khronos SPIR-V headers"
-   "CUDA", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
-   "HIP", ".hip", "crosstl/translator/codegen/hip_codegen.py", "crosstl/backend/HIP", "tests/test_translator/test_codegen/test_hip_codegen.py, tests/test_backend/test_HIP", "821", "136", "ROCm HIP documentation"
-   "Mojo", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "918", "98", "Mojo manual"
-   "Rust", ".rs", "crosstl/translator/codegen/rust_codegen.py", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "976", "69", "Rust reference"
-   "Slang", ".slang", "crosstl/translator/codegen/slang_codegen.py", "crosstl/backend/slang", "tests/test_translator/test_codegen/test_slang_codegen.py, tests/test_backend/test_slang", "786", "410", "Slang user guide"
+   "DirectX / HLSL", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1071", "291", "Microsoft Learn HLSL reference; HLSL specification project"
+   "OpenGL / GLSL", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1167", "177", "GLSL 4.60 specification; OpenGL registry"
+   "Metal", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "962", "492", "Apple Metal resources; Metal Shading Language specification"
+   "Vulkan SPIR-V", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "972", "36", "SPIR-V unified grammar; Khronos SPIR-V headers"
+   "CUDA", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
+   "HIP", ".hip", "crosstl/translator/codegen/hip_codegen.py", "native", "crosstl/backend/HIP", "tests/test_translator/test_codegen/test_hip_codegen.py, tests/test_backend/test_HIP", "821", "136", "ROCm HIP documentation"
+   "Mojo", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "918", "98", "Mojo manual"
+   "Rust", ".rs", "crosstl/translator/codegen/rust_codegen.py", "native", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "976", "69", "Rust reference"
+   "Slang", ".slang", "crosstl/translator/codegen/slang_codegen.py", "native", "crosstl/backend/slang", "tests/test_translator/test_codegen/test_slang_codegen.py, tests/test_backend/test_slang", "786", "410", "Slang user guide"
 
 .. csv-table:: Summary by backend
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"

--- a/support/backends.json
+++ b/support/backends.json
@@ -4,6 +4,7 @@
     {
       "id": "directx",
       "name": "DirectX / HLSL",
+      "source_kind": "native",
       "aliases": ["hlsl", "dx"],
       "target_extension": ".hlsl",
       "translator_codegen": "crosstl/translator/codegen/directx_codegen.py",
@@ -26,6 +27,7 @@
     {
       "id": "opengl",
       "name": "OpenGL / GLSL",
+      "source_kind": "native",
       "aliases": ["glsl", "ogl"],
       "target_extension": ".glsl",
       "translator_codegen": "crosstl/translator/codegen/GLSL_codegen.py",
@@ -48,6 +50,7 @@
     {
       "id": "metal",
       "name": "Metal",
+      "source_kind": "native",
       "aliases": ["metal", "msl"],
       "target_extension": ".metal",
       "translator_codegen": "crosstl/translator/codegen/metal_codegen.py",
@@ -70,6 +73,7 @@
     {
       "id": "vulkan",
       "name": "Vulkan SPIR-V",
+      "source_kind": "native",
       "aliases": ["spirv", "spv"],
       "target_extension": ".spvasm",
       "translator_codegen": "crosstl/translator/codegen/SPIRV_codegen.py",
@@ -92,6 +96,7 @@
     {
       "id": "cuda",
       "name": "CUDA",
+      "source_kind": "native",
       "aliases": ["cu"],
       "target_extension": ".cu",
       "translator_codegen": "crosstl/translator/codegen/cuda_codegen.py",
@@ -110,6 +115,7 @@
     {
       "id": "hip",
       "name": "HIP",
+      "source_kind": "native",
       "aliases": ["hip"],
       "target_extension": ".hip",
       "translator_codegen": "crosstl/translator/codegen/hip_codegen.py",
@@ -128,6 +134,7 @@
     {
       "id": "mojo",
       "name": "Mojo",
+      "source_kind": "native",
       "aliases": ["mojo"],
       "target_extension": ".mojo",
       "translator_codegen": "crosstl/translator/codegen/mojo_codegen.py",
@@ -146,6 +153,7 @@
     {
       "id": "rust",
       "name": "Rust",
+      "source_kind": "native",
       "aliases": ["rs"],
       "target_extension": ".rs",
       "translator_codegen": "crosstl/translator/codegen/rust_codegen.py",
@@ -164,6 +172,7 @@
     {
       "id": "slang",
       "name": "Slang",
+      "source_kind": "native",
       "aliases": ["slang"],
       "target_extension": ".slang",
       "translator_codegen": "crosstl/translator/codegen/slang_codegen.py",

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -106,6 +106,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".hlsl",
       "tests": {
         "paths": [
@@ -225,6 +226,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".glsl",
       "tests": {
         "paths": [
@@ -344,6 +346,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".metal",
       "tests": {
         "paths": [
@@ -463,6 +466,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".spvasm",
       "tests": {
         "paths": [
@@ -577,6 +581,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".cu",
       "tests": {
         "paths": [
@@ -691,6 +696,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".hip",
       "tests": {
         "paths": [
@@ -805,6 +811,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".mojo",
       "tests": {
         "paths": [
@@ -919,6 +926,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".rs",
       "tests": {
         "paths": [
@@ -1033,6 +1041,7 @@
           }
         ]
       },
+      "source_kind": "native",
       "target_extension": ".slang",
       "tests": {
         "paths": [

--- a/tests/test_backend/test_package_contracts.py
+++ b/tests/test_backend/test_package_contracts.py
@@ -13,6 +13,14 @@ def _catalog_backends():
     return catalog["backends"]
 
 
+def _native_source_backends():
+    return [
+        backend
+        for backend in _catalog_backends()
+        if backend.get("source_kind", "native") == "native"
+    ]
+
+
 def _module_name(path):
     return ".".join(path.with_suffix("").relative_to(ROOT).parts)
 
@@ -28,7 +36,7 @@ def _classes_declared_in(module):
 def test_native_backend_modules_are_importable():
     failures = []
 
-    for backend in _catalog_backends():
+    for backend in _native_source_backends():
         backend_path = ROOT / backend["native_backend"]
         for module_path in sorted(backend_path.glob("*.py")):
             if module_path.name == "__init__.py":
@@ -45,7 +53,7 @@ def test_native_backend_modules_are_importable():
 def test_native_backend_packages_expose_core_frontend_classes():
     missing = []
 
-    for backend in _catalog_backends():
+    for backend in _native_source_backends():
         backend_id = backend["id"]
         backend_path = ROOT / backend["native_backend"]
         modules = {

--- a/tests/test_support_matrix.py
+++ b/tests/test_support_matrix.py
@@ -45,11 +45,25 @@ def _backend(backend_id, aliases, extension):
     return {
         "id": backend_id,
         "name": backend_id,
+        "source_kind": "native",
         "aliases": aliases,
         "target_extension": extension,
         "translator_codegen": codegen_path,
         "native_backend": native_backend,
         "tests": [test_path],
+        "docs": [{"name": "Docs", "url": f"https://example.com/{backend_id}"}],
+    }
+
+
+def _target_only_backend(backend_id, aliases, extension):
+    return {
+        "id": backend_id,
+        "name": backend_id,
+        "source_kind": "target-only",
+        "aliases": aliases,
+        "target_extension": extension,
+        "translator_codegen": "crosstl/translator/codegen/GLSL_codegen.py",
+        "tests": ["tests/test_translator/test_codegen/test_GLSL_codegen.py"],
         "docs": [{"name": "Docs", "url": f"https://example.com/{backend_id}"}],
     }
 
@@ -218,6 +232,110 @@ def test_validate_backend_catalog_rejects_duplicate_aliases():
 
     with pytest.raises(module.SupportMatrixError, match="Duplicate backend alias"):
         module.validate_backend_catalog(backends)
+
+
+def test_validate_backend_catalog_accepts_target_only_backends():
+    module = load_support_matrix_module()
+    backends = {"backends": [_target_only_backend("webgl", ["webgl2"], ".webgl.glsl")]}
+
+    backend_ids = module.validate_backend_catalog(backends)
+    matrix = module.build_matrix(
+        backends,
+        {
+            "statuses": _status_descriptions(module),
+            "features": [
+                {
+                    "id": "target.codegen",
+                    "category": "target",
+                    "name": "Code generation",
+                    "description": "Emit target code.",
+                    "support": {"webgl": {"status": "partial"}},
+                }
+            ],
+        },
+    )
+
+    assert backend_ids == {"webgl"}
+    assert matrix["backends"][0]["source_kind"] == "target-only"
+    assert matrix["backends"][0]["native_backend"] == {
+        "path": None,
+        "exists": False,
+    }
+
+
+def test_target_only_backend_missing_source_feature_support_stays_auditable():
+    module = load_support_matrix_module()
+    backends = {"backends": [_target_only_backend("webgl", ["webgl2"], ".webgl.glsl")]}
+
+    matrix = module.build_matrix(
+        backends,
+        {
+            "statuses": _status_descriptions(module),
+            "features": [
+                {
+                    "id": "target.codegen",
+                    "category": "target",
+                    "name": "Code generation",
+                    "description": "Emit target code.",
+                    "support": {"webgl": {"status": "partial"}},
+                },
+                {
+                    "id": "source.parse",
+                    "category": "source",
+                    "name": "Source parsing",
+                    "description": "Parse native source.",
+                    "support": {},
+                },
+            ],
+        },
+    )
+
+    source_feature = next(
+        feature for feature in matrix["features"] if feature["id"] == "source.parse"
+    )
+    assert source_feature["support"]["webgl"]["status"] == "unknown"
+    assert any(
+        row["feature_id"] == "source.parse"
+        and row["backend_id"] == "webgl"
+        and row["status"] == "unknown"
+        for row in matrix["backlog"]
+    )
+
+
+def test_validate_backend_catalog_requires_source_kind():
+    module = load_support_matrix_module()
+    backend = _backend("directx", ["hlsl"], ".hlsl")
+    backend.pop("source_kind")
+
+    with pytest.raises(module.SupportMatrixError, match="missing 'source_kind'"):
+        module.validate_backend_catalog({"backends": [backend]})
+
+
+def test_validate_backend_catalog_requires_native_backend_for_native_sources():
+    module = load_support_matrix_module()
+    backend = _backend("directx", ["hlsl"], ".hlsl")
+    backend.pop("native_backend")
+
+    with pytest.raises(module.SupportMatrixError, match="missing 'native_backend'"):
+        module.validate_backend_catalog({"backends": [backend]})
+
+
+def test_validate_backend_catalog_rejects_unknown_source_kind():
+    module = load_support_matrix_module()
+    backend = _target_only_backend("webgl", ["webgl2"], ".webgl.glsl")
+    backend["source_kind"] = "frontendish"
+
+    with pytest.raises(module.SupportMatrixError, match="source_kind"):
+        module.validate_backend_catalog({"backends": [backend]})
+
+
+def test_validate_backend_catalog_rejects_native_backend_for_target_only():
+    module = load_support_matrix_module()
+    backend = _target_only_backend("webgl", ["webgl2"], ".webgl.glsl")
+    backend["native_backend"] = "crosstl/backend/GLSL"
+
+    with pytest.raises(module.SupportMatrixError, match="must not define"):
+        module.validate_backend_catalog({"backends": [backend]})
 
 
 def test_validate_feature_catalog_requires_all_status_definitions():
@@ -424,26 +542,38 @@ def test_support_backend_catalog_matches_codegen_registry():
     register_default_sources()
 
     backend_ids = {backend["id"] for backend in catalog["backends"]}
+    native_source_backend_ids = {
+        backend["id"]
+        for backend in catalog["backends"]
+        if backend.get("source_kind", "native") == "native"
+    }
     assert backend_ids == set(codegen.backend_names())
-    assert backend_ids.issubset(set(SOURCE_REGISTRY.names()))
+    assert native_source_backend_ids == set(codegen.source_backend_names())
+    assert native_source_backend_ids.issubset(set(SOURCE_REGISTRY.names()))
 
     for backend in catalog["backends"]:
         backend_id = backend["id"]
         spec = codegen.get_backend(backend_id)
         assert spec is not None, f"{backend_id} is not registered"
         assert codegen.get_backend_extension(backend_id) == backend["target_extension"]
-        assert (
-            SOURCE_REGISTRY.get_by_extension(backend["target_extension"]).name
-            == backend_id
-        )
+        if backend_id in native_source_backend_ids:
+            assert spec.source_registry_name == backend_id
+            assert (
+                SOURCE_REGISTRY.get_by_extension(backend["target_extension"]).name
+                == backend_id
+            )
+        else:
+            assert spec.source_registry_name is None
 
         for alias in backend.get("aliases", []):
             assert (
                 codegen.normalize_backend_name(alias) == backend_id
             ), f"{backend_id} support alias is not accepted by codegen: {alias}"
-            assert (
-                SOURCE_REGISTRY.get(alias).name == backend_id
-            ), f"{backend_id} support alias is not accepted by source registry: {alias}"
+            if backend_id in native_source_backend_ids:
+                assert SOURCE_REGISTRY.get(alias).name == backend_id, (
+                    f"{backend_id} support alias is not accepted by source registry: "
+                    f"{alias}"
+                )
 
 
 def test_graphics_backend_roadmap_is_focused_on_primary_graphics_targets():

--- a/tests/test_support_signals.py
+++ b/tests/test_support_signals.py
@@ -341,6 +341,34 @@ def test_build_report_summarizes_docs_probe_load_error():
     assert report["issues"] == []
 
 
+def test_build_report_preserves_target_only_backend_inventory():
+    module = load_signals_module()
+    backends = {
+        "backends": [
+            {
+                "id": "webgl",
+                "name": "WebGL / GLSL ES",
+                "source_kind": "target-only",
+                "translator_codegen": "tools/support_signals.py",
+                "tests": ["tests/test_support_signals.py"],
+            }
+        ]
+    }
+    features = {"features": []}
+
+    report = module.build_report(backends, features, docs_report=None)
+
+    assert report["backends"] == [
+        {
+            "id": "webgl",
+            "name": "WebGL / GLSL ES",
+            "source_kind": "target-only",
+            "implementation_paths": ["tools/support_signals.py"],
+            "test_paths": ["tests/test_support_signals.py"],
+        }
+    ]
+
+
 def test_build_report_scans_repo_implementation_and_tests():
     module = load_signals_module()
     backends = {

--- a/tests/test_translator/test_codegen/test_backend_registry.py
+++ b/tests/test_translator/test_codegen/test_backend_registry.py
@@ -7,6 +7,7 @@ import pytest
 import crosstl.translator.codegen as codegen
 from crosstl.formatter import CodeFormatter, ShaderLanguage
 from crosstl.translator import parse
+from crosstl.translator.codegen.registry import BackendRegistry, BackendSpec
 from crosstl.translator.plugin_loader import discover_backend_plugins
 from crosstl.translator.source_registry import (
     BINARY_SPIRV_UNSUPPORTED_MESSAGE,
@@ -87,6 +88,10 @@ REAL_WORLD_TARGET_EXTENSION_BACKENDS = (
 SOURCE_ONLY_BACKEND_DIRS = {"OpenCL"}
 
 
+class _DummyCodeGen:
+    pass
+
+
 def _backend_root():
     return os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "..", "..", "crosstl", "backend")
@@ -137,12 +142,53 @@ def test_backend_registry_covers_backend_dirs():
 def test_source_registry_covers_backend_dirs():
     register_default_sources()
     discover_backend_plugins()
+    source_backend_names = set(codegen.source_backend_names()) | {
+        name.lower() for name in SOURCE_ONLY_BACKEND_DIRS
+    }
     missing = []
     for name in _backend_dirs():
         normalized = _normalize_backend_dir(name)
+        if normalized not in source_backend_names:
+            continue
         if not SOURCE_REGISTRY.get(normalized):
             missing.append(name)
     assert not missing, f"Unregistered source backends: {missing}"
+
+
+def test_backend_registry_tracks_target_only_backends_separately():
+    registry = BackendRegistry()
+    registry.register(
+        BackendSpec(
+            name="wgsl",
+            codegen_class=_DummyCodeGen,
+            aliases=("webgpu",),
+            file_extensions=(".wgsl",),
+            has_source_frontend=False,
+        )
+    )
+
+    assert registry.names() == ["wgsl"]
+    assert registry.source_backend_names() == []
+    assert registry.resolve_name("shader.WGSL") == "wgsl"
+    assert registry.get("webgpu").source_registry_name is None
+
+
+def test_backend_registry_can_map_target_to_differently_named_source_frontend():
+    registry = BackendRegistry()
+    registry.register(
+        BackendSpec(
+            name="webgl",
+            codegen_class=_DummyCodeGen,
+            aliases=("webgl2", "glsl-es"),
+            file_extensions=(".webgl.glsl",),
+            source_name="opengl",
+        )
+    )
+
+    assert registry.names() == ["webgl"]
+    assert registry.source_backend_names() == ["webgl"]
+    assert registry.resolve_name("shader.webgl.glsl") == "webgl"
+    assert registry.get("glsl-es").source_registry_name == "opengl"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -103,8 +103,10 @@ def _assert_generated_output_is_usable(generated):
 def test_registered_native_sources_have_reverse_codegen_factories():
     register_default_sources()
 
-    for backend in codegen.backend_names():
-        spec = SOURCE_REGISTRY.get(backend)
+    for backend in codegen.source_backend_names():
+        backend_spec = codegen.get_backend(backend)
+        source_name = backend_spec.source_registry_name if backend_spec else backend
+        spec = SOURCE_REGISTRY.get(source_name)
         assert spec is not None
         assert spec.reverse_codegen_factory is not None
 

--- a/tools/support_matrix.py
+++ b/tools/support_matrix.py
@@ -197,6 +197,10 @@ def backend_signal_paths(backend):
     return paths
 
 
+def backend_source_kind(backend):
+    return backend["source_kind"]
+
+
 def validate_backend_catalog(backends_data):
     backends = backends_data.get("backends")
     if not isinstance(backends, list) or not backends:
@@ -216,9 +220,24 @@ def validate_backend_catalog(backends_data):
             raise SupportMatrixError(f"Duplicate backend id: {backend_id}")
         ids.add(backend_id)
 
-        for key in ("name", "translator_codegen", "native_backend", "tests", "docs"):
+        for key in ("name", "source_kind", "translator_codegen", "tests", "docs"):
             if key not in backend:
                 raise SupportMatrixError(f"Backend '{backend_id}' is missing '{key}'")
+        source_kind = backend_source_kind(backend)
+        if source_kind not in {"native", "target-only"}:
+            raise SupportMatrixError(
+                f"Backend '{backend_id}' source_kind must be 'native' or 'target-only'"
+            )
+        if source_kind == "native" and "native_backend" not in backend:
+            raise SupportMatrixError(
+                f"Backend '{backend_id}' with source_kind 'native' is missing "
+                "'native_backend'"
+            )
+        if source_kind == "target-only" and "native_backend" in backend:
+            raise SupportMatrixError(
+                f"Backend '{backend_id}' with source_kind 'target-only' must not "
+                "define 'native_backend'"
+            )
 
         if not isinstance(backend["name"], str) or not backend["name"].strip():
             raise SupportMatrixError(
@@ -250,10 +269,11 @@ def validate_backend_catalog(backends_data):
                     backend_id, backend["translator_codegen"]
                 )
             )
-        if not path_exists(backend["native_backend"]):
+        native_backend = backend.get("native_backend")
+        if native_backend and not path_exists(native_backend):
             raise SupportMatrixError(
                 "Backend '{}' native backend path does not exist: {}".format(
-                    backend_id, backend["native_backend"]
+                    backend_id, native_backend
                 )
             )
         require_list(backend.get("tests", []), f"Backend '{backend_id}' tests")
@@ -436,14 +456,19 @@ def backend_inventory(backend):
         "id": backend["id"],
         "name": backend["name"],
         "aliases": backend.get("aliases", []),
+        "source_kind": backend_source_kind(backend),
         "target_extension": backend.get("target_extension"),
         "translator_codegen": {
             "path": backend["translator_codegen"],
             "exists": path_exists(backend["translator_codegen"]),
         },
         "native_backend": {
-            "path": backend["native_backend"],
-            "exists": path_exists(backend["native_backend"]),
+            "path": backend.get("native_backend"),
+            "exists": (
+                path_exists(backend["native_backend"])
+                if backend.get("native_backend")
+                else False
+            ),
         },
         "tests": {
             "paths": tests,
@@ -868,7 +893,8 @@ def render_docs(matrix):
                 backend["name"],
                 backend.get("target_extension") or "",
                 backend["translator_codegen"]["path"],
-                backend["native_backend"]["path"],
+                backend["source_kind"],
+                backend["native_backend"]["path"] or "",
                 ", ".join(backend["tests"]["paths"]),
                 backend["tests"]["test_count"],
                 backend["signals"]["unsupported_marker_count"],
@@ -882,6 +908,7 @@ def render_docs(matrix):
                 "Backend",
                 "Ext",
                 "Target generator",
+                "Source kind",
                 "Native frontend",
                 "Tests",
                 "Test count",

--- a/tools/support_signals.py
+++ b/tools/support_signals.py
@@ -700,6 +700,10 @@ def backend_implementation_paths(backend: dict[str, Any]) -> list[str]:
     return paths
 
 
+def backend_source_kind(backend: dict[str, Any]) -> str:
+    return backend.get("source_kind", "native")
+
+
 def split_identifier(token: str) -> list[str]:
     parts: list[str] = []
     for chunk in re.split(r"[_\W]+", token):
@@ -1632,6 +1636,7 @@ def build_report(
             {
                 "id": backend["id"],
                 "name": backend["name"],
+                "source_kind": backend_source_kind(backend),
                 "implementation_paths": backend_implementation_paths(backend),
                 "test_paths": backend.get("tests", []),
             }


### PR DESCRIPTION
## Summary
- separate registered target backends from native source frontend coverage
- add explicit support catalog source_kind metadata for native and target-only backends
- update support matrix/signals generation and tests for future WebGL/WGSL target-only backends

## Verification
- .venv/bin/python -m pytest -q
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest tests/test_translator/test_codegen/test_backend_registry.py tests/test_support_matrix.py tests/test_support_signals.py tests/test_backend/test_package_contracts.py tests/test_translator/test_translation_pipeline.py::test_registered_native_sources_have_reverse_codegen_factories -q

Support issue traceability: no issue closed