### PR TITLE
Extract host interface metadata with target parsers

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -9123,14 +9123,50 @@ def _runtime_host_interface_empty(
     }
 
 
+_RUNTIME_HOST_INTERFACE_STAGE_NAMES = frozenset(
+    {
+        "vertex",
+        "fragment",
+        "compute",
+        "geometry",
+        "tessellation_control",
+        "tessellation_evaluation",
+        "mesh",
+        "task",
+        "ray_generation",
+        "ray_intersection",
+        "ray_any_hit",
+        "ray_closest_hit",
+        "ray_miss",
+        "ray_callable",
+    }
+)
+
+
 def _runtime_host_interface_stage_name(stage: Any) -> str | None:
     if hasattr(stage, "value"):
         value = getattr(stage, "value")
-        return str(value) if value else None
+        if not value:
+            return None
+        stage = value
     if stage is None:
         return None
     label = str(stage)
-    return label.rsplit(".", 1)[-1].lower() if label else None
+    if not label:
+        return None
+    label = label.rsplit(".", 1)[-1].lower().replace("-", "_")
+    return {
+        "frag": "fragment",
+        "fs": "fragment",
+        "vert": "vertex",
+        "vs": "vertex",
+        "comp": "compute",
+        "cs": "compute",
+        "geom": "geometry",
+        "gs": "geometry",
+        "tess_control": "tessellation_control",
+        "tess_eval": "tessellation_evaluation",
+    }.get(label, label)
 
 
 def _runtime_host_interface_json_value(value: Any) -> Any:
@@ -9194,11 +9230,22 @@ def _runtime_host_interface_type_name(type_node: Any) -> str | None:
 
 def _runtime_host_interface_attribute_value(node: Any, names: Sequence[str]) -> Any:
     normalized_names = {name.lower() for name in names}
+    for layout_name in ("layout", "interface_layout"):
+        layout = getattr(node, layout_name, None)
+        if not isinstance(layout, Mapping):
+            continue
+        for key, value in layout.items():
+            if str(key).lower() in normalized_names:
+                return _runtime_host_interface_json_value(value)
     for attribute in getattr(node, "attributes", []) or []:
         attribute_name = str(getattr(attribute, "name", "")).lower()
         if attribute_name not in normalized_names:
             continue
-        arguments = getattr(attribute, "arguments", []) or []
+        arguments = (
+            getattr(attribute, "arguments", None)
+            or getattr(attribute, "args", None)
+            or []
+        )
         if not arguments:
             return None
         return _runtime_host_interface_json_value(arguments[0])
@@ -9229,7 +9276,7 @@ def _runtime_host_interface_resource_access(node: Any) -> str | None:
         return "read_write"
     if qualifiers & {"writeonly", "write_only"}:
         return "write"
-    if qualifiers & {"readonly", "read_only"}:
+    if qualifiers & {"readonly", "read_only", "constant"}:
         return "read"
     return None
 
@@ -9243,7 +9290,11 @@ def _runtime_host_interface_resource_kind(node: Any) -> str | None:
     if class_name == "SamplerNode":
         return "sampler"
 
-    type_name = _runtime_host_interface_type_name(getattr(node, "var_type", None)) or ""
+    type_name = (
+        _runtime_host_interface_type_name(getattr(node, "var_type", None))
+        or _runtime_host_interface_type_name(getattr(node, "vtype", None))
+        or ""
+    )
     type_label = type_name.lower()
     qualifiers = {
         str(qualifier).lower() for qualifier in getattr(node, "qualifiers", [])
@@ -9262,13 +9313,15 @@ def _runtime_host_interface_resource_kind(node: Any) -> str | None:
         or "uav" in attribute_names
     ):
         return "storage-texture"
+    if "constant" in qualifiers:
+        return "constant-buffer"
     if (
         "texture" in type_label
         or "sampler2d" in type_label
         or "texture" in attribute_names
     ):
         return "texture"
-    if "buffer" in type_label or "buffer" in qualifiers:
+    if "buffer" in type_label or "buffer" in qualifiers or "buffer" in attribute_names:
         return "buffer"
     if "uniform" in qualifiers:
         return "uniform"
