### PR TITLE
Preserve runtime loader package paths

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -12998,6 +12998,18 @@ def _runtime_loader_metadata_source(
     return {"field": field, "path": path}
 
 
+def _runtime_loader_package_command_path(package_path: Any) -> str:
+    return PurePosixPath(str(package_path).replace("\\", "/")).as_posix()
+
+
+def _runtime_loader_normalize_package_command_path(
+    command: Sequence[str], package_path: Any
+) -> list[str]:
+    native_path = str(Path(str(package_path)))
+    command_path = _runtime_loader_package_command_path(package_path)
+    return [command_path if part == native_path else part for part in command]
+
+
 def _runtime_loader_metadata_slug(value: Any, fallback: str) -> str:
     text = value if isinstance(value, str) else ""
     text = text.strip().lower()
@@ -13175,13 +13187,13 @@ def _runtime_loader_directx_commands(
     package_path = adapter.get("packagePath")
     if not _is_non_empty_string(package_path) or not tools:
         return []
-    command_path = Path(str(package_path))
+    command_path = _runtime_loader_package_command_path(package_path)
     entry_profiles = _runtime_loader_directx_entry_profiles(
         adapter, package_root=package_root
     )
     tool = tools[0]
     if entry_profiles is None:
-        return [[tool, "-T", "lib_6_3", str(command_path), "-Fo", os.devnull]]
+        return [[tool, "-T", "lib_6_3", command_path, "-Fo", os.devnull]]
     return [
         _directx_dxc_entry_smoke_command(tool, command_path, entry, profile)
         for entry, profile in entry_profiles
@@ -13436,7 +13448,12 @@ def _runtime_loader_validation_command(
         return [tools[0], "--stdin", "-S", stage]
 
     if normalized_target == "wgsl":
-        return [tools[0], "--input-kind", "wgsl", str(package_path)]
+        return [
+            tools[0],
+            "--input-kind",
+            "wgsl",
+            _runtime_loader_package_command_path(package_path),
+        ]
 
     if normalized_target == "directx":
         commands = _runtime_loader_directx_commands(
@@ -13451,7 +13468,9 @@ def _runtime_loader_validation_command(
         artifact=adapter,
     )
     if smoke_command is not None:
-        return smoke_command[0]
+        return _runtime_loader_normalize_package_command_path(
+            smoke_command[0], package_path
+        )
 
     availability_command = TOOLCHAIN_AVAILABILITY_COMMANDS.get(normalized_target)
     return list(availability_command) if availability_command is not None else None

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -29173,6 +29173,71 @@ def test_runtime_loader_manifest_reports_wgsl_validation_command(tmp_path):
         },
         "language": "wgsl",
     }
+
+
+def test_runtime_loader_validation_commands_preserve_posix_package_paths_on_windows(
+    monkeypatch,
+):
+    monkeypatch.setattr(project_pipeline, "Path", PureWindowsPath)
+    monkeypatch.setattr(
+        project_pipeline,
+        "_runtime_loader_directx_entry_profiles",
+        lambda _adapter, *, package_root=None: (("VSMain", "vs_6_0"),),
+    )
+
+    directx_adapter = {
+        "target": "directx",
+        "packagePath": "artifacts/out/directx/graphics.hlsl",
+    }
+    vulkan_adapter = {
+        "target": "vulkan",
+        "packagePath": "artifacts/out/vulkan/simple.spvasm",
+    }
+    wgsl_adapter = {
+        "target": "wgsl",
+        "packagePath": "artifacts/out/wgsl/simple.wgsl",
+    }
+
+    assert project_pipeline._runtime_loader_validation_command(
+        directx_adapter
+    ) == [
+        "dxc",
+        "-T",
+        "vs_6_0",
+        "-E",
+        "VSMain",
+        "artifacts/out/directx/graphics.hlsl",
+        "-Fo",
+        project_pipeline.os.devnull,
+    ]
+    assert project_pipeline._runtime_loader_validation_command_input_metadata(
+        directx_adapter
+    )["commands"] == [
+        [
+            "dxc",
+            "-T",
+            "vs_6_0",
+            "-E",
+            "VSMain",
+            "artifacts/out/directx/graphics.hlsl",
+            "-Fo",
+            project_pipeline.os.devnull,
+        ]
+    ]
+    assert project_pipeline._runtime_loader_validation_command(
+        vulkan_adapter
+    ) == [
+        "spirv-as",
+        "artifacts/out/vulkan/simple.spvasm",
+        "-o",
+        project_pipeline.os.devnull,
+    ]
+    assert project_pipeline._runtime_loader_validation_command(wgsl_adapter) == [
+        "naga",
+        "--input-kind",
+        "wgsl",
+        "artifacts/out/wgsl/simple.wgsl",
+    ]
 
 
 def test_runtime_loader_manifest_reports_directx_dxc_entry_profile_metadata(tmp_path):


### PR DESCRIPTION
## Summary
- Preserve package-relative POSIX paths when runtime loader manifests render validation commands.
- Keep DirectX `dxc`, Vulkan `spirv-as`, and WGSL `naga` command metadata stable on Windows.
- Add a simulated Windows-path regression test for runtime loader command rendering.

## Root Cause
Runtime package paths are stored as stable POSIX manifest paths, but loader command construction converted them through `Path(...)` before stringifying. On Windows that changed `artifacts/out/...` to `artifacts\\out\\...`, causing generated frontend IR/runtime manifest tests to fail even though the manifest contract expects POSIX paths.

The WebGL stage artifact failures came from the same generated support window; current project translation already emits and packages the vertex and fragment stage artifacts, and the targeted regression remains passing.

## Validation
- `.venv/bin/python -m pytest tests/test_translator/test_project_translation.py::test_runtime_loader_manifest_reports_directx_dxc_entry_profile_metadata tests/test_translator/test_project_translation.py::test_translate_project_webgl_graphics_emits_runtime_stage_artifacts tests/test_translator/test_project_translation.py::test_webgl_runtime_package_preserves_graphics_stage_artifacts tests/test_translator/test_project_translation.py::test_runtime_loader_manifest_reports_blocked_host_interface_metadata tests/test_translator/test_project_translation.py::test_runtime_loader_validation_commands_preserve_posix_package_paths_on_windows -q`
- `git diff --check`

closes #927
closes #928
