### PR TITLE
Fix WGSL constant buffer support row

### DIFF
--- a/crosstl/translator/codegen/wgsl_codegen.py
+++ b/crosstl/translator/codegen/wgsl_codegen.py
@@ -762,6 +762,7 @@ class WGSLCodeGen:
     def generate_cbuffer(self, node):
         lines = [f"struct {node.name} {{"]
         for member in getattr(node, "members", []) or []:
+            self.validate_cbuffer_member(node, member)
             lines.append(
                 f"    {member.name}: {self.type_name_string(member.member_type)},"
             )
@@ -1572,6 +1573,45 @@ class WGSLCodeGen:
 
     def buffer_pointer_parameter_type(self, vtype):
         return f"ptr<storage, {self.buffer_pointer_storage_type(vtype)}, read_write>"
+
+    def validate_cbuffer_member(self, cbuffer, member):
+        member_type = getattr(member, "member_type", None)
+        element_type = self.array_element_type(member_type)
+        resource_type_name = self.resource_type_name(element_type)
+        if resource_type_name is not None and not self.is_resource_type_name(
+            resource_type_name
+        ):
+            resource_type_name = None
+        if resource_type_name:
+            display_type_name = (
+                str(element_type.name)
+                if isinstance(element_type, NamedType)
+                else str(element_type)
+            )
+            raise ValueError(
+                "WGSL target does not support resource member "
+                f"{cbuffer.name}.{member.name} of type {display_type_name} "
+                "inside uniform buffers; declare resources as module-scope "
+                "bindings instead"
+            )
+        if self.structured_buffer_element_type(element_type) is not None:
+            raise ValueError(
+                "WGSL target does not support storage-buffer resource member "
+                f"{cbuffer.name}.{member.name} inside uniform buffers; "
+                "declare StructuredBuffer resources as module-scope bindings"
+            )
+        if self.unsized_array_type(member_type) is not None:
+            raise ValueError(
+                "WGSL target does not support runtime-sized array member "
+                f"{cbuffer.name}.{member.name} inside uniform buffers"
+            )
+
+    def unsized_array_type(self, vtype):
+        while isinstance(vtype, ArrayType):
+            if vtype.size is None:
+                return vtype
+            vtype = vtype.element_type
+        return None
 
     def sampled_texture_type(self, vtype):
         type_name = self.resource_type_name(vtype)

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -25,7 +25,7 @@ implicitly supported.
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1091", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
-   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "48", "54", "WGSL specification; WebGPU specification"
+   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "52", "57", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "986", "496", "Apple Metal resources; Metal Shading Language specification"
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "996", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
@@ -40,7 +40,7 @@ implicitly supported.
    "DirectX / HLSL", "64", "0", "2", "0", "0", "0"
    "OpenGL / GLSL", "64", "0", "2", "0", "0", "0"
    "WebGL / GLSL ES", "35", "0", "22", "9", "0", "0"
-   "WebGPU / WGSL", "36", "4", "19", "7", "0", "0"
+   "WebGPU / WGSL", "37", "3", "19", "7", "0", "0"
    "Metal", "63", "0", "3", "0", "0", "0"
    "Vulkan SPIR-V", "64", "0", "2", "0", "0", "0"
    "CUDA", "59", "0", "7", "0", "0", "0"
@@ -130,7 +130,7 @@ Each category below uses the status codes from the legend.
    :header: "Feature", "DirectX / HLSL", "OpenGL / GLSL", "WebGL / GLSL ES", "WebGPU / WGSL", "Metal", "Vulkan SPIR-V", "CUDA", "HIP", "Mojo", "Rust", "Slang"
 
    "Explicit and automatic resource bindings", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
-   "Constant/uniform buffers", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Constant/uniform buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Structured/storage buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource arrays", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Texture and sampler object model", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
@@ -215,7 +215,6 @@ implementation work can be scoped accurately.
 .. csv-table:: Actionable backlog rows
    :header: "Backend", "Category", "Feature", "Status", "Current gap", "Next scope", "Notes"
 
