### PR TITLE
Triage WGSL pipeline layout support signals

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -60,6 +60,10 @@ cross-checks them against implementation/test identifiers. The checked-in matrix
 keeps reviewed support statuses conservative; generated support-signal issues
 track missing or uncataloged candidates so coverage gaps do not depend on manual
 lookup.
+Backend documentation can also contain host API fields or object properties that
+are not shader-language features. Keep those false positives in the
+backend-specific documented-candidate triage map in `tools/support_signals.py`
+instead of adding support catalog rows for non-language terms.
 
 Process rules:
 

--- a/tests/test_support_signals.py
+++ b/tests/test_support_signals.py
@@ -675,6 +675,45 @@ def test_build_report_creates_issues_for_unmapped_documented_candidates():
     )
 
 
+def test_build_report_skips_triaged_wgsl_webgpu_api_candidates():
+    module = load_signals_module()
+    backends = {
+        "backends": [
+            {
+                "id": "wgsl",
+                "name": "WebGPU / WGSL",
+                "translator_codegen": "tools/support_signals.py",
+                "native_backend": "tools",
+                "tests": ["tests/test_support_signals.py"],
+            }
+        ]
+    }
+    features = {"features": []}
+    docs_report = {
+        "documents": [
+            {
+                "backend_id": "wgsl",
+                "backend": "WebGPU / WGSL",
+                "source": "WebGPU specification",
+                "url": "https://example.com/webgpu",
+                "ok": True,
+                "candidate_terms": [
+                    {"term": "pipelineLayout", "count": 2},
+                    {"term": "pipelineTargetsLayout", "count": 1},
+                    {"term": "PipelineMagicState", "count": 1},
+                ],
+            }
+        ]
+    }
+
+    report = module.build_report(backends, features, docs_report=docs_report)
+    features_by_issue = {issue["feature"] for issue in report["issues"]}
+
+    assert "pipelineLayout" not in features_by_issue
+    assert "pipelineTargetsLayout" not in features_by_issue
+    assert "PipelineMagicState" in features_by_issue
+
+
 def test_build_report_skips_documented_candidates_mapped_to_existing_features():
     module = load_signals_module()
     backends = {

--- a/tools/support_signals.py
+++ b/tools/support_signals.py
@@ -343,6 +343,12 @@ DOC_CANDIDATE_FEATURE_ALIAS_PATTERNS = (
     ),
 )
 DOC_CANDIDATE_NOISE_PATTERNS = (re.compile(r"^(?:cuda|hip)(?:error|success)"),)
+TRIAGED_DOC_CANDIDATE_NOISE_BY_BACKEND = {
+    "wgsl": {
+        "pipelinelayout",
+        "pipelinetargetslayout",
+    },
+}
 
 
 class DocumentHTMLParser(HTMLParser):
@@ -995,6 +1001,10 @@ def actionable_doc_candidate(term: str, backend_id: str | None = None) -> bool:
     if len(normalized) < 4:
         return False
     if normalized in DOC_CANDIDATE_NOISE:
+        return False
+    if normalized in TRIAGED_DOC_CANDIDATE_NOISE_BY_BACKEND.get(
+        backend_id or "", set()
+    ):
         return False
     if any(pattern.search(normalized) for pattern in DOC_CANDIDATE_NOISE_PATTERNS):
         return False


### PR DESCRIPTION
## Summary
- Add backend-specific documented-candidate triage for WGSL pipeline layout API fields that are not shader-language features.
- Cover the triage with a support-signal regression while preserving reporting for an untriaged pipeline-shaped candidate.
- Document where future documented-candidate false positives should be handled.

## Validation
- .venv/bin/python -m pytest tests/test_support_signals.py tests/test_support_issue_sync.py -q
- .venv/bin/python tools/support_matrix.py check
- .venv/bin/python tools/support_signals.py check --docs-report /tmp/wgsl-doc-candidate-report.json --output /tmp/wgsl-support-signals.json
- .venv/bin/python tools/sync_support_issues.py --dry-run --signals /tmp/wgsl-support-signals.json --plan-output /tmp/wgsl-support-issue-plan.json --repo CrossGL/crosstl

closes #885
closes #886