### PR TITLE
Preserve Metal vertex return outputs

### DIFF
--- a/crosstl/backend/Metal/MetalCrossGLCodeGen.py
+++ b/crosstl/backend/Metal/MetalCrossGLCodeGen.py
@@ -2184,11 +2184,12 @@ class MetalToCrossGLConverter:
         elif isinstance(expr, CastNode):
             mapped_type = self.map_type(expr.target_type)
             value = self.generate_expression(expr.expression, is_main)
-            if mapped_type == expr.target_type and "::" not in str(mapped_type):
-                return f"{self.sanitize_identifier(mapped_type)}({value})"
-            return (
-                f"({mapped_type}){self.generate_cast_operand(expr.expression, value)}"
-            )
+            if not self.cast_uses_constructor_syntax(mapped_type):
+                return (
+                    f"({mapped_type})"
+                    f"{self.generate_cast_operand(expr.expression, value)}"
+                )
+            return f"{self.sanitize_identifier(mapped_type)}({value})"
         elif isinstance(expr, VectorConstructorNode):
             size_query = self.texture_size_constructor_expression(expr, is_main)
             if size_query is not None:
@@ -2405,6 +2406,24 @@ class MetalToCrossGLConverter:
         ):
             return f"({rendered_operand})"
         return rendered_operand
+
+    def cast_uses_constructor_syntax(self, mapped_type):
+        mapped_text = str(mapped_type).strip()
+        if "*" in mapped_text or "&" in mapped_text:
+            return False
+        if mapped_text in {"float", "double", "int", "uint", "bool"}:
+            return True
+        if self.crossgl_identifier_pattern.fullmatch(mapped_text) and mapped_text[
+            0
+        ].isupper():
+            return True
+        return bool(
+            re.fullmatch(
+                r"(?:f16vec[234]|[biu]?vec[234]|dvec[234]|"
+                r"mat[234](?:x[234])?|dmat[234](?:x[234])?)",
+                mapped_text,
+            )
+        )
 
     def map_type(self, metal_type):
         """Map a Metal type name to the closest CrossGL type name."""

--- a/crosstl/translator/codegen/SPIRV_codegen.py
+++ b/crosstl/translator/codegen/SPIRV_codegen.py
@@ -10582,6 +10582,11 @@ class VulkanSPIRVCodeGen:
         aliases = {
             "f32": "float",
             "f64": "double",
+            "f16": "float",
+            "float16": "float",
+            "float16_t": "float",
+            "half": "float",
+            "min16float": "float",
             "i32": "int",
             "u32": "uint",
             "int64": "i64",
@@ -10595,6 +10600,11 @@ class VulkanSPIRVCodeGen:
 
     def normalize_generic_vector_type(self, type_str: str) -> str:
         compact = re.sub(r"\s+", "", str(type_str))
+        half_vector_match = re.fullmatch(
+            r"(?:f16vec|half|min16float|float16_t)([234])", compact
+        )
+        if half_vector_match:
+            return f"vec{half_vector_match.group(1)}"
         match = re.fullmatch(r"vec([234])<([^>]+)>", compact)
         if match:
             size, element_type = match.groups()

--- a/tests/test_backend/test_metal/test_codegen.py
+++ b/tests/test_backend/test_metal/test_codegen.py
@@ -347,9 +347,10 @@ def test_codegen_xhalf_vectors_lower_before_opengl_generation():
     glsl = GLSLCodeGen().generate(parse_crossgl(crossgl))
 
     assert "f16vec3 viewDir;" in crossgl
-    assert "(f16vec3)normalize" in crossgl
+    assert "f16vec3(normalize" in crossgl
     assert "xhalf" not in crossgl
     assert "out vec3 viewDir;" in glsl
+    assert "viewDir = vec3(normalize" in glsl
     assert "xhalf" not in glsl
     assert "f16vec3" not in glsl
 
@@ -2271,7 +2272,7 @@ def test_codegen_lowers_static_cast_from_apple_compute_sample():
     """
     crossgl = convert(code)
 
-    assert "vec2 p0 = (vec2)gid;" in crossgl
+    assert "vec2 p0 = vec2(gid);" in crossgl
     assert "static_cast" not in crossgl
     assert parse_crossgl(crossgl) is not None
 
@@ -3711,7 +3712,7 @@ def test_codegen_sizeof_and_cast():
     result = convert(code)
     assert "sizeof(int)" in result
     assert "alignof(float4)" in result
-    assert "(vec3)" in result or "(float3)" in result
+    assert "vec3(1.0)" in result
 
 
 def test_codegen_sizeof_dependent_typename_from_tinygrad_tile_copy():

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -370,7 +370,7 @@ def test_native_source_extension_aliases_translate_to_parseable_crossgl(
     crosstl.translator.parse(generated)
 
 
-def test_metal_xhalf_vectors_do_not_leak_to_opengl(tmp_path):
+def test_metal_vertex_struct_return_preserves_view_dir_outputs(tmp_path):
     source_path = _write_source(
         tmp_path,
         "xhalf-view-dir.metal",
@@ -390,14 +390,36 @@ def test_metal_xhalf_vectors_do_not_leak_to_opengl(tmp_path):
         """,
     )
 