@@ -9276,18 +9329,22 @@ def _runtime_host_interface_resource_kind(node: Any) -> str | None:
 
 
 def _runtime_host_interface_resource_from_node(node: Any) -> dict[str, Any] | None:
+    if _is_non_empty_string(getattr(node, "interface_block", None)):
+        return None
     kind = _runtime_host_interface_resource_kind(node)
     if kind is None:
         return None
 
+    type_name = (
+        _runtime_host_interface_type_name(getattr(node, "buffer_type", None))
+        or getattr(node, "texture_type", None)
+        or _runtime_host_interface_type_name(getattr(node, "var_type", None))
+        or _runtime_host_interface_type_name(getattr(node, "vtype", None))
+    )
     return {
         "name": getattr(node, "name", None),
         "kind": kind,
-        "type": (
-            _runtime_host_interface_type_name(getattr(node, "buffer_type", None))
-            or getattr(node, "texture_type", None)
-            or _runtime_host_interface_type_name(getattr(node, "var_type", None))
-        ),
+        "type": type_name,
         "set": (
             getattr(node, "set", None)
             if isinstance(getattr(node, "set", None), int)
@@ -9297,7 +9354,7 @@ def _runtime_host_interface_resource_from_node(node: Any) -> dict[str, Any] | No
             getattr(node, "binding", None)
             if isinstance(getattr(node, "binding", None), int)
             else _runtime_host_interface_int_attribute(
-                node, ("binding", "texture", "sampler", "uav")
+                node, ("binding", "buffer", "texture", "sampler", "uav")
             )
         ),
         "access": _runtime_host_interface_resource_access(node),
@@ -9313,6 +9370,45 @@ def _runtime_host_interface_cbuffer_resource(node: Any) -> dict[str, Any]:
         "binding": _runtime_host_interface_int_attribute(node, ("binding",)),
         "access": "read",
     }
+
+
+def _runtime_host_interface_resource_from_interface_block(
+    node: Any,
+) -> dict[str, Any] | None:
+    if not getattr(node, "interface_block", False):
+        return None
+    qualifiers = {
+        str(qualifier).lower()
+        for qualifier in getattr(node, "interface_qualifiers", []) or []
+    }
+    if "uniform" in qualifiers:
+        kind = "constant-buffer"
+        access = "read"
+    elif "buffer" in qualifiers:
+        kind = "buffer"
+        access = _runtime_host_interface_resource_access(node) or "read_write"
+    else:
+        return None
+    return {
+        "name": getattr(node, "name", None),
+        "kind": kind,
+        "type": getattr(node, "name", None),
+        "set": _runtime_host_interface_int_attribute(node, ("set", "space")),
+        "binding": _runtime_host_interface_int_attribute(node, ("binding",)),
+        "access": access,
+    }
+
+
+def _runtime_host_interface_function_stage(function: Any, ast: Any) -> str | None:
+    for qualifier in getattr(function, "qualifiers", []) or []:
+        stage = _runtime_host_interface_stage_name(qualifier)
+        if stage in _RUNTIME_HOST_INTERFACE_STAGE_NAMES:
+            return stage
+    if getattr(function, "name", None) == "main":
+        stage = _runtime_host_interface_stage_name(getattr(ast, "shader_type", None))
+        if stage in _RUNTIME_HOST_INTERFACE_STAGE_NAMES:
+            return stage
+    return None
 
 
 def _runtime_host_interface_entry_points(ast: Any) -> list[dict[str, Any]]:
@@ -9332,6 +9428,28 @@ def _runtime_host_interface_entry_points(ast: Any) -> list[dict[str, Any]]:
                 ),
             }
         )
+    seen = {
+        (
+            entry_point.get("name"),
+            entry_point.get("stage"),
+        )
+        for entry_point in entry_points
+    }
+    for function in getattr(ast, "functions", []) or []:
+        stage = _runtime_host_interface_function_stage(function, ast)
+        if stage is None:
+            continue
+        key = (getattr(function, "name", None), stage)
+        if key in seen:
+            continue
+        seen.add(key)
+        entry_points.append(
+            {
+                "name": getattr(function, "name", None),
+                "stage": stage,
+                "executionConfig": {},
+            }
+        )
     return entry_points
 
 
