### PR TITLE
Fix HLSL scalar vector constructor splats

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -15500,7 +15500,19 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             self.type_name_string,
             self.map_type,
             self.vector_component_type,
-            scalar_types={"float", "double", "int", "uint", "bool"},
+            scalar_types={
+                "float",
+                "half",
+                "min16float",
+                "min10float",
+                "double",
+                "int",
+                "min16int",
+                "min12int",
+                "uint",
+                "min16uint",
+                "bool",
+            },
             excluded_type_markers=("x",),
         )
 
@@ -15511,7 +15523,19 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             self.type_name_string,
             self.map_type,
             self.vector_component_type,
-            scalar_types={"float", "double", "int", "uint", "bool"},
+            scalar_types={
+                "float",
+                "half",
+                "min16float",
+                "min10float",
+                "double",
+                "int",
+                "min16int",
+                "min12int",
+                "uint",
+                "min16uint",
+                "bool",
+            },
             excluded_type_markers=("x",),
         )
 
@@ -15552,6 +15576,15 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             return all(
                 self.hlsl_expression_is_repeatable(getattr(expr, name, None))
                 for name in ("condition", "true_expr", "false_expr")
+            )
+        if isinstance(expr, FunctionCallNode) or (
+            hasattr(expr, "__class__") and "FunctionCall" in str(expr.__class__)
+        ):
+            func_expr = getattr(expr, "function", getattr(expr, "name", None))
+            func_name = getattr(func_expr, "name", func_expr)
+            args = getattr(expr, "arguments", getattr(expr, "args", []))
+            return self.is_scalar_value_type(func_name) and all(
+                self.hlsl_expression_is_repeatable(arg) for arg in args
             )
         return False
 

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -458,6 +458,45 @@ def test_metal_uint2_dispatch_id_promotes_to_directx_uint3(tmp_path):
     assert "uint2 id : SV_DispatchThreadID" not in generated
 
 
+def test_metal_scalar_vector_constructor_lowers_to_directx_splat(tmp_path):
+    source_path = _write_source(
+        tmp_path,
+        "metal-scalar-vector-constructor.metal",
+        """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        struct Input {
+            float3 position [[attribute(0)]];
+        };
+
+        struct Output {
+            half3 viewDir [[user(TEXCOORD0)]];
+        };
+
+        vertex Output VSMain(Input in [[stage_in]]) {
+            half scalar = half(0);
+            Output literalValue = Output(half3(0));
+            Output scalarValue = Output(half3(scalar));
+            Output nestedValue = Output(half3(half(0)));
+            return scalarValue;
+        }
+        """,
+    )
+
+    generated = crosstl.translate(
+        str(source_path), backend="directx", format_output=False
+    )
+
+    _assert_generated_output_is_usable(generated)
+    assert "Output literalValue = Output(half3(0, 0, 0));" in generated
+    assert "Output scalarValue = Output(half3(scalar, scalar, scalar));" in generated
+    assert "Output nestedValue = Output(half3(half(0), half(0), half(0)));" in generated
+    assert "half3(0))" not in generated
+    assert "half3(scalar))" not in generated
+    assert "half3(half(0)))" not in generated
+
+
 def test_metal_threadgroup_scratch_lowers_to_directx_groupshared(tmp_path):
     source_path = _write_source(
         tmp_path,


### PR DESCRIPTION
closes #930

## Summary
- expand DirectX scalar component counting to include half and min-precision scalar types
- repeat pure scalar type constructors during vector splat lowering so Metal forms like `half3(half(0))` become valid HLSL initializers
- add a Metal-to-DirectX regression for `Output(half3(0))`, scalar variables, and nested scalar constructors

## Validation
- `pytest tests/test_translator/test_translation_pipeline.py::test_metal_scalar_vector_constructor_lowers_to_directx_splat tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_vector_constructor_scalar_splats_expand_for_dxc tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_diagnostic_vector_zero_fallbacks_expand_for_dxc tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_float16_ir_aliases_map_to_half_and_min_precision_names tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_float16_matrix_ir_aliases_map_to_half_matrices -q`
- `pytest tests/test_translator/test_translation_pipeline.py -k "metal_scalar_vector_constructor or metal_uint2_dispatch_id_promotes_to_directx_uint3 or metal_threadgroup_scratch_lowers_to_directx_groupshared or metal_scalar_dispatch_id_promotes_to_directx_uint3 or metal_multi_entry_resource_names_are_scoped_for_directx" -q`
- `python3 tools/support_matrix.py check`