### PR TITLE
Fix SPIR-V gather offsets with vector operands

### DIFF
--- a/crosstl/translator/codegen/SPIRV_codegen.py
+++ b/crosstl/translator/codegen/SPIRV_codegen.py
@@ -3274,6 +3274,9 @@ class VulkanSPIRVCodeGen:
             return [], component_id
 
         offsets_value = extra_args[0]
+        if self.integer_value_component_count(offsets_value) is not None:
+            return [offsets_value] * 4, component_id
+
         offsets_type = self.value_types.get(offsets_value.id)
         element_type = self.array_element_type_from_type(offsets_type)
         if element_type is not None:


### PR DESCRIPTION
## Summary
- Treat a single integer vector offset passed to textureGatherOffsets as one offset value to duplicate across the four gather lanes.
- Keep aggregate offsets operands on the existing decomposition path.

## Root cause
The Complete Test Suite failed because the SPIR-V generator treated the single ivec2 offset form of textureGatherOffsets as an aggregate offsets collection. It decomposed the vector into scalar integers, which failed offset validation and skipped the four expected OpImageGather instructions.

## Verification
- .venv/bin/python -m pytest tests/test_translator/test_codegen/test_SPIRV_codegen.py::TestVulkanSPIRVCodeGen::test_sampled_operations_ignore_explicit_sampler_operands -q
- .venv/bin/python -m pytest tests/test_translator/test_codegen/test_SPIRV_codegen.py -q -k "sampled_operations_ignore_explicit_sampler_operands or texture_gather_offsets or texture_gather_offset or gather_offsets"
- .venv/bin/python -m pytest tests/test_translator/test_codegen/test_SPIRV_codegen.py -q

closes #989