@@ -9339,10 +9457,22 @@ def _runtime_host_interface_resources(ast: Any) -> list[dict[str, Any]]:
     resources: list[dict[str, Any]] = []
     for cbuffer in getattr(ast, "cbuffers", []) or []:
         resources.append(_runtime_host_interface_cbuffer_resource(cbuffer))
-    for variable in getattr(ast, "global_variables", []) or []:
-        resource = _runtime_host_interface_resource_from_node(variable)
+    for struct in getattr(ast, "structs", []) or []:
+        resource = _runtime_host_interface_resource_from_interface_block(struct)
         if resource is not None:
             resources.append(resource)
+    for variable_group in ("global_variables", "uniforms"):
+        for variable in getattr(ast, variable_group, []) or []:
+            resource = _runtime_host_interface_resource_from_node(variable)
+            if resource is not None:
+                resources.append(resource)
+    for function in getattr(ast, "functions", []) or []:
+        if _runtime_host_interface_function_stage(function, ast) is None:
+            continue
+        for parameter in getattr(function, "params", []) or []:
+            resource = _runtime_host_interface_resource_from_node(parameter)
+            if resource is not None:
+                resources.append(resource)
 
     stages = getattr(ast, "stages", None)
     stage_values = stages.values() if hasattr(stages, "values") else []
@@ -9379,15 +9509,25 @@ def _runtime_package_inspection_host_interface(
 ) -> dict[str, Any]:
     target = artifact.get("target")
     target_name = str(target).lower() if _is_non_empty_string(target) else ""
+    parser_name = None
+    source_spec = None
+    try:
+        register_default_sources()
+        parser_name = SOURCE_REGISTRY.resolve_name(target_name) if target_name else None
+        source_spec = SOURCE_REGISTRY.get(parser_name) if parser_name else None
+    except Exception:
+        parser_name = None
+        source_spec = None
+
     if artifact_diagnostics:
         return _runtime_host_interface_empty(
             "not-inspected",
-            parser="cgl" if target_name in {"cgl", "crossgl"} else None,
+            parser=parser_name,
             diagnostics=(
                 "project.runtime-package-inspection.host-interface-artifact-not-ready",
             ),
         )
