### PR TITLE
Fix DirectX fragment varying input semantics

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -2324,9 +2324,9 @@ class HLSLCodeGen:
                     declaration_type = f"{member_type}[]"
                 else:
                     declaration_type = f"{member_type}[1024]"
-                semantic = self.hlsl_struct_member_declared_semantic(member)
+                semantic = default_member_semantics.get(member.name)
                 if semantic is None:
-                    semantic = default_member_semantics.get(member.name)
+                    semantic = self.hlsl_struct_member_declared_semantic(member)
                 self.validate_hlsl_struct_member_semantic_type(
                     node.name,
                     member.name,
@@ -2393,9 +2393,9 @@ class HLSLCodeGen:
                 if array_size is None:
                     member_type = f"{self.map_struct_member_type(node.name, member.name, raw_element_type)}[1024]"
 
-            semantic = self.hlsl_struct_member_declared_semantic(member)
+            semantic = default_member_semantics.get(member.name)
             if semantic is None:
-                semantic = default_member_semantics.get(member.name)
+                semantic = self.hlsl_struct_member_declared_semantic(member)
 
             self.validate_hlsl_struct_member_semantic_type(
                 node.name,
@@ -12833,7 +12833,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         used_semantics = set()
         for member in getattr(struct_node, "members", []) or []:
             semantic = self.hlsl_struct_member_declared_semantic(member)
-            if semantic is not None:
+            if semantic is not None and self.hlsl_location_attribute_index(
+                member
+            ) is None:
                 used_semantics.add(self.hlsl_semantic_key(semantic))
 
         defaults = {}
@@ -12842,13 +12844,18 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             member_name = getattr(member, "name", None)
             if not member_name:
                 continue
-            if self.hlsl_struct_member_declared_semantic(member) is not None:
-                continue
             if not self.hlsl_can_default_fragment_input_semantic(
                 self.hlsl_struct_member_type_name(member)
             ):
                 continue
 
+            declared_semantic = self.hlsl_struct_member_declared_semantic(member)
+            location_index = self.hlsl_location_attribute_index(member)
+            if declared_semantic is not None and location_index is None:
+                continue
+
+            if location_index is not None:
+                next_texcoord = location_index
             while self.hlsl_semantic_key(f"TEXCOORD{next_texcoord}") in used_semantics:
                 next_texcoord += 1
             semantic = f"TEXCOORD{next_texcoord}"
@@ -18514,21 +18521,34 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         return name
 
     def hlsl_location_return_semantic(self, attr):
-        name = getattr(attr, "name", None)
-        if str(name).lower() != "location":
-            return None
-        arguments = getattr(attr, "arguments", None) or getattr(attr, "args", None)
-        if not arguments:
-            return None
-        index_arg = arguments[0]
-        index = getattr(index_arg, "value", None)
-        if index is None:
-            index = getattr(index_arg, "name", None)
-        if index is None:
-            index = self.attribute_value_to_string(index_arg)
+        index = self.hlsl_location_attribute_index(attr)
         if index is None:
             return None
         return f"SV_Target{index}"
+
+    def hlsl_location_attribute_index(self, node):
+        if hasattr(node, "attributes"):
+            attributes = getattr(node, "attributes", [])
+        else:
+            attributes = [node]
+        for attr in attributes or []:
+            name = getattr(attr, "name", None)
+            if str(name).lower() != "location":
+                continue
+            arguments = getattr(attr, "arguments", None) or getattr(attr, "args", None)
+            if not arguments:
+                continue
+            index_arg = arguments[0]
+            index = getattr(index_arg, "value", None)
+            if index is None:
+                index = getattr(index_arg, "name", None)
+            if index is None:
+                index = self.attribute_value_to_string(index_arg)
+            if isinstance(index, int):
+                return index
+            if str(index).isdigit():
+                return int(index)
+        return None
 
     def semantic_from_struct_member(self, member):
         if isinstance(member, ArrayNode):

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1090", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1091", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "42", "34", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1090
+        "test_count": 1091
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -231,6 +231,34 @@ def test_glsl_fragment_fragcoord_lowers_to_hlsl_position_input(tmp_path):
     assert "_crossglFragCoord.y" in generated_code
 
 
+def test_glsl_fragment_input_locations_lower_to_distinct_hlsl_semantics(tmp_path):
+    shader = """
+    #version 450
+    layout(location = 0) in vec3 nearPoint;
+    layout(location = 1) in vec3 farPoint;
+    layout(location = 0) out vec4 outColor;
+
+    void main() {
+        outColor = vec4(nearPoint + farPoint, 1.0);
+    }
+    """
+    shader_path = tmp_path / "line_grid.frag"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="opengl",
+    )
+
+    assert "float3 nearPoint: TEXCOORD0;" in generated_code
+    assert "float3 farPoint: TEXCOORD1;" in generated_code
+    assert ": location" not in generated_code
+    assert generated_code.count(": TEXCOORD0") == 1
+    assert generated_code.count(": TEXCOORD1") == 1
+
+
 def test_directx_user_defined_synchronization_names_are_not_lowered():
     shader = """
     shader SynchronizationShadowing {


### PR DESCRIPTION
Summary:
- Map GLSL fragment input layout locations to distinct indexed HLSL TEXCOORD semantics in DirectX output.
- Preserve explicit HLSL semantics while using source locations when available for GLSL fragment varyings.
- Add a regression covering OpenGL fragment shader translation to DirectX and refresh support matrix test counts.

Tests:
- pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_fragment_input_locations_lower_to_distinct_hlsl_semantics tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_fragment_fragcoord_lowers_to_hlsl_position_input
- pytest tests/test_translator/test_codegen/test_directx_codegen.py tests/test_backend/test_directx/test_codegen.py
- python3 tools/support_matrix.py check
- pytest tests/test_support_matrix.py::test_support_matrix_generated_artifacts_are_current
- python3 -m py_compile crosstl/translator/codegen/directx_codegen.py tests/test_translator/test_codegen/test_directx_codegen.py

closes #959
