### PR TITLE
Escape HLSL reserved identifiers

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -344,7 +344,25 @@ class HLSLCodeGen:
         "sample": "sample",
         "linear_sample": "sample",
     }
-    HLSL_RESERVED_IDENTIFIER_NAMES = {"linear"}
+    HLSL_RESERVED_IDENTIFIER_NAMES = {
+        "centroid",
+        "column_major",
+        "globallycoherent",
+        "line",
+        "lineadj",
+        "linear",
+        "nointerpolation",
+        "noperspective",
+        "point",
+        "precise",
+        "row_major",
+        "sample",
+        "snorm",
+        "triangle",
+        "triangleadj",
+        "uniform",
+        "unorm",
+    }
     HLSL_FEEDBACK_WRITE_HELPERS = {
         "write_sampler_feedback": ("WriteSamplerFeedback", {4, 5}),
         "write_sampler_feedback_bias": ("WriteSamplerFeedbackBias", {5, 6}),

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1089", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1090", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1183", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "42", "34", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1089
+        "test_count": 1090
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -4934,7 +4934,7 @@ def test_codegen_tiled_resource_status_only_loads_roundtrip_without_offsets():
 
     hlsl = TranslatorHLSLCodeGen().generate(parse_crossgl(crossgl))
 
-    assert "float4 line = ramp.Load(int2(x, lod));" in hlsl
+    assert "float4 line_ = ramp.Load(int2(x, lod));" in hlsl
     assert "float4 color = colorMap.Load(int3(pixel, lod));" in hlsl
     assert "float4 layer = layers.Load(int4(pixelLayer, lod));" in hlsl
     assert "float4 volumeColor = volume.Load(int4(voxel, lod));" in hlsl

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -973,7 +973,10 @@ def test_hlsl_diagnostic_vector_zero_fallbacks_expand_for_dxc():
     generated_code = generate_code(parse_code(tokenize_code(shader)))
 
     assert "float2 uv = float2(0.0, 0.0) /* unsupported HLSL" in generated_code
-    assert "double2 precise = double2(0.0, 0.0) /* unsupported HLSL" in generated_code
+    assert (
+        "double2 precise_ = double2(0.0, 0.0) /* unsupported HLSL"
+        in generated_code
+    )
     assert "float3 normal = float3(0.0, 0.0, 0.0) /* unsupported HLSL" in generated_code
     assert (
         "float4 color = float4(0.0, 0.0, 0.0, 0.0) /* unsupported HLSL"
@@ -6813,6 +6816,28 @@ def test_hlsl_reserved_linear_parameter_is_renamed_consistently():
     assert "float linearToSrgb(float linear_)" in generated_code
     assert "return (linear_ + (linear_ * linear_));" in generated_code
     assert re.search(r"\blinear\b", generated_code) is None
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_hlsl_reserved_line_local_is_renamed_consistently():
+    shader = """
+    shader HlslReservedLineLocal {
+        vertex {
+            vec4 main(vec2 uv @ TEXCOORD0) @ gl_Position {
+                float line = uv.x;
+                line = line + 1.0;
+                return vec4(line, line, line, 1.0);
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "float line_ = uv.x;" in generated_code
+    assert "line_ = (line_ + 1.0);" in generated_code
+    assert "return float4(line_, line_, line_, 1.0);" in generated_code
+    assert re.search(r"\bline\b", generated_code) is None
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
 
 


### PR DESCRIPTION
## Summary
- Expand DirectX HLSL reserved identifier sanitation to cover contextual modifier keywords such as `line`, `precise`, and interpolation/primitive modifiers.
- Keep generated HLSL declarations and references consistent when local names are escaped.
- Refresh support matrix generated counts after adding DirectX coverage.

closes #922

## Tests
- `pytest tests/test_translator/test_codegen/test_directx_codegen.py`
- `pytest tests/test_backend/test_directx`
- `pytest tests/test_backend/test_GLSL/test_external_fixtures.py::test_codegen_vulkan_samples_fragment_stage_preserved_by_default_converter`
- `python3 tools/support_matrix.py check`

DXC was not run locally because `dxc` is not installed in this environment.