-    if target_name not in {"cgl", "crossgl"}:
+    if source_spec is None:
         return _runtime_host_interface_empty(
             "unavailable",
             diagnostics=(
@@ -9399,7 +9539,7 @@ def _runtime_package_inspection_host_interface(
     if not _is_non_empty_string(package_relative_path):
         return _runtime_host_interface_empty(
             "not-inspected",
-            parser="cgl",
+            parser=parser_name,
             diagnostics=(
                 "project.runtime-package-inspection.host-interface-artifact-not-ready",
             ),
@@ -9409,23 +9549,13 @@ def _runtime_package_inspection_host_interface(
     if not _is_relative_to(artifact_path, package_root) or not artifact_path.is_file():
         return _runtime_host_interface_empty(
             "not-inspected",
-            parser="cgl",
+            parser=parser_name,
             diagnostics=(
                 "project.runtime-package-inspection.host-interface-artifact-not-ready",
             ),
         )
 
     try:
-        register_default_sources()
-        source_spec = SOURCE_REGISTRY.get("cgl")
-        if source_spec is None:
-            return _runtime_host_interface_empty(
-                "unavailable",
-                parser="cgl",
-                diagnostics=(
-                    "project.runtime-package-inspection.host-interface-parser-unavailable",
-                ),
-            )
         ast = source_spec.parse(
             artifact_path.read_text(encoding="utf-8"),
             file_path=str(artifact_path),
@@ -9433,12 +9563,19 @@ def _runtime_package_inspection_host_interface(
     except Exception:
         return _runtime_host_interface_empty(
             "failed",
-            parser="cgl",
+            parser=parser_name,
             diagnostics=(
                 "project.runtime-package-inspection.host-interface-parse-failed",
             ),
         )
-    return _runtime_host_interface_from_ast(ast, parser="cgl")
+    host_interface = _runtime_host_interface_from_ast(ast, parser=parser_name or "")
+    if host_interface["entryPointCount"] == 0 and host_interface["resourceCount"] == 0:
+        return _runtime_host_interface_empty(
+            "unavailable",
+            parser=parser_name,
+            diagnostics=("project.runtime-package-inspection.host-interface-empty",),
+        )
+    return host_interface
 
 
 def _runtime_package_inspection_binding(

--- a/crosstl/translator/codegen/metal_codegen.py
+++ b/crosstl/translator/codegen/metal_codegen.py
@@ -3626,7 +3626,9 @@ class MetalCodeGen:
                     "gl_VertexIndex"
                 ] = explicit_stage_builtins["vertex_id"]
             reserved_builtin_names = set(reserved_parameter_names)
-            reserved_builtin_names.update(self.metal_function_local_variable_names(func))
+            reserved_builtin_names.update(
+                self.metal_function_local_variable_names(func)
+            )
             for (
                 builtin_name,
                 name,
@@ -3637,9 +3639,7 @@ class MetalCodeGen:
             ):
                 params.append(f"{param_type} {name} [[{attribute}]]")
                 reserved_parameter_names.add(name)
-                self.current_metal_graphics_builtin_parameter_names[
-                    builtin_name
-                ] = name
+                self.current_metal_graphics_builtin_parameter_names[builtin_name] = name
 
         if shader_type == "compute":
             existing_param_names = {getattr(p, "name", None) for p in param_list}

--- a/crosstl/translator/codegen/metal_codegen.py
+++ b/crosstl/translator/codegen/metal_codegen.py
@@ -3889,8 +3889,8 @@ class MetalCodeGen:
         if shader_type == "vertex":
             function_name = entry_name or f"vertex_{func.name}"
             if vertex_stage_input_parameters:
-                stage_input_struct_name = (
-                    self.unique_vertex_stage_input_struct_name(function_name)
+                stage_input_struct_name = self.unique_vertex_stage_input_struct_name(
+                    function_name
                 )
                 stage_input_parameter_name = self.unique_metal_generated_name(
                     "_crossglInput",

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -434,8 +434,11 @@ packaged artifact frontend is available, and ``wire-runtime-adapter`` actions
 for host loader or build-system tooling. When host interface metadata is
 unavailable or not ready, the plan emits ``resolve-host-interface-metadata``
 actions so host and build tooling can provide reflection or backend-specific
-binding metadata before wiring the adapter. It also carries through package
-inspection diagnostics and
+binding metadata before wiring the adapter. Source targets with registered
+frontends can contribute parser-derived interface summaries; formats that need
+compiled reflection, such as SPIR-V handoff artifacts without reflected entry
+point/resource data, remain explicit follow-up actions. The plan also carries
+through package inspection diagnostics and
 ``review-runtime-references`` actions when the source repository contained
 runtime API references. The plan is a target-scoped integration contract; it
 does not rewrite host application code, execute device code, generate runtime

--- a/support/features.json
+++ b/support/features.json
@@ -8686,10 +8686,12 @@
       "support": {
         "directx": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8700,10 +8702,12 @@
         },
         "opengl": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8714,10 +8718,12 @@
         },
         "metal": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8728,10 +8734,12 @@
         },
         "vulkan": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8742,10 +8750,12 @@
         },
         "cuda": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8756,10 +8766,12 @@
         },
         "hip": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8770,10 +8782,12 @@
         },
         "mojo": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8784,10 +8798,12 @@
         },
         "rust": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8798,10 +8814,12 @@
         },
         "slang": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8812,10 +8830,12 @@
         },
         "webgl": {
           "status": "supported",
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -8975,7 +8995,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -8987,7 +9008,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -8999,7 +9021,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9011,7 +9034,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9023,7 +9047,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9035,7 +9060,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9047,7 +9073,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9059,7 +9086,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9071,7 +9099,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -9083,7 +9112,8 @@
           "notes": "plan-runtime-adapters builds crosstl-runtime-adapter-plan JSON, text, and SARIF output from a runtime package manifest, consumes package inspection diagnostics, records target adapterKind, artifactFormat, requiredTools, hostResponsibilities, and hostInterface metadata for ready bindings, preserves source-remap handoff paths, emits wire-runtime-adapter and review-runtime-references actions for host loader or build-system tooling, and emits resolve-host-interface-metadata actions when packaged artifact interface metadata is unavailable or not ready. The plan does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -3065,6 +3065,8 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -3072,13 +3074,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -3086,13 +3090,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -3100,7 +3106,7 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }
@@ -3161,7 +3167,8 @@
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -3173,7 +3180,8 @@
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -3185,7 +3193,8 @@
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -4598,6 +4598,8 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4605,13 +4607,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4619,13 +4623,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4633,13 +4639,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4647,13 +4655,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4661,13 +4671,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4675,13 +4687,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4689,13 +4703,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4703,13 +4719,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4717,13 +4735,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -4731,7 +4751,7 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }
@@ -4883,7 +4903,8 @@
         "cuda": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4895,7 +4916,8 @@
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4907,7 +4929,8 @@
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4919,7 +4942,8 @@
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4931,7 +4955,8 @@
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4943,7 +4968,8 @@
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4955,7 +4981,8 @@
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4967,7 +4994,8 @@
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4979,7 +5007,8 @@
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -4991,7 +5020,8 @@
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -10323,6 +10323,8 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10330,13 +10332,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10344,13 +10348,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10358,13 +10364,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10372,13 +10380,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10386,13 +10396,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10400,13 +10412,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10414,13 +10428,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10428,13 +10444,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10442,13 +10460,15 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_ready_bindings",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_host_interface_resources",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_reports_entry_point_parameter_resources",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_packaged_artifact",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_packaged_artifact_hash_mismatch",
             "tests/test_translator/test_project_translation.py::def test_inspect_runtime_package_detects_missing_source_remap",
@@ -10456,7 +10476,7 @@
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_text_outputs_readiness",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_runtime_package_json_writes_output"
           ],
