### PR TITLE
Lower GLSL fragment outputs to HLSL target semantics

### DIFF
--- a/crosstl/backend/GLSL/openglCrossglCodegen.py
+++ b/crosstl/backend/GLSL/openglCrossglCodegen.py
@@ -1551,9 +1551,19 @@ class GLSLToCrossGLConverter:
             var
         ) + self.variable_qualifier_attribute_suffix(var)
 
-    def fragment_return_attribute_suffix(self, var):
+    def fragment_output_location_attribute(self, var, index=0):
+        layout = getattr(var, "layout", None) or {}
+        if layout.get("location") is not None:
+            return ""
+        return f" @location({index})"
+
+    def fragment_return_attribute_suffix(self, var, index=0):
+        semantic = self.semantic_attribute_suffix(getattr(var, "semantic", None))
+        if semantic:
+            return semantic
         return (
             self.variable_layout_attribute_suffix(var)
+            + self.fragment_output_location_attribute(var, index)
             + self.interface_qualifier_attribute_suffix(var)
             + self.variable_qualifier_attribute_suffix(var)
         )
@@ -2681,20 +2691,17 @@ class GLSLToCrossGLConverter:
                     result += self.indent() + f"void main({input_parameter})"
                 else:
                     output_type = "vec4"
-                    output_name = "gl_FragColor"
                     output_attributes = ""
                     if self.outputs:
                         output_var = self.outputs[0]
                         output_type = self.convert_type(output_var.vtype)
-                        output_name = output_var.name
                         output_attributes = self.fragment_return_attribute_suffix(
-                            output_var
+                            output_var, 0
                         )
                     result += (
                         self.indent()
                         + f"{output_type} main({input_parameter})"
-                        + f"{output_attributes} "
-                        + self.crossgl_attribute_reference(output_name)
+                        + output_attributes
                     )
             elif self.shader_type in self.NON_STRUCT_STAGE_TYPES:
                 result += self.indent() + "void main()"

--- a/tests/test_backend/test_GLSL/test_codegen.py
+++ b/tests/test_backend/test_GLSL/test_codegen.py
@@ -443,7 +443,8 @@ def test_codegen_fragment_output_named_crossgl_stage_keyword_roundtrips(keyword)
 
     crossgl = assert_roundtrip(code, "fragment", ShaderStage.FRAGMENT)
 
-    assert f"@{keyword}" in crossgl
+    assert "vec4 main(FragmentInput input) @location(0)" in crossgl
+    assert f"@{keyword}" not in crossgl
     assert f"@ {keyword}" not in crossgl
     assert f"vec4 {keyword};" in crossgl
     assert f"{keyword} = vec4(input.color, 1.0);" in crossgl

--- a/tests/test_backend/test_GLSL/test_layout_and_ssbo.py
+++ b/tests/test_backend/test_GLSL/test_layout_and_ssbo.py
@@ -50,7 +50,7 @@ def test_parse_layout_locations_and_components():
     assert "flat centroid vec4 color @location(1) @component(2) @highp;" in crossgl
     assert (
         "vec4 main(FragmentInput input) @location(0) @index(1) "
-        "@noperspective @sample @invariant @precise @mediump @ fragColor"
+        "@noperspective @sample @invariant @precise @mediump"
     ) in crossgl
 
     glsl = GLSLCodeGen().generate(crosstl.translator.parse(crossgl))
@@ -473,7 +473,8 @@ def test_parse_fragment_sample_builtin_without_user_inputs_roundtrip():
 
     crossgl = generate_crossgl(code, "fragment")
 
-    assert "vec4 main() @location(0) @ color" in crossgl
+    assert "vec4 main() @location(0)" in crossgl
+    assert "@ color" not in crossgl
     assert "FragmentInput input" not in crossgl
 
     glsl = GLSLCodeGen().generate(crosstl.translator.parse(crossgl))

--- a/tests/test_backend/test_GLSL/test_stage_inference.py
+++ b/tests/test_backend/test_GLSL/test_stage_inference.py
@@ -284,7 +284,7 @@ def reverse_plain_glsl(source: str, file_path: str = "/tmp/upstream-sample.glsl"
             [
                 "fragment {",
                 "#pragma shader_stage ( fragment )",
-                "vec4 main() @location(0) @ outColor",
+                "vec4 main() @location(0)",
                 "outColor = vec4(1.0);",
             ],
             id="glslc-pragma-shader-stage-fragment",
@@ -346,7 +346,7 @@ def reverse_plain_glsl(source: str, file_path: str = "/tmp/upstream-sample.glsl"
             [
                 "fragment {",
                 "#extension GL_ARB_separate_shader_objects : enable",
-                "vec4 main(FragmentInput input) @location(0) @ outColor",
+                "vec4 main(FragmentInput input) @location(0)",
                 "outColor = vec4(input.uv, 0.0, 1.0);",
             ],
             id="vulkan-fragment-output-location-infers-fragment",

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -185,6 +185,12 @@ def test_glsl_fragment_fragcoord_lowers_to_hlsl_position_input(tmp_path):
 
     assert "gl_FragCoord" not in generated_code
     assert "float4 _crossglFragCoord : SV_Position" in generated_code
+    assert (
+        "float4 PSMain(float4 _crossglFragCoord : SV_Position): SV_Target0"
+        in generated_code
+    )
+    assert "): fragColor" not in generated_code
+    assert "return fragColor;" in generated_code
     assert "_crossglFragCoord.x" in generated_code
     assert "_crossglFragCoord.y" in generated_code
 


### PR DESCRIPTION
## Summary
- emit location-based CrossGL return annotations for single GLSL fragment output variables instead of using the output variable name as a return semantic
- preserve the original fragment output variable as the local value returned from the generated HLSL pixel shader
- add DirectX regression coverage for GLSL fragment output lowering and update GLSL bridge expectations

closes #875

## Tests
- pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_fragment_fragcoord_lowers_to_hlsl_position_input -q
- pytest tests/test_backend/test_GLSL/test_layout_and_ssbo.py -q
- pytest tests/test_translator/test_codegen/test_directx_codegen.py -q