### PR TITLE
Fix Metal matmul device resource lowering

### DIFF
--- a/crosstl/backend/Metal/MetalCrossGLCodeGen.py
+++ b/crosstl/backend/Metal/MetalCrossGLCodeGen.py
@@ -1411,6 +1411,9 @@ class MetalToCrossGLConverter:
 
     def map_variable_type(self, var):
         raw_type = getattr(var, "vtype", None)
+        constant_buffer_type = self.constant_buffer_pointer_type(var)
+        if constant_buffer_type:
+            return constant_buffer_type
         structured_buffer_type = self.structured_buffer_pointer_type(var)
         if structured_buffer_type:
             return structured_buffer_type
@@ -1440,7 +1443,9 @@ class MetalToCrossGLConverter:
         return mapped_type
 
     def address_space_qualifier_prefix(self, var):
-        if self.structured_buffer_pointer_type(var):
+        if self.constant_buffer_pointer_type(
+            var
+        ) or self.structured_buffer_pointer_type(var):
             return ""
 
         qualifiers = [
@@ -3054,6 +3059,8 @@ class MetalToCrossGLConverter:
         if not element_type:
             return None
         element_type = self.resolve_type_alias(element_type)
+        if "constant" in qualifiers and element_type in self.struct_member_types:
+            return None
 
         buffer_type = (
             "StructuredBuffer"
@@ -3061,6 +3068,24 @@ class MetalToCrossGLConverter:
             else "RWStructuredBuffer"
         )
         return f"{buffer_type}<{self.map_type(element_type)}>"
+
+    def constant_buffer_pointer_type(self, var):
+        if not self.has_attribute(var, "buffer"):
+            return None
+
+        qualifiers = {
+            str(qualifier).lower() for qualifier in getattr(var, "qualifiers", []) or []
+        }
+        if "constant" not in qualifiers:
+            return None
+
+        element_type = self.pointer_element_type(getattr(var, "vtype", None))
+        if not element_type:
+            return None
+        element_type = self.resolve_type_alias(element_type)
+        if element_type not in self.struct_member_types:
+            return None
+        return f"ConstantBuffer<{self.map_type(element_type)}>"
 
     def is_structured_buffer_expression(self, expr):
         name = self.expression_base_name(expr)

--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -3098,6 +3098,36 @@ class GLSLCodeGen:
                         resource_count,
                     )
                 continue
+            if self.is_constant_buffer_type(vtype):
+                binding_namespace = "uniform buffer binding"
+                resource_binding = self.opengl_resource_binding_for_declaration(
+                    node,
+                    used_resource_bindings,
+                    resource_binding_cursors,
+                    binding_namespace,
+                    resource_count,
+                )
+                self.reserve_resource_binding_range(
+                    used_resource_bindings,
+                    "OpenGL",
+                    binding_namespace,
+                    resource_binding,
+                    resource_count,
+                    var_name,
+                )
+                code += self.glsl_constant_buffer_block_declaration(
+                    vtype,
+                    var_name,
+                    resource_binding,
+                    array_suffix,
+                )
+                self.advance_resource_binding(
+                    resource_binding_cursors,
+                    binding_namespace,
+                    resource_binding,
+                    resource_count,
+                )
+                continue
             if self.is_opaque_resource_type(mapped_type):
                 self.texture_variable_types[var_name] = mapped_type
                 fixed_array_size = self.glsl_resource_array_size_value(array_size)
@@ -6750,9 +6780,13 @@ class GLSLCodeGen:
     def stage_entry_parameter_expression_type(self, param, raw_type):
         resource_type = self.stage_entry_resource_parameter_type(param)
         if resource_type is None:
+            if self.is_constant_buffer_type(raw_type):
+                return self.constant_buffer_element_type(raw_type)
             return self.type_name_string(raw_type)
         if self.is_structured_buffer_type(resource_type):
             return f"{self.structured_buffer_element_type(resource_type)}[]"
+        if self.is_constant_buffer_type(resource_type):
+            return self.constant_buffer_element_type(resource_type)
         return self.type_name_string(resource_type)
 
     def is_stage_entry_resource_parameter(self, param):
@@ -6760,6 +6794,8 @@ class GLSLCodeGen:
         if self.is_sampler_type(raw_type):
             return False
         if self.stage_entry_constant_struct_parameter_type(param) is not None:
+            return True
+        if self.is_constant_buffer_type(raw_type):
             return True
         resource_type = self.stage_entry_resource_parameter_type(param)
         if resource_type is not None:
@@ -15315,6 +15351,15 @@ class GLSLCodeGen:
             "ConsumeStructuredBuffer",
         }
 
+    def is_constant_buffer_type(self, vtype):
+        return str(self.resource_base_type(vtype)).split("<", 1)[0] == "ConstantBuffer"
+
+    def constant_buffer_element_type(self, vtype):
+        type_name = str(self.resource_base_type(vtype))
+        if "<" not in type_name or not type_name.endswith(">"):
+            return None
+        return type_name.split("<", 1)[1][:-1].strip()
+
     def structured_buffer_requires_counter(self, vtype):
         return self.structured_buffer_type_name(vtype) in {
             "AppendStructuredBuffer",
@@ -15657,6 +15702,10 @@ class GLSLCodeGen:
         names = set()
         for node in global_vars:
             node_type = self.resource_node_type(node)
+            if self.is_constant_buffer_type(node_type):
+                element_type = self.constant_buffer_element_type(node_type)
+                if element_type:
+                    names.add(str(element_type))
             if not self.is_layout_bound_struct_uniform(node, node_type):
                 continue
             names.add(str(self.resource_base_type(node_type)))
@@ -15794,6 +15843,19 @@ class GLSLCodeGen:
             and self.explicit_resource_binding_index(node) is not None
         )
 
