### PR TITLE
Preserve HLSL texture resources for Metal

### DIFF
--- a/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
+++ b/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
@@ -3561,18 +3561,19 @@ class HLSLToCrossGLConverter:
         base_type = self.raw_type_base(type_name)
         if not base_type:
             return False
-        return (
-            base_type in {"sampler", "comparison_sampler", "accelerationStructure"}
-            or base_type.startswith(
-                (
-                    "sampler",
-                    "isampler",
-                    "usampler",
-                    "image",
-                    "iimage",
-                    "uimage",
-                    "feedbackTexture",
-                )
+        return base_type in {
+            "sampler",
+            "comparison_sampler",
+            "accelerationStructure",
+        } or base_type.startswith(
+            (
+                "sampler",
+                "isampler",
+                "usampler",
+                "image",
+                "iimage",
+                "uimage",
+                "feedbackTexture",
             )
         )
 

--- a/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
+++ b/crosstl/backend/DirectX/DirectxCrossGLCodeGen.py
@@ -3531,9 +3531,11 @@ class HLSLToCrossGLConverter:
         base_type = self.raw_type_base(type_name)
         if not base_type:
             return False
+        mapped_base_type = self.raw_type_base(self.map_type(type_name))
         if (
             self.is_uav_resource_type(type_name)
             or self.is_buffer_resource_type(type_name)
+            or self.is_crossgl_resource_type(mapped_base_type)
             or base_type.startswith(("Texture", "FeedbackTexture"))
             or base_type
             in {
@@ -3554,6 +3556,25 @@ class HLSLToCrossGLConverter:
         ):
             return False
         return True
+
+    def is_crossgl_resource_type(self, type_name):
+        base_type = self.raw_type_base(type_name)
+        if not base_type:
+            return False
+        return (
+            base_type in {"sampler", "comparison_sampler", "accelerationStructure"}
+            or base_type.startswith(
+                (
+                    "sampler",
+                    "isampler",
+                    "usampler",
+                    "image",
+                    "iimage",
+                    "uimage",
+                    "feedbackTexture",
+                )
+            )
+        )
 
     def collect_hlsl_program_constant_global_ids(self, ast):
         candidates = {

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -975,6 +975,49 @@ def test_hlsl_legacy_sampler_register_lowers_to_opengl_binding(tmp_path):
     assert "fragColor = texture(Texture, uv);" in generated
 
 
+def test_hlsl_fx_macro_texture_resource_survives_metal_translation(tmp_path):
+    _write_source(
+        tmp_path,
+        "Macros.fxh",
+        """
+        #define DECLARE_TEXTURE(Name, index) \\
+            sampler2D Name : register(s##index);
+        #define SAMPLE_TEXTURE(Name, texCoord) tex2D(Name, texCoord)
+        """,
+    )
+    source_path = _write_source(
+        tmp_path,
+        "SpriteEffect.fx",
+        """
+        #include "Macros.fxh"
+
+        DECLARE_TEXTURE(Texture, 0);
+
+        struct VSOutput {
+            float4 position : SV_Position;
+            float4 color : COLOR0;
+            float2 texCoord : TEXCOORD0;
+        };
+
+        float4 SpritePixelShader(VSOutput input) : SV_Target0 {
+            return SAMPLE_TEXTURE(Texture, input.texCoord) * input.color;
+        }
+        """,
+    )
+
+    crossgl = crosstl.translate(str(source_path), backend="cgl", format_output=False)
+    metal = crosstl.translate(str(source_path), backend="metal", format_output=False)
+
+    assert "@ register(s0)\n    sampler2D Texture;" in crossgl
+    assert "@ hlsl_program_constant\n    @ register(s0)\n    sampler2D Texture;" not in crossgl
+    assert "texture2d<float> Texture [[texture(0)]]" in metal
+    assert (
+        "Texture.sample(sampler(mag_filter::linear, min_filter::linear), input.texCoord)"
+        in metal
+    )
+    _compile_with_metal_if_available(metal, tmp_path)
+
+
 @pytest.mark.parametrize("target", ["metal", "directx", "vulkan"])
 def test_glsl_fragment_invocation_density_rejects_unsupported_targets_before_output(
     tmp_path, target

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -1009,7 +1009,10 @@ def test_hlsl_fx_macro_texture_resource_survives_metal_translation(tmp_path):
     metal = crosstl.translate(str(source_path), backend="metal", format_output=False)
 
     assert "@ register(s0)\n    sampler2D Texture;" in crossgl
-    assert "@ hlsl_program_constant\n    @ register(s0)\n    sampler2D Texture;" not in crossgl
+    assert (
+        "@ hlsl_program_constant\n    @ register(s0)\n    sampler2D Texture;"
+        not in crossgl
+    )
     assert "texture2d<float> Texture [[texture(0)]]" in metal
     assert (
         "Texture.sample(sampler(mag_filter::linear, min_filter::linear), input.texCoord)"


### PR DESCRIPTION
## Summary
- Keep HLSL texture/image/sampler resources out of synthetic program constants after DirectX-to-CrossGL lowering.
- Add a MonoGame-style FX macro regression covering legacy sampler2D texture sampling into Metal.

## Tests
- pytest tests/test_translator/test_translation_pipeline.py::test_hlsl_fx_macro_texture_resource_survives_metal_translation tests/test_translator/test_translation_pipeline.py::test_hlsl_legacy_sampler_register_lowers_to_opengl_binding tests/test_translator/test_translation_pipeline.py::test_hlsl_hello_const_buffers_vertex_semantics_lower_to_metal_attributes -q
- pytest tests/test_translator/test_translation_pipeline.py -q
- pytest tests/test_backend/test_directx/test_codegen.py -q
- Exact MonoGame SpriteEffect project repro from demo-open-source-repo-porting with Metal target: translated, artifact written

closes #873