### PR TITLE
Add WGSL resource array diagnostics

### DIFF
--- a/crosstl/translator/codegen/wgsl_codegen.py
+++ b/crosstl/translator/codegen/wgsl_codegen.py
@@ -1449,6 +1449,7 @@ class WGSLCodeGen:
                 f"{self.type_name_string(vtype.element_type)}>"
             )
         if isinstance(vtype, ArrayType):
+            self.validate_not_resource_array(vtype)
             element = self.type_name_string(vtype.element_type)
             if vtype.size is None:
                 return f"array<{element}>"
@@ -1557,6 +1558,33 @@ class WGSLCodeGen:
         ):
             return str(vtype.name)
         return None
+
+    def validate_not_resource_array(self, vtype):
+        resource_type = self.resource_array_element_type_name(vtype)
+        if resource_type is None:
+            return
+        raise ValueError(
+            "WGSL target does not support resource arrays of "
+            f"{resource_type}; WebGPU/WGSL requires texture, sampler, image, "
+            "and storage-buffer resources to be declared as individual "
+            "module-scope bindings"
+        )
+
+    def resource_array_element_type_name(self, vtype):
+        if not isinstance(vtype, ArrayType):
+            return None
+        element_type = self.array_element_type(vtype)
+        resource_type = self.resource_type_name(element_type)
+        if resource_type is not None and self.is_resource_type_name(resource_type):
+            return self.type_display_name(element_type)
+        return self.storage_buffer_like_type_name(element_type)
+
+    def type_display_name(self, vtype):
+        if isinstance(vtype, NamedType):
+            return str(vtype.name)
+        if isinstance(vtype, str):
+            return vtype.strip()
+        return str(vtype)
 
     def is_buffer_pointer_type(self, vtype, qualifiers=()):
         if not isinstance(vtype, PointerType):

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -25,7 +25,7 @@ implicitly supported.
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1093", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
-   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "52", "57", "WGSL specification; WebGPU specification"
+   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "54", "58", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "996", "496", "Apple Metal resources; Metal Shading Language specification"
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "997", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
@@ -40,7 +40,7 @@ implicitly supported.
    "DirectX / HLSL", "65", "0", "2", "0", "0", "0"
    "OpenGL / GLSL", "65", "0", "2", "0", "0", "0"
    "WebGL / GLSL ES", "36", "0", "22", "9", "0", "0"
-   "WebGPU / WGSL", "38", "3", "19", "7", "0", "0"
+   "WebGPU / WGSL", "38", "2", "20", "7", "0", "0"
    "Metal", "64", "0", "3", "0", "0", "0"
    "Vulkan SPIR-V", "65", "0", "2", "0", "0", "0"
    "CUDA", "60", "0", "7", "0", "0", "0"
@@ -132,7 +132,7 @@ Each category below uses the status codes from the legend.
    "Explicit and automatic resource bindings", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Constant/uniform buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Structured/storage buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
-   "Resource arrays", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Resource arrays", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Texture and sampler object model", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "GLSL buffer block lowering", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource memory qualifiers", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
@@ -216,7 +216,6 @@ implementation work can be scoped accurately.
 .. csv-table:: Actionable backlog rows
    :header: "Backend", "Category", "Feature", "Status", "Current gap", "Next scope", "Notes"
 
-   "WebGPU / WGSL", "resources", "Resource arrays", "partial", "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work.", "", "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work."
    "WebGPU / WGSL", "resources", "Texture and sampler object model", "partial", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.", "", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work."
    "WebGPU / WGSL", "resources", "GLSL buffer block lowering", "partial", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.", "", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work."
 