-          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged CrossGL artifacts, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "inspect-runtime-package builds crosstl-runtime-package-inspection JSON, text, and SARIF output from a runtime package manifest, verifies copied packaged artifact and source-remap sidecar presence, hash, and byte-size metadata, records ready and failed host binding records, records parser-derived hostInterface entry point and resource summaries for packaged artifacts with registered source frontends and records explicit metadata diagnostics when parsed artifacts do not expose usable interface data, preserves runtime-loader-plan-v1 summary linkage, and emits structured diagnostics for stale, missing, or malformed package contents. Inspection is read-only and does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }
@@ -10608,7 +10628,8 @@
         "cuda": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10620,7 +10641,8 @@
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10632,7 +10654,8 @@
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10644,7 +10667,8 @@
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10656,7 +10680,8 @@
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10668,7 +10693,8 @@
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10680,7 +10706,8 @@
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10692,7 +10719,8 @@
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10704,7 +10732,8 @@
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",
@@ -10716,7 +10745,8 @@
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_from_runtime_package",
-            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface",
+            "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty",
             "tests/test_translator/test_project_translation.py::def test_plan_runtime_adapters_rejects_failed_package",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_outputs_adapters",
             "tests/test_translator/test_project_translation.py::def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status",

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -23260,6 +23260,123 @@ def test_inspect_runtime_package_reports_host_interface_resources(tmp_path):
     assert host_interface["diagnostics"] == []
 
 
