### PR TITLE
Gate host binding plans on package inspection

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -1047,6 +1047,16 @@ def _format_runtime_host_binding_plan(payload):
             f"{summary.get('runtimeReferenceCount', 0)} runtime references"
         )
 
+    package_inspection = payload.get("packageInspection")
+    if isinstance(package_inspection, Mapping):
+        status = "ok" if package_inspection.get("success") else "failed"
+        lines.append(
+            "Package inspection: "
+            f"{status}, "
+            f"{package_inspection.get('readyBindingCount', 0)} ready bindings, "
+            f"{package_inspection.get('failedBindingCount', 0)} failed bindings"
+        )
+
     targets = payload.get("targets", [])
     if targets:
         lines.append("Host binding targets:")

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -313,6 +313,7 @@ RUNTIME_HOST_BINDING_PLAN_FIELDS = frozenset(
         "targets",
         "actions",
         "runtimePlan",
+        "packageInspection",
         "diagnosticCounts",
         "diagnostics",
     )
@@ -8640,89 +8641,6 @@ def build_runtime_package(
     return payload
 
 
-def _runtime_host_binding_load_package(
-    path: Path,
-) -> tuple[Mapping[str, Any], list[ProjectDiagnostic]]:
-    try:
-        package = json.loads(path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        return {}, [
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-read-failed",
-                message=f"Runtime package manifest could not be read: {exc}",
-                location=SourceLocation(file=str(path)),
-                check_kind="runtime-host-bindings",
-            )
-        ]
-    except json.JSONDecodeError as exc:
-        return {}, [
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-json-invalid",
-                message=f"Runtime package manifest is not valid JSON: {exc}",
-                location=SourceLocation(
-                    file=str(path), line=exc.lineno, column=exc.colno
-                ),
-                check_kind="runtime-host-bindings",
-            )
-        ]
-    if not isinstance(package, Mapping):
-        return {}, [
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-invalid",
-                message="Runtime package manifest must be a JSON object.",
-                location=SourceLocation(file=str(path)),
-                check_kind="runtime-host-bindings",
-            )
-        ]
-    return package, []
-
-
-def _runtime_host_binding_package_diagnostics(
-    path: Path, package: Mapping[str, Any]
-) -> list[ProjectDiagnostic]:
-    diagnostics: list[ProjectDiagnostic] = []
-    if package.get("schemaVersion") != REPORT_SCHEMA_VERSION:
-        diagnostics.append(
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-schema-invalid",
-                message=f"Runtime package schemaVersion must be {REPORT_SCHEMA_VERSION}.",
-                location=SourceLocation(file=str(path)),
-                check_kind="runtime-host-bindings",
-            )
-        )
-    if package.get("kind") != RUNTIME_PACKAGE_KIND:
-        diagnostics.append(
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-kind-invalid",
-                message=(
-                    "Host binding planning input must be a "
-                    f"{RUNTIME_PACKAGE_KIND} document."
-                ),
-                location=SourceLocation(file=str(path)),
-                check_kind="runtime-host-bindings",
-            )
-        )
-    if package.get("success") is not True:
-        diagnostics.append(
-            ProjectDiagnostic(
-                severity="error",
-                code="project.runtime-host-bindings.package-failed",
-                message=(
-                    "Runtime package must be successful before host bindings can "
-                    "be planned."
-                ),
-                location=SourceLocation(file=str(path)),
-                check_kind="runtime-host-bindings",
-            )
-        )
-    return diagnostics
-
-
 def _runtime_host_binding_packaged_artifacts(
     package: Mapping[str, Any],
 ) -> list[Mapping[str, Any]]:
@@ -8733,22 +8651,23 @@ def _runtime_host_binding_packaged_artifacts(
     ]
 
 
