### PR TITLE
Fix DirectX GLSL vertex output semantics

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -12781,7 +12781,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         used_semantics = set()
         for member in getattr(struct_node, "members", []) or []:
             semantic = self.hlsl_struct_member_declared_semantic(member)
-            if semantic is not None:
+            if semantic is not None and self.hlsl_location_attribute_index(
+                member
+            ) is None:
                 used_semantics.add(self.hlsl_semantic_key(semantic))
 
         defaults = {}
@@ -12808,13 +12810,18 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 continue
             if member_name in defaults:
                 continue
-            if self.hlsl_struct_member_declared_semantic(member) is not None:
-                continue
             if not self.hlsl_can_default_fragment_input_semantic(
                 self.hlsl_struct_member_type_name(member)
             ):
                 continue
 
+            declared_semantic = self.hlsl_struct_member_declared_semantic(member)
+            location_index = self.hlsl_location_attribute_index(member)
+            if declared_semantic is not None and location_index is None:
+                continue
+
+            if location_index is not None:
+                next_texcoord = location_index
             while self.hlsl_semantic_key(f"TEXCOORD{next_texcoord}") in used_semantics:
                 next_texcoord += 1
             semantic = f"TEXCOORD{next_texcoord}"

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1092", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1093", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "52", "57", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1092
+        "test_count": 1093
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -259,6 +259,36 @@ def test_glsl_fragment_input_locations_lower_to_distinct_hlsl_semantics(tmp_path
     assert generated_code.count(": TEXCOORD1") == 1
 
 
+def test_glsl_vertex_output_locations_lower_to_distinct_hlsl_semantics(tmp_path):
+    shader = """
+    #version 450
+    layout(location = 0) out vec4 texcoord;
+    layout(location = 1) out vec3 frag_pos;
+
+    void main() {
+        texcoord = vec4(1.0);
+        frag_pos = vec3(0.0);
+        gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+    """
+    shader_path = tmp_path / "cube.vert"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="opengl",
+    )
+
+    assert "float4 texcoord: TEXCOORD0;" in generated_code
+    assert "float3 frag_pos: TEXCOORD1;" in generated_code
+    assert "float4 gl_Position: SV_POSITION;" in generated_code
+    assert ": location" not in generated_code
+    assert generated_code.count(": TEXCOORD0") == 1
+    assert generated_code.count(": TEXCOORD1") == 1
+
+
 def test_directx_user_defined_synchronization_names_are_not_lowered():
     shader = """
     shader SynchronizationShadowing {

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -6707,6 +6707,69 @@ def test_translate_project_glsl_vertex_color_output_does_not_synthesize_position
     assert_directx_vertex_validates_if_available(directx, tmp_path)
 
 
+def test_translate_project_glsl_vertex_output_locations_match_fragment_inputs_directx(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    shader_dir = repo / "gpu"
+    shader_dir.mkdir(parents=True)
+    (shader_dir / "cube_vs.vert").write_text(
+        textwrap.dedent("""
+            #version 450
+            layout(location = 0) out vec4 texcoord;
+            layout(location = 1) out vec3 frag_pos;
+
+            void main() {
+                texcoord = vec4(1.0);
+                frag_pos = vec3(0.0);
+                gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+    (shader_dir / "cube_fs.frag").write_text(
+        textwrap.dedent("""
+            #version 450
+            layout(location = 0) in vec4 texcoord;
+            layout(location = 1) in vec3 frag_pos;
+            layout(location = 0) out vec4 outColor;
+
+            void main() {
+                outColor = texcoord + vec4(frag_pos, 1.0);
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["gpu"]
+            targets = ["directx"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    vertex_directx = (
+        repo / "translated" / "directx" / "gpu" / "cube_vs.hlsl"
+    ).read_text(encoding="utf-8")
+    fragment_directx = (
+        repo / "translated" / "directx" / "gpu" / "cube_fs.hlsl"
+    ).read_text(encoding="utf-8")
+
+    assert payload["summary"]["translatedCount"] == 2
+    assert payload["summary"]["failedCount"] == 0
+    assert "float4 texcoord: TEXCOORD0;" in vertex_directx
+    assert "float3 frag_pos: TEXCOORD1;" in vertex_directx
+    assert "float4 texcoord: TEXCOORD0;" in fragment_directx
+    assert "float3 frag_pos: TEXCOORD1;" in fragment_directx
+    assert ": location" not in vertex_directx
+    assert ": location" not in fragment_directx
+    assert_directx_vertex_validates_if_available(vertex_directx, tmp_path)
+
+
 def test_translate_project_lowers_glsl_vertex_index_to_metal_vertex_id(tmp_path):
     repo = tmp_path / "repo"
     shader_dir = repo / "gpu"


### PR DESCRIPTION
## Summary
- Treat GLSL vertex output `layout(location = n)` members as indexed DirectX `TEXCOORDn` semantics.
- Preserve explicit HLSL and builtin semantics while matching existing fragment input location lowering.
- Add focused unit and project regressions for vertex output and fragment input compatibility.

## Root cause
GLSL `layout(location = n)` attributes on vertex output struct members were treated as declared HLSL semantics named `location`. Multiple varyings therefore emitted duplicate `: location` semantics, which DXC rejects as an overlap.

## Validation
- `uv run --with-requirements requirements.txt python -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_fragment_input_locations_lower_to_distinct_hlsl_semantics tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_vertex_output_locations_lower_to_distinct_hlsl_semantics tests/test_translator/test_project_translation.py::test_translate_project_glsl_vertex_output_locations_match_fragment_inputs_directx`
- `dxc` is unavailable locally, so validation is limited to generated HLSL shape and the project regression; the project helper will compile with DXC when available.

closes #975