+def test_inspect_runtime_package_uses_registered_target_parser_for_host_interface(
+    tmp_path,
+):
+    source = textwrap.dedent("""
+        shader ResourceShader {
+            layout(set = 1, binding = 2) uniform sampler2D sourceTexture;
+
+            cbuffer Camera {
+                mat4 viewProj;
+            }
+
+            fragment {
+                vec4 main() {
+                    return vec4(1.0);
+                }
+            }
+        }
+        """).strip()
+    _, package_dir, _ = _build_runtime_package_fixture(
+        tmp_path,
+        source=source,
+        source_name="resource.cgl",
+        targets=("opengl",),
+    )
+
+    payload = inspect_runtime_package(package_dir / "runtime-package.json")
+
+    host_interface = payload["bindings"][0]["hostInterface"]
+    assert host_interface["status"] == "ready"
+    assert host_interface["source"] == "package-artifact"
+    assert host_interface["parser"] == "opengl"
+    assert host_interface["entryPointCount"] == 1
+    assert host_interface["entryPoints"] == [
+        {
+            "name": "main",
+            "stage": "fragment",
+            "executionConfig": {},
+        }
+    ]
+    assert host_interface["resourceCount"] == 2
+    assert host_interface["resources"] == [
+        {
+            "name": "Camera",
+            "kind": "constant-buffer",
+            "type": "Camera",
+            "set": None,
+            "binding": 0,
+            "access": "read",
+        },
+        {
+            "name": "sourceTexture",
+            "kind": "texture",
+            "type": "sampler2D",
+            "set": None,
+            "binding": 1026,
+            "access": None,
+        },
+    ]
+    assert host_interface["diagnostics"] == []
+
+
+def test_inspect_runtime_package_reports_entry_point_parameter_resources(tmp_path):
+    source = textwrap.dedent("""
+        shader ResourceShader {
+            layout(set = 1, binding = 2) uniform sampler2D sourceTexture;
+
+            cbuffer Camera {
+                mat4 viewProj;
+            }
+
+            fragment {
+                vec4 main() {
+                    return vec4(1.0);
+                }
+            }
+        }
+        """).strip()
+    _, package_dir, _ = _build_runtime_package_fixture(
+        tmp_path,
+        source=source,
+        source_name="resource.cgl",
+        targets=("metal",),
+    )
+
+    payload = inspect_runtime_package(package_dir / "runtime-package.json")
+
+    host_interface = payload["bindings"][0]["hostInterface"]
+    assert host_interface["status"] == "ready"
+    assert host_interface["parser"] == "metal"
+    assert host_interface["entryPoints"] == [
+        {
+            "name": "fragment_main",
+            "stage": "fragment",
+            "executionConfig": {},
+        }
+    ]
+    assert host_interface["resources"] == [
+        {
+            "name": "camera",
+            "kind": "constant-buffer",
+            "type": "Camera&",
+            "set": None,
+            "binding": 0,
+            "access": "read",
+        },
+        {
+            "name": "sourceTexture",
+            "kind": "texture",
+            "type": "texture2d<float>",
+            "set": None,
+            "binding": 0,
+            "access": None,
+        },
+    ]
+    assert host_interface["diagnostics"] == []
+
+
 def test_inspect_runtime_package_detects_missing_packaged_artifact(tmp_path):
     _, package_dir, _ = _build_runtime_package_fixture(tmp_path)
     (package_dir / "artifacts" / "out" / "cgl" / "simple.cgl").unlink()
@@ -23799,7 +23916,7 @@ def test_plan_runtime_adapters_from_runtime_package(tmp_path):
     }
 
 
-def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_target(
+def test_plan_runtime_adapters_uses_registered_target_parser_for_host_interface(
     tmp_path,
 ):
     _, package_dir, _ = _build_runtime_package_fixture(tmp_path, targets=("opengl",))
@@ -23813,7 +23930,7 @@ def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_ta
         "readyBindingCount": 1,
         "failedBindingCount": 0,
         "adapterCount": 1,
-        "actionCount": 3,
+        "actionCount": 2,
         "runtimeReferenceCount": 1,
     }
     assert payload["targets"][0]["target"] == "opengl"
@@ -23822,17 +23939,61 @@ def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_ta
     adapter = payload["adapters"][0]
     assert adapter["target"] == "opengl"
     assert adapter["adapterKind"] == "opengl-glsl-adapter"