-def _runtime_host_binding_action(artifact: Mapping[str, Any]) -> dict[str, Any]:
-    source_remap = artifact.get("sourceRemap")
+def _runtime_host_binding_action(record: Mapping[str, Any]) -> dict[str, Any]:
+    source_remap = record.get("sourceRemap")
+    artifact = record.get("artifact", record.get("id"))
     return {
         "kind": "bind-runtime-artifact",
         "severity": "note",
         "message": (
             "Load packaged artifact "
-            f"{artifact.get('packagePath')} for target {artifact.get('target')}."
+            f"{record.get('packagePath')} for target {record.get('target')}."
         ),
-        "target": artifact.get("target"),
-        "artifact": artifact.get("id"),
-        "packagePath": artifact.get("packagePath"),
+        "target": record.get("target"),
+        "artifact": artifact,
+        "packagePath": record.get("packagePath"),
         "sourceRemap": (
             source_remap.get("packagePath")
             if isinstance(source_remap, Mapping)
-            else None
+            else source_remap if _is_non_empty_string(source_remap) else None
         ),
     }
 
@@ -8775,18 +8694,73 @@ def _runtime_host_binding_review_action(
 
 def _runtime_host_binding_target(
     target: str,
-    artifacts: Sequence[Mapping[str, Any]],
+    records: Sequence[Mapping[str, Any]],
     runtime_reference_count: int,
 ) -> dict[str, Any]:
-    target_artifacts = [
-        artifact for artifact in artifacts if artifact.get("target") == target
-    ]
+    target_records = [record for record in records if record.get("target") == target]
     return {
         "target": target,
-        "artifactCount": len(target_artifacts),
+        "artifactCount": len(target_records),
         "runtimeReferenceCount": runtime_reference_count,
-        "artifacts": [artifact.get("id") for artifact in target_artifacts],
-        "packagePaths": [artifact.get("packagePath") for artifact in target_artifacts],
+        "artifacts": [
+            record.get("artifact", record.get("id")) for record in target_records
+        ],
+        "packagePaths": [record.get("packagePath") for record in target_records],
+    }
+
+
+def _runtime_host_binding_ready_bindings(
+    bindings: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    return [binding for binding in bindings if binding.get("status") == "ready"]
+
+
+def _runtime_host_binding_actions(
+    bindings: Sequence[Mapping[str, Any]],
+    targets: Sequence[str],
+    runtime_reference_count: int,
+) -> list[dict[str, Any]]:
+    ready_bindings = _runtime_host_binding_ready_bindings(bindings)
+    actions = [_runtime_host_binding_action(binding) for binding in ready_bindings]
+    review_action = _runtime_host_binding_review_action(
+        targets, runtime_reference_count
+    )
+    if review_action is not None and ready_bindings:
+        actions.append(review_action)
+    return actions
+
+
+def _runtime_host_binding_package_inspection_summary(
+    inspection: Mapping[str, Any],
+) -> dict[str, Any]:
+    summary = (
+        inspection.get("summary")
+        if isinstance(inspection.get("summary"), Mapping)
+        else {}
+    )
+    return {
+        "kind": inspection.get("kind"),
+        "success": inspection.get("success"),
+        "readyBindingCount": (
+            summary.get("readyBindingCount")
+            if _is_non_negative_int(summary.get("readyBindingCount"))
+            else 0
+        ),
+        "failedBindingCount": (
+            summary.get("failedBindingCount")
+            if _is_non_negative_int(summary.get("failedBindingCount"))
+            else 0
+        ),
+        "verifiedArtifactCount": (
+            summary.get("verifiedArtifactCount")
+            if _is_non_negative_int(summary.get("verifiedArtifactCount"))
+            else 0
+        ),
+        "failedArtifactCount": (
+            summary.get("failedArtifactCount")
+            if _is_non_negative_int(summary.get("failedArtifactCount"))
+            else 0
+        ),
     }
 
 
@@ -8798,15 +8772,10 @@ def plan_runtime_host_bindings(
     package_path = _filesystem_path_arg(
         package_manifest_path, field_name="Runtime package manifest path"
     )
-    package, diagnostics = _runtime_host_binding_load_package(package_path)
-    if package:
-        diagnostics.extend(
-            _runtime_host_binding_package_diagnostics(package_path, package)
-        )
-
+    inspection = inspect_runtime_package(package_path)
     project_payload = (
-        dict(package.get("project"))
-        if isinstance(package.get("project"), Mapping)
+        dict(inspection.get("project"))
+        if isinstance(inspection.get("project"), Mapping)
         else {"targets": []}
     )
     targets = [
@@ -8815,24 +8784,27 @@ def plan_runtime_host_bindings(
         if _is_non_empty_string(target)
     ]
     runtime_plan = (
-        dict(package.get("runtimePlan"))
-        if isinstance(package.get("runtimePlan"), Mapping)
+        dict(inspection.get("runtimePlan"))
+        if isinstance(inspection.get("runtimePlan"), Mapping)
+        else {}
+    )
+    inspection_summary = (
+        inspection.get("summary")
+        if isinstance(inspection.get("summary"), Mapping)
         else {}
     )
     runtime_reference_count = (
-        runtime_plan.get("runtimeReferenceCount")
-        if _is_non_negative_int(runtime_plan.get("runtimeReferenceCount"))
+        inspection_summary.get("runtimeReferenceCount")
+        if _is_non_negative_int(inspection_summary.get("runtimeReferenceCount"))
         else 0
     )
-    artifacts = (
-        _runtime_host_binding_packaged_artifacts(package) if not diagnostics else []
-    )
-    actions = [_runtime_host_binding_action(artifact) for artifact in artifacts]
-    review_action = _runtime_host_binding_review_action(
-        targets, runtime_reference_count
-    )
-    if review_action is not None and artifacts:
-        actions.append(review_action)
+    bindings = [
+        binding
+        for binding in _record_sequence(inspection.get("bindings"))
+        if isinstance(binding, Mapping)
+    ]
+    ready_bindings = _runtime_host_binding_ready_bindings(bindings)
+    actions = _runtime_host_binding_actions(bindings, targets, runtime_reference_count)
 
     return {
         "schemaVersion": REPORT_SCHEMA_VERSION,
@@ -8840,29 +8812,38 @@ def plan_runtime_host_bindings(
         "sourcePackage": str(package_path),
         "sourcePackageHash": _optional_source_hash(package_path),
         "generatedAt": int(time.time()),
-        "success": not any(
-            diagnostic.severity == "error" for diagnostic in diagnostics
-        ),
+        "success": bool(inspection.get("success")),
         "scope": RUNTIME_HOST_BINDING_PLAN_SCOPE,
         "nonGoals": list(RUNTIME_HOST_BINDING_PLAN_NON_GOALS),
-        "packageRoot": (
-            package.get("packageRoot") if isinstance(package, Mapping) else None
-        ),
+        "packageRoot": inspection.get("packageRoot"),
         "project": project_payload,
         "summary": {
             "targetCount": len(targets),
-            "artifactCount": len(artifacts),
+            "artifactCount": len(ready_bindings),
             "actionCount": len(actions),
             "runtimeReferenceCount": runtime_reference_count,
         },
         "targets": [
-            _runtime_host_binding_target(target, artifacts, runtime_reference_count)
+            _runtime_host_binding_target(
+                target, ready_bindings, runtime_reference_count
+            )
             for target in targets
         ],
         "actions": actions,
         "runtimePlan": runtime_plan,
-        "diagnosticCounts": _diagnostic_counts(diagnostics),
-        "diagnostics": [diagnostic.to_json() for diagnostic in diagnostics],
+        "packageInspection": _runtime_host_binding_package_inspection_summary(
+            inspection
+        ),
+        "diagnosticCounts": (
+            dict(inspection.get("diagnosticCounts"))
+            if isinstance(inspection.get("diagnosticCounts"), Mapping)
+            else {}
+        ),
+        "diagnostics": (
+            [dict(diagnostic) for diagnostic in inspection.get("diagnostics", [])]
+            if isinstance(inspection.get("diagnostics"), list)
+            else []
+        ),
     }
 
 
@@ -9275,8 +9256,8 @@ def inspect_runtime_package(
         if isinstance(binding.get("sourceRemap"), Mapping)
         and binding["sourceRemap"].get("status") == "ready"
     )
-    host_binding_plan = (
-        plan_runtime_host_bindings(package_path) if package_input_valid else {}
+    host_binding_actions = _runtime_host_binding_actions(
+        bindings, targets, runtime_reference_count
     )
 
     return {
@@ -9305,21 +9286,13 @@ def inspect_runtime_package(
             "failedBindingCount": failed_binding_count,
             "bindingCount": len(bindings),
             "runtimeReferenceCount": runtime_reference_count,
-            "actionCount": (
-                host_binding_plan.get("summary", {}).get("actionCount")
-                if isinstance(host_binding_plan.get("summary"), Mapping)
-                else 0
-            ),
+            "actionCount": len(host_binding_actions),
         },
         "hostBindingPlan": {
-            "kind": host_binding_plan.get("kind"),
-            "actionCount": (
-                host_binding_plan.get("summary", {}).get("actionCount")
-                if isinstance(host_binding_plan.get("summary"), Mapping)
-                else 0
-            ),
+            "kind": RUNTIME_HOST_BINDING_PLAN_KIND,
+            "actionCount": len(host_binding_actions),
             "runtimeReferenceCount": runtime_reference_count,
-            "reviewRequired": runtime_reference_count > 0,
+            "reviewRequired": runtime_reference_count > 0 and ready_binding_count > 0,
         },
         "targets": [
             _runtime_package_inspection_target(

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -407,12 +407,15 @@ Build a host binding plan from a runtime package manifest:
      --format text
 
 Host binding plans emit a ``crosstl-runtime-host-binding-plan`` JSON document
-with per-target packaged artifact paths, ``bind-runtime-artifact`` actions for
-host loader or build-system tooling, and ``review-runtime-references`` actions
-when the source repository contained runtime API references. The plan preserves
-the ``runtime-loader-plan-v1`` summary linkage from earlier reports. It is an
-action plan only; it does not rewrite host application code, execute device
-code, generate runtime framework code, or install target SDKs.
+with per-target packaged artifact paths, package-inspection readiness metadata,
+``bind-runtime-artifact`` actions for host loader or build-system tooling, and
+``review-runtime-references`` actions when the source repository contained
+runtime API references. The planner reuses runtime package inspection and only
+emits bind actions for ready package records; missing or stale package artifacts
+remain diagnostics instead of host-integration work items. The plan preserves the
+``runtime-loader-plan-v1`` summary linkage from earlier reports. It is an action
+plan only; it does not rewrite host application code, execute device code,
+generate runtime framework code, or install target SDKs.
 
 Build a target-scoped runtime adapter plan from a runtime package manifest:
 

--- a/support/features.json
+++ b/support/features.json
@@ -8824,101 +8824,131 @@
       "support": {
         "directx": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "opengl": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "metal": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "vulkan": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "cuda": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "hip": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "mojo": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "rust": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "slang": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         },
         "webgl": {
           "status": "supported",
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ]
         }

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -3112,30 +3112,39 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -4736,100 +4736,130 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -10461,100 +10461,130 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_from_runtime_package",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_failed_package",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_host_bindings_rejects_missing_source_remap",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_outputs_actions",
+            "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_text_rejects_stale_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_host_bindings_json_writes_output"
           ],
-          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, records packaged artifact binding actions as bind-runtime-artifact entries, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, and rejects failed runtime packages with structured diagnostics. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "plan-host-bindings builds crosstl-runtime-host-binding-plan JSON, text, and SARIF output from a runtime package manifest, reuses runtime package inspection readiness before emitting bind-runtime-artifact entries, records packageInspection ready and failed binding counts, records review-runtime-references actions when runtime references were detected, preserves runtime-loader-plan-v1 summary linkage, rejects failed runtime packages and missing or stale packaged artifacts with structured package-inspection diagnostics, and does not emit host bind actions for failed package records. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/tests/test_support_matrix.py
+++ b/tests/test_support_matrix.py
@@ -816,7 +816,12 @@ def test_project_runtime_host_binding_plan_is_first_class_support_feature():
         assert backend_support["status"] == "supported"
         assert "crosstl-runtime-host-binding-plan" in backend_support["notes"]
         assert "runtime package manifest" in backend_support["notes"]
+        assert "runtime package inspection readiness" in backend_support["notes"]
+        assert "packageInspection" in backend_support["notes"]
         assert "bind-runtime-artifact" in backend_support["notes"]
+        assert "does not emit host bind actions for failed package records" in (
+            backend_support["notes"]
+        )
         assert "review-runtime-references" in backend_support["notes"]
         assert "runtime-loader-plan-v1" in backend_support["notes"]
         assert "does not rewrite host application code" in backend_support["notes"]
@@ -832,7 +837,19 @@ def test_project_runtime_host_binding_plan_is_first_class_support_feature():
         ) in backend_support["evidence"]
         assert (
             "tests/test_translator/test_project_translation.py::def "
+            "test_plan_runtime_host_bindings_rejects_missing_packaged_artifact"
+        ) in backend_support["evidence"]
+        assert (
+            "tests/test_translator/test_project_translation.py::def "
+            "test_plan_runtime_host_bindings_rejects_missing_source_remap"
+        ) in backend_support["evidence"]
+        assert (
+            "tests/test_translator/test_project_translation.py::def "
             "test_project_cli_plan_host_bindings_text_outputs_actions"
+        ) in backend_support["evidence"]
+        assert (
+            "tests/test_translator/test_project_translation.py::def "
+            "test_project_cli_plan_host_bindings_text_rejects_stale_package"
         ) in backend_support["evidence"]
         assert (
             "tests/test_translator/test_project_translation.py::def "

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -23416,6 +23416,14 @@ def test_plan_runtime_host_bindings_from_runtime_package(tmp_path):
         payload["actions"][1]["message"]
     )
     assert payload["runtimePlan"]["contract"] == "runtime-loader-plan-v1"
+    assert payload["packageInspection"] == {
+        "kind": project_pipeline.RUNTIME_PACKAGE_INSPECTION_KIND,
+        "success": True,
+        "readyBindingCount": 1,
+        "failedBindingCount": 0,
+        "verifiedArtifactCount": 1,
+        "failedArtifactCount": 0,
+    }
 
 
 def test_plan_runtime_host_bindings_rejects_failed_package(tmp_path):
@@ -23446,9 +23454,71 @@ def test_plan_runtime_host_bindings_rejects_failed_package(tmp_path):
     assert payload["summary"]["artifactCount"] == 0
     assert payload["targets"][0]["artifactCount"] == 0
     assert payload["actions"] == []
+    assert payload["packageInspection"] == {
+        "kind": project_pipeline.RUNTIME_PACKAGE_INSPECTION_KIND,
+        "success": False,
+        "readyBindingCount": 0,
+        "failedBindingCount": 0,
+        "verifiedArtifactCount": 0,
+        "failedArtifactCount": 0,
+    }
     assert payload["diagnosticCounts"]["error"] == 1
     assert payload["diagnostics"][0]["code"] == (
-        "project.runtime-host-bindings.package-failed"
+        "project.runtime-package-inspection.package-failed"
+    )
+
+
+def test_plan_runtime_host_bindings_rejects_missing_packaged_artifact(tmp_path):
+    _, package_dir, _ = _build_runtime_package_fixture(tmp_path)
+    (package_dir / "artifacts" / "out" / "cgl" / "simple.cgl").unlink()
+
+    payload = plan_runtime_host_bindings(package_dir / "runtime-package.json")
+
+    assert payload["success"] is False
+    assert payload["summary"]["artifactCount"] == 0
+    assert payload["summary"]["actionCount"] == 0
+    assert payload["targets"][0]["artifactCount"] == 0
+    assert payload["targets"][0]["artifacts"] == []
+    assert payload["targets"][0]["packagePaths"] == []
+    assert payload["actions"] == []
+    assert payload["packageInspection"] == {
+        "kind": project_pipeline.RUNTIME_PACKAGE_INSPECTION_KIND,
+        "success": False,
+        "readyBindingCount": 0,
+        "failedBindingCount": 1,
+        "verifiedArtifactCount": 0,
+        "failedArtifactCount": 1,
+    }
+    assert payload["diagnosticCounts"]["error"] == 1
+    assert payload["diagnostics"][0]["code"] == (
+        "project.runtime-package-inspection.artifact-missing"
+    )
+
+
+def test_plan_runtime_host_bindings_rejects_missing_source_remap(tmp_path):
+    _, package_dir, _ = _build_runtime_package_fixture(tmp_path)
+    (
+        package_dir / "source-remaps" / "out" / "cgl" / "simple.source-remap.json"
+    ).unlink()
+
+    payload = plan_runtime_host_bindings(package_dir / "runtime-package.json")
+
+    assert payload["success"] is False
+    assert payload["summary"]["artifactCount"] == 0
+    assert payload["summary"]["actionCount"] == 0
+    assert payload["targets"][0]["artifactCount"] == 0
+    assert payload["actions"] == []
+    assert payload["packageInspection"] == {
+        "kind": project_pipeline.RUNTIME_PACKAGE_INSPECTION_KIND,
+        "success": False,
+        "readyBindingCount": 0,
+        "failedBindingCount": 1,
+        "verifiedArtifactCount": 1,
+        "failedArtifactCount": 0,
+    }
+    assert payload["diagnosticCounts"]["error"] == 1
+    assert payload["diagnostics"][0]["code"] == (
+        "project.runtime-package-inspection.source-remap-missing"
     )
 
 
@@ -23499,9 +23569,43 @@ def test_project_cli_plan_host_bindings_text_outputs_actions(tmp_path):
     assert "Summary: 1 targets, 1 artifacts, 2 actions, 1 runtime references" in (
         result.stdout
     )
+    assert "Package inspection: ok, 1 ready bindings, 0 failed bindings" in (
+        result.stdout
+    )
     assert "- cgl: 1 artifacts, 1 runtime references" in result.stdout
     assert "bind-runtime-artifact" in result.stdout
     assert "review-runtime-references" in result.stdout
+
+
+def test_project_cli_plan_host_bindings_text_rejects_stale_package(tmp_path):
+    _, package_dir, _ = _build_runtime_package_fixture(tmp_path)
+    artifact_path = package_dir / "artifacts" / "out" / "cgl" / "simple.cgl"
+    artifact_path.write_text("// stale package artifact\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "plan-host-bindings",
+            str(package_dir / "runtime-package.json"),
+            "--format",
+            "text",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Status: failed" in result.stdout
+    assert "Package inspection: failed, 0 ready bindings, 1 failed bindings" in (
+        result.stdout
+    )
+    assert "Host binding actions:" not in result.stdout
+    assert "bind-runtime-artifact" not in result.stdout
+    assert "project.runtime-package-inspection.artifact-hash-mismatch" in result.stdout
 
 
 def test_project_cli_plan_host_bindings_json_writes_output(tmp_path):
@@ -23541,6 +23645,7 @@ def test_project_cli_plan_host_bindings_json_writes_output(tmp_path):
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["kind"] == project_pipeline.RUNTIME_HOST_BINDING_PLAN_KIND
     assert payload["actions"][0]["kind"] == "bind-runtime-artifact"
+    assert payload["packageInspection"]["readyBindingCount"] == 1
 
 
 def test_plan_runtime_adapters_from_runtime_package(tmp_path):


### PR DESCRIPTION
## Summary
- make host binding plans consume runtime package inspection before emitting bind actions
- include packageInspection readiness metadata in host binding plan output and CLI text
- document and support-matrix the readiness-gated host binding behavior

## Validation
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest -q -n auto
- .venv/bin/python tools/support_matrix.py check
- .venv/bin/python tools/support_signals.py check
- .venv/bin/python tools/sync_support_issues.py --dry-run --repo CrossGL/crosstl

Support issue traceability: no issue closed.