-    generated = crosstl.translate(
-        str(source_path), backend="opengl", format_output=False
+    opengl = crosstl.translate(str(source_path), backend="opengl", format_output=False)
+    directx = crosstl.translate(
+        str(source_path), backend="directx", format_output=False
     )
+    spirv = crosstl.translate(str(source_path), backend="vulkan", format_output=False)
 
-    _assert_generated_output_is_usable(generated)
-    assert "out vec3 viewDir;" in generated
-    assert "xhalf" not in generated
-    assert "f16vec3" not in generated
+    _assert_generated_output_is_usable(opengl)
+    assert "out vec3 viewDir;" in opengl
+    assert "viewDir = vec3(normalize" in opengl
+    assert "xhalf" not in opengl
+    assert "f16vec3" not in opengl
+
+    _assert_generated_output_is_usable(directx)
+    assert "half3 viewDir: TEXCOORD0;" in directx
+    assert "out_.viewDir = half3(normalize" in directx
+    assert "return out_;" in directx
+    assert "return Output(half3(0));" not in directx
+
+    _assert_generated_output_is_usable(spirv)
+    output_match = re.search(
+        r'OpName %(\d+) "CrossGL_vertex_output_main_vertex_viewDir"', spirv
+    )
+    assert output_match is not None
+    output_id = output_match.group(1)
+    stored_values = re.findall(rf"OpStore %{output_id} %(\d+)", spirv)
+    assert stored_values
+    assert re.search(rf"%{stored_values[-1]} = OpCompositeExtract %\d+ %\d+ 0", spirv)
+    assert "Normalize" in spirv
+    assert "Unknown type f16vec3" not in spirv
+    assert "cannot lower unknown function 'f16vec3'" not in spirv
 
 
 def test_metal_template_helper_specializes_to_concrete_opengl(tmp_path):


### PR DESCRIPTION
## Summary
- Emit parser-safe CrossGL constructor casts for Metal value casts so stage entry bodies survive reparsing.
- Preserve returned vertex output struct assignments across OpenGL, DirectX, and SPIR-V generation for the reduced viewDir shader.
- Widen SPIR-V half-vector aliases to existing 32-bit vector handling.

## Tests
- pytest tests/test_backend/test_metal/test_codegen.py tests/test_backend/test_metal/test_external_fixtures.py tests/test_translator/test_translation_pipeline.py::test_metal_vertex_struct_return_preserves_view_dir_outputs tests/test_translator/test_codegen/test_SPIRV_codegen.py::TestVulkanSPIRVCodeGen::test_hlsl_16bit_matrix_aliases_lower_to_float_matrices -q
- pytest tests/test_translator/test_translation_pipeline.py -q
- spirv-as + spirv-val on the reduced Metal viewDir shader

closes #951