--- a/support/features.json
+++ b/support/features.json
@@ -2019,12 +2019,14 @@
           ]
         },
         "wgsl": {
-          "status": "partial",
-          "notes": "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work.",
+          "status": "diagnostic",
+          "notes": "Core WebGPU/WGSL does not expose descriptor/resource binding arrays. The WGSL backend now rejects fixed and unsized texture, sampler, image, and StructuredBuffer resource arrays, including resource-array function parameters, with deterministic diagnostics that direct callers to individual module-scope bindings. Ordinary sampled texture resources, texture_2d_array resource types, struct-held texture handles lowered to module bindings, and storage buffers remain covered by their separate rows.",
           "evidence": [
             "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_sampled_texture_resources_and_calls",
             "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_explicit_sampler_texture_calls",
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_array_declarations",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_array_parameters"
           ]
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -399,7 +399,7 @@
         "path": null
       },
       "signals": {
-        "unsupported_marker_count": 57,
+        "unsupported_marker_count": 58,
         "unsupported_marker_samples": [
           {
             "path": "crosstl/translator/codegen/wgsl_codegen.py",
@@ -493,7 +493,7 @@
         "paths": [
           "tests/test_translator/test_codegen/test_wgsl_codegen.py"
         ],
-        "test_count": 52
+        "test_count": 54
       },
       "translator_codegen": {
         "exists": true,
@@ -1331,15 +1331,6 @@
     }
   ],
   "backlog": [
-    {
-      "backend": "WebGPU / WGSL",
-      "backend_id": "wgsl",
-      "category": "resources",
-      "feature": "Resource arrays",
-      "feature_id": "resources.resource_arrays",
-      "notes": "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work.",
-      "status": "partial"
-    },
     {
       "backend": "WebGPU / WGSL",
       "backend_id": "wgsl",
@@ -3439,10 +3430,12 @@
           "evidence": [
             "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_sampled_texture_resources_and_calls",
             "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_explicit_sampler_texture_calls",
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_array_declarations",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_resource_array_parameters"
           ],
-          "notes": "Basic sampled texture calls lower to WGSL textureSample for combined texture/coords and explicit texture/sampler/coords forms, including helper texture parameters with companion sampler threading. Shadow comparison sampling, texture arrays, struct-held handles, and advanced sampling forms remain deterministic diagnostics or future work.",
-          "status": "partial"
+          "notes": "Core WebGPU/WGSL does not expose descriptor/resource binding arrays. The WGSL backend now rejects fixed and unsized texture, sampler, image, and StructuredBuffer resource arrays, including resource-array function parameters, with deterministic diagnostics that direct callers to individual module-scope bindings. Ordinary sampled texture resources, texture_2d_array resource types, struct-held texture handles lowered to module bindings, and storage buffers remain covered by their separate rows.",
+          "status": "diagnostic"
         }
       }
     },
@@ -15266,7 +15259,7 @@
   },
   "summary": {
     "backend_count": 11,
-    "backlog_count": 3,
+    "backlog_count": 2,
     "feature_count": 67,
     "status_counts": {
       "cuda": {
@@ -15350,8 +15343,8 @@
         "validated_rejection": 9
       },
       "wgsl": {
-        "diagnostic": 19,
-        "partial": 3,
+        "diagnostic": 20,
+        "partial": 2,
         "supported": 38,
         "unknown": 0,
         "unsupported": 0,

--- a/tests/test_translator/test_codegen/test_wgsl_codegen.py
+++ b/tests/test_translator/test_codegen/test_wgsl_codegen.py
@@ -1083,6 +1083,66 @@ def test_wgsl_codegen_lowers_explicit_sampler_texture_calls():
     assert "return textureSample(colorTex, linearSampler, uv);" in generated
 
 
+@pytest.mark.parametrize(
+    ("declaration", "resource_type"),
+    (
+        ("sampler2D textures[4];", "sampler2D"),
+        ("sampler samplers[2];", "sampler"),
+        ("image2D images[2];", "image2D"),
+        ("StructuredBuffer<float> values[4];", "StructuredBuffer"),
+        ("RWStructuredBuffer<float> values[];", "RWStructuredBuffer"),
+    ),
+)
+def test_wgsl_codegen_rejects_resource_array_declarations(
+    declaration, resource_type
+):
+    shader = f"""
+    shader WGSLResourceArray {{
+        {declaration}
+        compute {{
+            void main() {{
+                return;
+            }}
+        }}
+    }}
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"WGSL target does not support resource arrays of {resource_type}; "
+            r"WebGPU/WGSL requires texture, sampler, image, and storage-buffer "
+            r"resources to be declared as individual module-scope bindings"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
+def test_wgsl_codegen_rejects_resource_array_parameters():
+    shader = """
+    shader WGSLResourceArrayParameter {
+        vec4 sampleAt(sampler2D textures[4], int index, vec2 uv) {
+            return texture(textures[index], uv);
+        }
+        fragment {
+            vec4 main(vec2 uv @ TEXCOORD0, int index @ TEXCOORD1) @ gl_FragColor {
+                return vec4(1.0);
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target does not support resource arrays of sampler2D; "
+            r"WebGPU/WGSL requires texture, sampler, image, and storage-buffer "
+            r"resources to be declared as individual module-scope bindings"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
 def test_wgsl_codegen_emits_stage_local_resource_declarations():
     shader = """
     shader WGSLStageLocalResources {


### PR DESCRIPTION
## Summary
- reject WGSL arrays of texture, sampler, image, and storage-buffer resources with a direct diagnostic
- add focused WGSL tests for resource-array declarations and parameters
- promote the WGSL resources.resource_arrays matrix row to diagnostic and regenerate support artifacts

## Root Cause
Core WebGPU/WGSL does not expose descriptor/resource binding arrays, while the previous matrix row described older texture sampling gaps and left resource arrays as partial. The backend also surfaced generic type errors for resource-array shapes instead of a target-specific diagnostic.

## Validation
- .venv/bin/python -m pytest tests/test_translator/test_codegen/test_wgsl_codegen.py
- .venv/bin/python tools/support_matrix.py check

closes #882