### PR TITLE
Lower MonoGame HLSL semantics for GLSL helpers

### DIFF
--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -2848,9 +2848,15 @@ class GLSLCodeGen:
                                 self.generate_legacy_output_declarations(node),
                                 "vertex",
                             )
+                            if self.stage_io_struct_referenced_outside_stage_entries(
+                                ast, node.name
+                            ):
+                                data_struct_nodes.append(node)
                         else:
                             data_struct_nodes.append(node)
-                    elif node.name in self.fragment_output_struct_names:
+                    elif self.should_emit_flattened_stage_io_struct(
+                        ast, node.name, emitted_io, emit_graphics_io
+                    ):
                         data_struct_nodes.append(node)
                 elif node.name in self.vertex_output_struct_names:
                     emitted_io = False
@@ -5946,10 +5952,7 @@ class GLSLCodeGen:
             parameter_qualifiers = self.glsl_parameter_qualifiers(p)
             if parameter_qualifiers:
                 declaration = f"{' '.join(parameter_qualifiers)} {declaration}"
-            semantic_attr = self.map_semantic(semantic)
-            params.append(
-                f"{declaration} {semantic_attr}" if semantic_attr else declaration
-            )
+            params.append(declaration)
             if self.structured_buffer_requires_counter(raw_param_type):
                 counter_name = self.structured_buffer_counter_parameter_name(p.name)
                 self.current_structured_buffer_counter_parameters[p.name] = counter_name

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1086", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1087", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1183", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "42", "34", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1086
+        "test_count": 1087
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -549,6 +549,44 @@ def test_root_signature_metadata_does_not_become_glsl_return_semantic():
     assert "RootSignature" not in generated
 
 
+def test_monogame_style_vertex_semantics_generate_valid_glsl_helpers():
+    hlsl = textwrap.dedent("""
+        struct VSOutput {
+            float4 Position : SV_Position;
+            float4 Color : COLOR0;
+            float2 TextureCoordinate : TEXCOORD0;
+        };
+
+        VSOutput SpriteVertexShader(
+            float4 position : POSITION,
+            float4 color : COLOR0,
+            float2 texCoord : TEXCOORD0
+        ) {
+            VSOutput output;
+            output.Position = position;
+            output.Color = color;
+            output.TextureCoordinate = texCoord;
+            return output;
+        }
+
+        float4 SpritePixelShader(VSOutput input) : SV_Target0 {
+            return input.Color;
+        }
+    """).strip()
+
+    generated = GLSLCodeGen().generate(parse_crossgl(generate_crossgl(hlsl)))
+
+    assert "struct VSOutput" in generated
+    assert (
+        "VSOutput SpriteVertexShader(vec4 position, vec4 color, vec2 texCoord)"
+        in generated
+    )
+    assert "vec4 position layout(location = 0)" not in generated
+    assert "vec4 color Color0" not in generated
+    assert "vec2 texCoord layout(location = 5)" not in generated
+    assert "vec4 SpritePixelShader(VSOutput input)" in generated
+
+
 def test_uint_vertex_id_import_uses_glsl_builtin_cast_alias():
     hlsl = textwrap.dedent("""
             void VSMain(in uint VertID : SV_VertexID, out float4 Pos : SV_Position) {


### PR DESCRIPTION
## Summary
- emit plain GLSL struct declarations when flattened HLSL stage-interface structs are still referenced by helper/local function signatures
- stop appending HLSL/CrossGL semantic metadata to GLSL function parameter declarations
- add a MonoGame-style DirectX-to-GLSL regression for `VSOutput`, `POSITION`, `COLOR0`, and `TEXCOORD0`

## Tests
- `.venv/bin/python -m pytest tests/test_backend/test_directx/test_codegen.py tests/test_translator/test_codegen/test_GLSL_codegen.py -q`
- `glslangValidator -S vert` on a reduced generated MonoGame-style vertex helper shader

closes #900