-   "WebGPU / WGSL", "resources", "Constant/uniform buffers", "partial", "StructuredBuffer and RWStructuredBuffer declarations lower to WGSL storage-buffer arrays with read/read_write access modes and deterministic binding allocation. Append/consume buffers, byte-address buffers, helper methods, and richer storage-resource layouts remain future work or deterministic diagnostics.", "", "StructuredBuffer and RWStructuredBuffer declarations lower to WGSL storage-buffer arrays with read/read_write access modes and deterministic binding allocation. Append/consume buffers, byte-address buffers, helper methods, and richer storage-resource layouts remain future work or deterministic diagnostics."
    "WebGPU / WGSL", "resources", "Resource arrays", "partial", "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work.", "", "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work."
    "WebGPU / WGSL", "resources", "Texture and sampler object model", "partial", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.", "", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work."
    "WebGPU / WGSL", "resources", "GLSL buffer block lowering", "partial", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.", "", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work."

--- a/support/features.json
+++ b/support/features.json
@@ -1678,10 +1678,16 @@
           ]
         },
         "wgsl": {
-          "status": "partial",
-          "notes": "StructuredBuffer and RWStructuredBuffer declarations lower to WGSL storage-buffer arrays with read/read_write access modes and deterministic binding allocation. Append/consume buffers, byte-address buffers, helper methods, and richer storage-resource layouts remain future work or deterministic diagnostics.",
+          "status": "supported",
+          "notes": "CrossGL cbuffers and uniform blocks lower to WGSL uniform structs with deterministic @group/@binding allocation, explicit @set/@group/@space/@binding and HLSL register/space preservation, bare member-reference rewriting through the generated uniform binding, duplicate binding diagnostics, and deterministic diagnostics for resource members, StructuredBuffer members, and runtime-sized array members inside uniform buffers.",
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_structured_buffers_to_storage_bindings"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_cbuffers_to_uniform_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_uniform_blocks_to_uniform_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_duplicate_hlsl_register_space_resource_bindings_raise",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_does_not_rewrite_shadowed_cbuffer_member_identifiers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_members_in_uniform_buffers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_storage_buffer_members_in_uniform_buffers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_unsized_array_members_in_uniform_buffers"
           ]
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -399,7 +399,7 @@
         "path": null
       },
       "signals": {
-        "unsupported_marker_count": 54,
+        "unsupported_marker_count": 57,
         "unsupported_marker_samples": [
           {
             "path": "crosstl/translator/codegen/wgsl_codegen.py",
@@ -493,7 +493,7 @@
         "paths": [
           "tests/test_translator/test_codegen/test_wgsl_codegen.py"
         ],
-        "test_count": 48
+        "test_count": 52
       },
       "translator_codegen": {
         "exists": true,
@@ -1331,15 +1331,6 @@
     }
   ],
   "backlog": [
-    {
-      "backend": "WebGPU / WGSL",
-      "backend_id": "wgsl",
-      "category": "resources",
-      "feature": "Constant/uniform buffers",
-      "feature_id": "resources.constant_buffers",
-      "notes": "StructuredBuffer and RWStructuredBuffer declarations lower to WGSL storage-buffer arrays with read/read_write access modes and deterministic binding allocation. Append/consume buffers, byte-address buffers, helper methods, and richer storage-resource layouts remain future work or deterministic diagnostics.",
-      "status": "partial"
-    },
     {
       "backend": "WebGPU / WGSL",
       "backend_id": "wgsl",
@@ -3105,10 +3096,16 @@
         },
         "wgsl": {
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_structured_buffers_to_storage_bindings"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_cbuffers_to_uniform_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_uniform_blocks_to_uniform_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_duplicate_hlsl_register_space_resource_bindings_raise",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_does_not_rewrite_shadowed_cbuffer_member_identifiers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_members_in_uniform_buffers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_storage_buffer_members_in_uniform_buffers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_unsized_array_members_in_uniform_buffers"
           ],
-          "notes": "StructuredBuffer and RWStructuredBuffer declarations lower to WGSL storage-buffer arrays with read/read_write access modes and deterministic binding allocation. Append/consume buffers, byte-address buffers, helper methods, and richer storage-resource layouts remain future work or deterministic diagnostics.",
-          "status": "partial"
+          "notes": "CrossGL cbuffers and uniform blocks lower to WGSL uniform structs with deterministic @group/@binding allocation, explicit @set/@group/@space/@binding and HLSL register/space preservation, bare member-reference rewriting through the generated uniform binding, duplicate binding diagnostics, and deterministic diagnostics for resource members, StructuredBuffer members, and runtime-sized array members inside uniform buffers.",
+          "status": "supported"
         }
       }
     },