+    assert adapter["hostInterface"]["status"] == "ready"
+    assert adapter["hostInterface"] == {
+        "status": "ready",
+        "source": "package-artifact",
+        "parser": "opengl",
+        "entryPointCount": 1,
+        "resourceCount": 0,
+        "entryPoints": [
+            {
+                "name": "main",
+                "stage": "vertex",
+                "executionConfig": {},
+            }
+        ],
+        "resources": [],
+        "diagnostics": [],
+    }
+    assert [action["kind"] for action in payload["actions"]] == [
+        "wire-runtime-adapter",
+        "review-runtime-references",
+    ]
+
+
+def test_plan_runtime_adapters_reports_unavailable_host_interface_when_empty(
+    tmp_path,
+):
+    _, package_dir, _ = _build_runtime_package_fixture(tmp_path, targets=("vulkan",))
+
+    payload = plan_runtime_adapters(package_dir / "runtime-package.json")
+
+    assert payload["success"] is True
+    assert payload["summary"] == {
+        "targetCount": 1,
+        "bindingCount": 1,
+        "readyBindingCount": 1,
+        "failedBindingCount": 0,
+        "adapterCount": 1,
+        "actionCount": 3,
+        "runtimeReferenceCount": 1,
+    }
+    assert payload["targets"][0]["target"] == "vulkan"
+    assert payload["targets"][0]["adapterKind"] == "vulkan-shader-adapter"
+    assert len(payload["adapters"]) == 1
+    adapter = payload["adapters"][0]
+    assert adapter["target"] == "vulkan"
+    assert adapter["adapterKind"] == "vulkan-shader-adapter"
     assert adapter["hostInterface"] == {
         "status": "unavailable",
         "source": "package-artifact",
-        "parser": None,
+        "parser": "vulkan",
         "entryPointCount": 0,
         "resourceCount": 0,
         "entryPoints": [],
         "resources": [],
-        "diagnostics": [
-            "project.runtime-package-inspection.host-interface-parser-unavailable"
-        ],
+        "diagnostics": ["project.runtime-package-inspection.host-interface-empty"],
     }
     assert [action["kind"] for action in payload["actions"]] == [
         "wire-runtime-adapter",
@@ -23844,12 +24005,12 @@ def test_plan_runtime_adapters_reports_unavailable_host_interface_for_non_cgl_ta
         project_pipeline.RUNTIME_ADAPTER_PLAN_ACTION_FIELDS
     )
     assert host_interface_action["severity"] == "warning"
-    assert host_interface_action["target"] == "opengl"
+    assert host_interface_action["target"] == "vulkan"
     assert host_interface_action["adapter"] == adapter["id"]
     assert host_interface_action["binding"] == adapter["binding"]
     assert host_interface_action["packagePath"] == adapter["packagePath"]
     assert "status is unavailable" in host_interface_action["message"]
-    assert "host-interface-parser-unavailable" in host_interface_action["message"]
+    assert "host-interface-empty" in host_interface_action["message"]
 
 
 def test_plan_runtime_adapters_rejects_failed_package(tmp_path):
@@ -23930,7 +24091,7 @@ def test_project_cli_plan_runtime_adapters_text_outputs_adapters(tmp_path):
 def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status(
     tmp_path,
 ):
-    _, package_dir, _ = _build_runtime_package_fixture(tmp_path, targets=("opengl",))
+    _, package_dir, _ = _build_runtime_package_fixture(tmp_path, targets=("vulkan",))
     package_manifest = package_dir / "runtime-package.json"
 
     result = subprocess.run(
@@ -23952,7 +24113,7 @@ def test_project_cli_plan_runtime_adapters_text_reports_host_interface_status(
     assert result.returncode == 0
     assert "Runtime adapters:" in result.stdout
     assert "interface: unavailable" in result.stdout
-    assert "host-interface-parser-unavailable" in result.stdout
+    assert "host-interface-empty" in result.stdout
     assert "Runtime adapter actions:" in result.stdout
     assert "resolve-host-interface-metadata" in result.stdout
 


### PR DESCRIPTION
## Summary
- use registered source frontends to extract runtime package host-interface metadata for translated target artifacts
- read common backend AST entry points, layout bindings, uniforms, interface blocks, and entry-point resource parameters
- keep unresolved artifacts diagnostic-driven with resolve-host-interface-metadata adapter actions

## Validation
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest -q -n auto
- .venv/bin/python tools/support_matrix.py check
- .venv/bin/python tools/support_signals.py check
- .venv/bin/python tools/sync_support_issues.py --repo CrossGL/crosstl --dry-run --no-sub-issues --min-desired-issues 0 --max-planned-created 0 --max-planned-updated 0 --max-planned-closed 0 --max-planned-attached 0 --max-planned-total 0

Support issue traceability: no issue closed