+    def glsl_constant_buffer_block_declaration(
+        self, vtype, var_name, binding, array_suffix=""
+    ):
+        struct_name = self.constant_buffer_element_type(vtype)
+        if struct_name not in self.structs_by_name:
+            return ""
+        return self.glsl_struct_uniform_block_declaration(
+            struct_name,
+            var_name,
+            binding,
+            array_suffix,
+        )
+
     def glsl_struct_uniform_block_declaration(
         self, vtype, var_name, binding, array_suffix=""
     ):
@@ -15890,6 +15952,14 @@ class GLSLCodeGen:
                 array_suffix,
                 resource_count,
             )
+        if self.is_constant_buffer_type(vtype):
+            return (
+                "uniform buffer binding",
+                "ConstantBuffer",
+                self.constant_buffer_element_type(vtype),
+                array_suffix,
+                resource_count,
+            )
 
         mapped_type = self.map_resource_type_with_format(vtype, node)
         if mapped_type == "sampler" or not self.is_opaque_resource_type(mapped_type):
@@ -15934,6 +16004,8 @@ class GLSLCodeGen:
             namespace = "buffer binding"
         elif self.is_structured_buffer_type(vtype):
             namespace = "buffer binding"
+        elif self.is_constant_buffer_type(vtype):
+            namespace = "uniform buffer binding"
         elif self.is_layout_bound_struct_uniform(node, vtype):
             namespace = "uniform buffer binding"
         else:

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -32433,6 +32433,87 @@ def test_translate_project_metal_matmul_buffers_lower_to_opengl_resources(
     assert "thread_position_in_grid" not in output
 
 
+def test_translate_project_metal_matmul_constant_pointer_params_lower_to_resources(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "matmul.metal").write_text(
+        textwrap.dedent("""
+            #include <metal_stdlib>
+            using namespace metal;
+
+            struct MatMulParams {
+                uint rows;
+                uint cols;
+                uint inner;
+            };
+
+            kernel void matmul(
+                constant MatMulParams* params [[buffer(0)]],
+                device const float* A [[buffer(1)]],
+                device const float* B [[buffer(2)]],
+                device float* X [[buffer(3)]],
+                uint3 gid [[thread_position_in_grid]]
+            ) {
+                if (gid.x >= params->cols || gid.y >= params->rows) {
+                    return;
+                }
+                float sum = 0.0;
+                for (uint k = 0; k < params->inner; ++k) {
+                    sum += A[gid.y * params->inner + k] * B[k * params->cols + gid.x];
+                }
+                X[gid.y * params->cols + gid.x] = sum;
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["opengl", "directx"],
+        output_dir="out",
+    ).to_json()
+
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("opengl", "translated"), ("directx", "translated")}
+
+    outputs = {
+        artifact["target"]: (repo / artifact["path"]).read_text(encoding="utf-8")
+        for artifact in payload["artifacts"]
+    }
+
+    opengl = outputs["opengl"]
+    assert "layout(std140, binding = 0) uniform MatMulParams" in opengl
+    assert "} params;" in opengl
+    assert "layout(std430, binding = 1) readonly buffer ABuffer { float A[]; };" in opengl
+    assert "layout(std430, binding = 2) readonly buffer BBuffer { float B[]; };" in opengl
+    assert "layout(std430, binding = 3) buffer XBuffer { float X[]; };" in opengl
+    assert "params.cols" in opengl
+    assert "params.rows" in opengl
+    assert "params.inner" in opengl
+    assert "paramsBuffer" not in opengl
+    assert "void matmul(" not in opengl
+    assert "float* A" not in opengl
+    assert "float* B" not in opengl
+    assert "float* X" not in opengl
+
+    directx = outputs["directx"]
+    assert "ConstantBuffer<MatMulParams> params : register(b0);" in directx
+    assert "StructuredBuffer<float> A : register(t1);" in directx
+    assert "StructuredBuffer<float> B : register(t2);" in directx
+    assert "RWStructuredBuffer<float> X : register(u3);" in directx
+    assert "void CSMain(uint3 gid : SV_DispatchThreadID)" in directx
+    assert "params.cols" in directx
+    assert "params.rows" in directx
+    assert "params.inner" in directx
+    assert "StructuredBuffer<MatMulParams> params" not in directx
+    assert "float* A" not in directx
+    assert "float* B" not in directx
+    assert "float* X" not in directx
+
+
 def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Lower Metal constant struct buffer pointers to constant-buffer resources instead of structured-buffer resources.
- Emit OpenGL constant-buffer stage resources as std140 uniform blocks with preserved bindings.
- Add a matmul project regression covering constant pointer params plus device input/output buffers for OpenGL and DirectX.

## Validation
- `pytest tests/test_translator/test_project_translation.py -k 'metal_matmul_buffers_lower_to_directx_resources or metal_matmul_buffers_lower_to_opengl_resources or metal_matmul_constant_pointer_params_lower_to_resources or metal_directx_relocates_stage_entry_buffer_bindings' -q`
- `python3 tools/support_matrix.py check`
- Generated OpenGL matmul compute shader validates locally.
- DirectX compiler is not installed locally; DirectX coverage is generated-shape assertions for resource declarations and no raw pointer entry params.

closes #973
closes #974