@@ -15118,7 +15115,7 @@
   },
   "summary": {
     "backend_count": 11,
-    "backlog_count": 4,
+    "backlog_count": 3,
     "feature_count": 66,
     "status_counts": {
       "cuda": {
@@ -15203,8 +15200,8 @@
       },
       "wgsl": {
         "diagnostic": 19,
-        "partial": 4,
-        "supported": 36,
+        "partial": 3,
+        "supported": 37,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 7

--- a/tests/test_translator/test_codegen/test_wgsl_codegen.py
+++ b/tests/test_translator/test_codegen/test_wgsl_codegen.py
@@ -371,6 +371,132 @@ def test_wgsl_codegen_lowers_cbuffers_to_uniform_struct_bindings():
     assert "var color: vec3<f32> = _TestBuffer.colors[0];" in generated
 
 
+def test_wgsl_codegen_lowers_uniform_blocks_to_uniform_struct_bindings():
+    shader = """
+    shader WGSLUniformBlock {
+        uniform Camera @set(2) @binding(3) {
+            mat4 viewProj;
+            vec4 tint;
+        };
+        vertex {
+            vec4 main(vec3 position @ POSITION) @ gl_Position {
+                vec4 projected = viewProj * vec4(position, 1.0);
+                return projected + tint;
+            }
+        }
+    }
+    """
+
+    generated = WGSLCodeGen().generate(parse_shader(shader))
+
+    assert (
+        "struct Camera {\n"
+        "    viewProj: mat4x4<f32>,\n"
+        "    tint: vec4<f32>,\n"
+        "};"
+    ) in generated
+    assert "@group(2) @binding(3)\nvar<uniform> _Camera: Camera;" in generated
+    assert (
+        "var projected: vec4<f32> = "
+        "(_Camera.viewProj * vec4<f32>(position, 1.0));"
+    ) in generated
+    assert "return (projected + _Camera.tint);" in generated
+
+
+def test_wgsl_codegen_rejects_resource_members_in_uniform_buffers():
+    shader = """
+    shader WGSLUniformResourceMember {
+        cbuffer Bad {
+            sampler2D colorTex;
+        };
+        compute {
+            void main() {
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target does not support resource member Bad\.colorTex "
+            r"of type sampler2D inside uniform buffers"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+    array_shader = """
+    shader WGSLUniformResourceMemberArray {
+        cbuffer Bad {
+            sampler2D colorTex[2];
+        };
+        compute {
+            void main() {
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target does not support resource member Bad\.colorTex "
+            r"of type sampler2D inside uniform buffers"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(array_shader))
+
+
+def test_wgsl_codegen_rejects_storage_buffer_members_in_uniform_buffers():
+    shader = """
+    shader WGSLUniformStorageBufferMember {
+        cbuffer Bad {
+            StructuredBuffer<float> values;
+        };
+        compute {
+            void main() {
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target does not support storage-buffer resource member "
+            r"Bad\.values inside uniform buffers"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
+def test_wgsl_codegen_rejects_unsized_array_members_in_uniform_buffers():
+    shader = """
+    shader WGSLUniformRuntimeArray {
+        cbuffer Bad {
+            float values[];
+        };
+        compute {
+            void main() {
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target does not support runtime-sized array member "
+            r"Bad\.values inside uniform buffers"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
 def test_wgsl_codegen_lowers_structured_buffers_to_storage_bindings():
     shader = """
     shader WGSLStructuredBuffers {


### PR DESCRIPTION
## Summary
- add WGSL uniform-buffer member validation for resource members, StructuredBuffer members, and runtime-sized array members
- add focused WGSL tests for cbuffer lowering, uniform block lowering, member rewriting, explicit bindings, and deterministic unsupported-shape diagnostics
- correct the WebGPU / WGSL constant/uniform buffer support row and regenerate support matrix artifacts

## Validation
- pytest tests/test_translator/test_codegen/test_wgsl_codegen.py -k 'wgsl_codegen_lowers_cbuffers_to_uniform_struct_bindings or wgsl_codegen_lowers_uniform_blocks_to_uniform_struct_bindings or wgsl_codegen_rejects_resource_members_in_uniform_buffers or wgsl_codegen_rejects_storage_buffer_members_in_uniform_buffers or wgsl_codegen_rejects_unsized_array_members_in_uniform_buffers or wgsl_duplicate_hlsl_register_space_resource_bindings_raise or wgsl_codegen_does_not_rewrite_shadowed_cbuffer_member_identifiers'
- python3 tools/support_matrix.py update
- python3 tools/support_matrix.py check

closes #880
