### PR TITLE
Support WGSL GLSL buffer block lowering

### DIFF
--- a/crosstl/translator/codegen/wgsl_codegen.py
+++ b/crosstl/translator/codegen/wgsl_codegen.py
@@ -259,6 +259,7 @@ class WGSLCodeGen:
         "store3",
         "store4",
     }
+    SUPPORTED_GLSL_BUFFER_BLOCK_LAYOUTS = {"std430"}
     SAMPLED_TEXTURE_TYPE_MAP = {
         "sampler1d": "texture_1d<f32>",
         "sampler2d": "texture_2d<f32>",
@@ -336,7 +337,9 @@ class WGSLCodeGen:
         self._structs_by_name = {}
         self._struct_member_types = {}
         self._struct_resource_paths = {}
+        self._glsl_buffer_block_struct_names = set()
         self._module_variable_types = {}
+        self._module_storage_access_modes = {}
         self._module_resource_bindings = {}
         self._function_resource_member_parameters = {}
         self._reserved_bindings_by_group = {}
@@ -359,7 +362,9 @@ class WGSLCodeGen:
         self._structs_by_name = {}
         self._struct_member_types = {}
         self._struct_resource_paths = {}
+        self._glsl_buffer_block_struct_names = set()
         self._module_variable_types = {}
+        self._module_storage_access_modes = {}
         self._module_resource_bindings = {}
         self._function_resource_member_parameters = {}
         self._reserved_bindings_by_group = {}
@@ -390,6 +395,21 @@ class WGSLCodeGen:
             for node in global_variable_nodes
             if getattr(node, "name", "")
         }
+        helper_function_nodes = list(self._helper_functions(ast, target_stage))
+        all_function_nodes = list(helper_function_nodes)
+        all_function_nodes.extend(
+            stage_node.entry_point
+            for stage_node in self._stage_nodes(ast, target_stage)
+            if getattr(stage_node, "entry_point", None) is not None
+        )
+        self._glsl_buffer_block_struct_names = (
+            self.collect_glsl_buffer_block_struct_names(
+                global_variable_nodes, all_function_nodes
+            )
+        )
+        self._module_storage_access_modes = self.module_storage_access_modes(
+            global_variable_nodes
+        )
         self.reserve_explicit_resource_bindings(cbuffers, global_variable_nodes)
         if structs:
             emitted_sections.append(
@@ -414,8 +434,7 @@ class WGSLCodeGen:
             emitted_sections.append("\n".join(global_variables))
 
         helper_functions = [
-            self.generate_function(func)
-            for func in self._helper_functions(ast, target_stage)
+            self.generate_function(func) for func in helper_function_nodes if func
         ]
         if helper_functions:
             emitted_sections.append("\n\n".join(helper_functions))
@@ -580,6 +599,11 @@ class WGSLCodeGen:
     def generate_parameter(self, node):
         attributes = self.wgsl_attributes(node.attributes, direction="in")
         prefix = f"{attributes} " if attributes else ""
+        if self.is_glsl_buffer_block_parameter(node):
+            raise ValueError(
+                "WGSL target does not support GLSL buffer block parameters yet; "
+                "use module-scope storage bindings"
+            )
         unsupported_storage_type = self.unsupported_storage_buffer_type_name(
             node.param_type
         )
@@ -750,10 +774,19 @@ class WGSLCodeGen:
     def generate_struct(self, node):
         if getattr(node, "generic_params", None):
             raise ValueError("WGSL target does not support generic structs yet")
+        if node.name in self._glsl_buffer_block_struct_names:
+            self.validate_glsl_buffer_block_struct(node)
         lines = [f"struct {node.name} {{"]
         for member in node.members:
             resource_type_name = self.struct_member_resource_type_name(member)
             if resource_type_name:
+                if node.name in self._glsl_buffer_block_struct_names:
+                    raise ValueError(
+                        "WGSL target does not support resource member "
+                        f"{node.name}.{member.name} of type {resource_type_name} "
+                        "inside GLSL buffer blocks; declare textures, samplers, "
+                        "and storage resources as module-scope bindings"
+                    )
                 if self.supported_struct_resource_member(member):
                     continue
                 raise ValueError(
@@ -800,6 +833,8 @@ class WGSLCodeGen:
             return self.generate_sampler_global_variable(node)
         if self.is_buffer_pointer_type(node.var_type, node.qualifiers):
             return self.generate_buffer_pointer_global_variable(node)
+        if self.is_glsl_buffer_block_variable(node):
+            return self.generate_glsl_buffer_block_global_variable(node)
 
         qualifier_names = {str(qualifier).lower() for qualifier in node.qualifiers}
         address_space = "private"
@@ -939,6 +974,20 @@ class WGSLCodeGen:
             f"{self.buffer_pointer_storage_type(node.var_type)};"
         )
 
+    def generate_glsl_buffer_block_global_variable(self, node):
+        self.validate_glsl_buffer_block_variable(node)
+        if node.initial_value is not None:
+            raise ValueError(
+                "WGSL target does not support initializers for GLSL buffer block "
+                f"resource {node.name}"
+            )
+        attributes = (
+            self.explicit_binding_attributes(node) or self.next_binding_attributes()
+        )
+        access = self.glsl_buffer_block_access(node)
+        type_name = self.glsl_buffer_block_struct_name(node.var_type)
+        return f"{attributes}\nvar<storage, {access}> {node.name}: {type_name};"
+
     def generate_statement(self, stmt, indent=0):
         pad = "    " * indent
         if isinstance(stmt, BlockNode):
@@ -1077,6 +1126,7 @@ class WGSLCodeGen:
         return "\n".join(lines)
 
     def generate_assignment(self, node):
+        self.validate_storage_assignment_target(node.target)
         return (
             f"{self.generate_expression(node.target)} {node.operator} "
             f"{self.generate_expression(node.value)}"
@@ -1130,6 +1180,11 @@ class WGSLCodeGen:
             resource_binding = self.resource_member_binding_for_access(expr)
             if resource_binding is not None:
                 return resource_binding["binding_name"]
+            if (
+                isinstance(expr.object_expr, IdentifierNode)
+                and self.is_pointer_identifier(expr.object_expr.name)
+            ):
+                return f"(*{expr.object_expr.name}).{expr.member}"
             return f"{self.generate_expression(expr.object_expr)}." f"{expr.member}"
         if isinstance(expr, SwizzleNode):
             return f"{self.generate_expression(expr.vector_expr)}." f"{expr.components}"
@@ -1771,6 +1826,135 @@ class WGSLCodeGen:
             return vtype.strip()
         return str(vtype)
 
+    def is_glsl_buffer_block_variable(self, node):
+        if self.is_buffer_pointer_type(
+            getattr(node, "var_type", None), getattr(node, "qualifiers", [])
+        ):
+            return False
+        if self.glsl_buffer_block_attribute(node) is not None:
+            return True
+        qualifier_names = {
+            str(qualifier).lower() for qualifier in getattr(node, "qualifiers", []) or []
+        }
+        if "buffer" not in qualifier_names:
+            return False
+        struct_name = self.glsl_buffer_block_struct_name(
+            getattr(node, "var_type", None)
+        )
+        return struct_name in self._structs_by_name
+
+    def is_glsl_buffer_block_parameter(self, node):
+        return self.glsl_buffer_block_attribute(node) is not None
+
+    def glsl_buffer_block_attribute(self, node):
+        for attr in getattr(node, "attributes", []) or []:
+            key = self.semantic_key(str(getattr(attr, "name", attr)))
+            if key == "glsl_buffer_block":
+                return attr
+        return None
+
+    def glsl_buffer_block_layout(self, node):
+        attr = self.glsl_buffer_block_attribute(node)
+        if attr is None:
+            qualifier_names = {
+                self.semantic_key(str(qualifier))
+                for qualifier in getattr(node, "qualifiers", []) or []
+            }
+            if "buffer" in qualifier_names:
+                return "std430"
+            return None
+        arguments = getattr(attr, "arguments", []) or []
+        if not arguments:
+            return None
+        return self.semantic_key(self.generate_attribute_argument(arguments[0]))
+
+    def glsl_buffer_block_struct_name(self, vtype):
+        return self.struct_type_name(self.array_element_type(vtype))
+
+    def glsl_buffer_block_access(self, node):
+        qualifiers = {
+            self.semantic_key(str(qualifier))
+            for qualifier in getattr(node, "qualifiers", []) or []
+        }
+        attributes = {
+            self.semantic_key(str(getattr(attr, "name", attr)))
+            for attr in getattr(node, "attributes", []) or []
+        }
+        names = qualifiers | attributes
+        if "readonly" in names:
+            return "read"
+        if "writeonly" in names:
+            return "write"
+        return "read_write"
+
+    def validate_glsl_buffer_block_layout(self, node, resource_name):
+        layout = self.glsl_buffer_block_layout(node)
+        if layout not in self.SUPPORTED_GLSL_BUFFER_BLOCK_LAYOUTS:
+            layout_name = layout or "unspecified"
+            raise ValueError(
+                "WGSL target only supports std430 GLSL buffer block layout "
+                f"for {resource_name}; got {layout_name}"
+            )
+
+    def validate_glsl_buffer_block_variable(self, node):
+        self.validate_glsl_buffer_block_layout(node, node.name)
+        if isinstance(getattr(node, "var_type", None), ArrayType):
+            raise ValueError(
+                "WGSL target does not support GLSL buffer block arrays yet; "
+                "declare each block as a separate storage binding"
+            )
+        struct_name = self.glsl_buffer_block_struct_name(node.var_type)
+        if not struct_name:
+            raise ValueError(
+                "WGSL target requires GLSL buffer block resource "
+                f"{node.name} to use a named struct type"
+            )
+
+    def validate_glsl_buffer_block_struct(self, node):
+        members = list(getattr(node, "members", []) or [])
+        for index, member in enumerate(members):
+            member_type = getattr(member, "member_type", None)
+            resource_type_name = self.struct_member_resource_type_name(member)
+            if resource_type_name:
+                continue
+            if self.structured_buffer_element_type(self.array_element_type(member_type)):
+                raise ValueError(
+                    "WGSL target does not support storage-buffer resource member "
+                    f"{node.name}.{member.name} inside GLSL buffer blocks"
+                )
+            if (
+                self.unsized_array_type(member_type) is not None
+                and index != len(members) - 1
+            ):
+                raise ValueError(
+                    "WGSL target requires runtime-sized array member "
+                    f"{node.name}.{member.name} to be the final GLSL buffer block member"
+                )
+
+    def collect_glsl_buffer_block_struct_names(self, global_variables, functions):
+        struct_names = set()
+        for variable in global_variables:
+            if not self.is_glsl_buffer_block_variable(variable):
+                continue
+            struct_name = self.glsl_buffer_block_struct_name(variable.var_type)
+            if struct_name:
+                struct_names.add(struct_name)
+        for function in functions:
+            for parameter in getattr(function, "parameters", []) or []:
+                if not self.is_glsl_buffer_block_parameter(parameter):
+                    continue
+                struct_name = self.glsl_buffer_block_struct_name(parameter.param_type)
+                if struct_name:
+                    struct_names.add(struct_name)
+        return struct_names
+
+    def module_storage_access_modes(self, global_variables):
+        modes = {}
+        for variable in global_variables:
+            if self.is_glsl_buffer_block_variable(variable):
+                modes[variable.name] = self.glsl_buffer_block_access(variable)
+        return modes
+
     def is_buffer_pointer_type(self, vtype, qualifiers=()):
         if not isinstance(vtype, PointerType):
             return False
@@ -2063,6 +2247,20 @@ class WGSLCodeGen:
         if alias is not None:
             return alias
         return self._module_resource_bindings.get((root_name, tuple(path)))
+
+    def storage_access_mode(self, name):
+        return self._module_storage_access_modes.get(name)
+
+    def validate_storage_assignment_target(self, target):
+        access_path = self.expression_access_path(target)
+        if access_path is None:
+            return
+        root_name, _path = access_path
+        if self.storage_access_mode(root_name) == "read":
+            raise ValueError(
+                "WGSL target cannot write read-only GLSL buffer block resource "
+                f"{root_name}"
+            )
 
     def resource_member_parameter_declarations(self, root_name, root_type):
         declarations = []

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -25,7 +25,7 @@ implicitly supported.
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1093", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
-   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "58", "58", "WGSL specification; WebGPU specification"
+   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "63", "63", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "996", "496", "Apple Metal resources; Metal Shading Language specification"
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "997", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
@@ -40,7 +40,7 @@ implicitly supported.
    "DirectX / HLSL", "65", "0", "2", "0", "0", "0"
    "OpenGL / GLSL", "65", "0", "2", "0", "0", "0"
    "WebGL / GLSL ES", "36", "0", "22", "9", "0", "0"
-   "WebGPU / WGSL", "39", "1", "20", "7", "0", "0"
+   "WebGPU / WGSL", "40", "0", "20", "7", "0", "0"
    "Metal", "64", "0", "3", "0", "0", "0"
    "Vulkan SPIR-V", "65", "0", "2", "0", "0", "0"
    "CUDA", "60", "0", "7", "0", "0", "0"
@@ -134,7 +134,7 @@ Each category below uses the status codes from the legend.
    "Structured/storage buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource arrays", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Texture and sampler object model", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
-   "GLSL buffer block lowering", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "GLSL buffer block lowering", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource memory qualifiers", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
 
 .. csv-table:: textures
@@ -216,7 +216,6 @@ implementation work can be scoped accurately.
 .. csv-table:: Actionable backlog rows
    :header: "Backend", "Category", "Feature", "Status", "Current gap", "Next scope", "Notes"
 
-   "WebGPU / WGSL", "resources", "GLSL buffer block lowering", "partial", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.", "", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work."
 
 Documentation Sources
 ---------------------

--- a/support/features.json
+++ b/support/features.json
@@ -2328,10 +2328,14 @@
           ]
         },
         "wgsl": {
-          "status": "partial",
-          "notes": "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.",
+          "status": "supported",
+          "notes": "GLSL layout(std430) buffer blocks and explicit @glsl_buffer_block variables lower to WGSL storage-buffer struct bindings with explicit or automatic group/binding metadata, read-only/read-write access modes, direct member and runtime-array member access, read-only write diagnostics, and Naga validation coverage. Non-std430 layouts, block arrays, buffer-block helper parameters, and resource or storage-buffer members inside blocks remain deterministic WGSL diagnostics under this feature contract.",
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_glsl_buffer_blocks_to_storage_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_glsl_buffer_block_parameters",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_unsupported_glsl_buffer_block_shapes",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_writes_to_readonly_glsl_buffer_blocks",
+            "tests/test_translator/test_codegen/test_external_shader_validators.py::def test_generated_wgsl_validates_with_naga"
           ]
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -399,7 +399,7 @@
         "path": null
       },
       "signals": {
-        "unsupported_marker_count": 58,
+        "unsupported_marker_count": 63,
         "unsupported_marker_samples": [
           {
             "path": "crosstl/translator/codegen/wgsl_codegen.py",
@@ -443,6 +443,10 @@
           },
           {
             "path": "crosstl/translator/codegen/wgsl_codegen.py",
+            "text": "\"WGSL target does not support GLSL buffer block parameters yet; \""
+          },
+          {
+            "path": "crosstl/translator/codegen/wgsl_codegen.py",
             "text": "unsupported_storage_type = self.unsupported_storage_buffer_type_name("
           },
           {
@@ -476,10 +480,6 @@
           {
             "path": "crosstl/translator/codegen/wgsl_codegen.py",
             "text": "\"WGSL target does not support implicit builtin identifier(s): \""
-          },
-          {
-            "path": "crosstl/translator/codegen/wgsl_codegen.py",
-            "text": "+ \", \".join(unsupported)"
           }
         ]
       },
@@ -493,7 +493,7 @@
         "paths": [
           "tests/test_translator/test_codegen/test_wgsl_codegen.py"
         ],
-        "test_count": 58
+        "test_count": 63
       },
       "translator_codegen": {
         "exists": true,
@@ -1330,17 +1330,7 @@
       }
     }
   ],
-  "backlog": [
-    {
-      "backend": "WebGPU / WGSL",
-      "backend_id": "wgsl",
-      "category": "resources",
-      "feature": "GLSL buffer block lowering",
-      "feature_id": "resources.glsl_buffer_blocks",
-      "notes": "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.",
-      "status": "partial"
-    }
-  ],
+  "backlog": [],
   "features": [
     {
       "category": "target",
@@ -3729,10 +3719,14 @@
         },
         "wgsl": {
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_glsl_buffer_blocks_to_storage_struct_bindings",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_glsl_buffer_block_parameters",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_unsupported_glsl_buffer_block_shapes",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_writes_to_readonly_glsl_buffer_blocks",
+            "tests/test_translator/test_codegen/test_external_shader_validators.py::def test_generated_wgsl_validates_with_naga"
           ],
-          "notes": "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.",
-          "status": "partial"
+          "notes": "GLSL layout(std430) buffer blocks and explicit @glsl_buffer_block variables lower to WGSL storage-buffer struct bindings with explicit or automatic group/binding metadata, read-only/read-write access modes, direct member and runtime-array member access, read-only write diagnostics, and Naga validation coverage. Non-std430 layouts, block arrays, buffer-block helper parameters, and resource or storage-buffer members inside blocks remain deterministic WGSL diagnostics under this feature contract.",
+          "status": "supported"
         }
       }
     },
@@ -15254,7 +15248,7 @@
   },
   "summary": {
     "backend_count": 11,
-    "backlog_count": 1,
+    "backlog_count": 0,
     "feature_count": 67,
     "status_counts": {
       "cuda": {
@@ -15339,8 +15333,8 @@
       },
       "wgsl": {
         "diagnostic": 20,
-        "partial": 1,
-        "supported": 39,
+        "partial": 0,
+        "supported": 40,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 7

--- a/tests/test_translator/test_codegen/test_external_shader_validators.py
+++ b/tests/test_translator/test_codegen/test_external_shader_validators.py
@@ -132,6 +132,25 @@ shader ExternalValidatorWGSLCompute {
 """
 
 
+CROSSGL_WGSL_BUFFER_BLOCK_SHADER = """
+shader ExternalValidatorWGSLBufferBlock {
+    layout(std430, set = 1, binding = 2) readonly buffer InputBlock {
+        float values[];
+    } inputBlock;
+    layout(std430, binding = 3) buffer OutputBlock {
+        float values[];
+    } outputBlock;
+    compute {
+        layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
+        void main(uint3 gid @ gl_GlobalInvocationID) {
+            outputBlock.values[gid.x] = inputBlock.values[gid.x];
+            return;
+        }
+    }
+}
+"""
+
+
 GLSL_SPECIALIZATION_CONSTANT_VERTEX_SHADER = """
 #version 400
 
@@ -2042,6 +2061,7 @@ def _run_validator_or_skip_unsupported_extension(
         CROSSGL_WGSL_GRAPHICS_SHADER,
         CROSSGL_WGSL_RESOURCE_SHADER,
         CROSSGL_WGSL_COMPUTE_SHADER,
+        CROSSGL_WGSL_BUFFER_BLOCK_SHADER,
     ),
 )
 def test_generated_wgsl_validates_with_naga(tmp_path, shader_source):

--- a/tests/test_translator/test_codegen/test_wgsl_codegen.py
+++ b/tests/test_translator/test_codegen/test_wgsl_codegen.py
@@ -493,6 +493,171 @@ def test_wgsl_codegen_rejects_unsized_array_members_in_uniform_buffers():
         WGSLCodeGen().generate(parse_shader(shader))
 
 
+def test_wgsl_codegen_lowers_glsl_buffer_blocks_to_storage_struct_bindings():
+    shader = """
+    shader WGSLBufferBlocks {
+        layout(std430, set = 1, binding = 2) readonly buffer InputBlock {
+            float values[];
+        } inputBlock;
+        layout(std430, binding = 3) buffer OutputBlock {
+            float values[];
+        } outputBlock;
+        compute {
+            void main(uint3 gid @ gl_GlobalInvocationID) {
+                outputBlock.values[gid.x] = inputBlock.values[gid.x];
+                return;
+            }
+        }
+    }
+    """
+
+    generated = WGSLCodeGen().generate(parse_shader(shader))
+
+    assert (
+        "struct InputBlock {\n"
+        "    values: array<f32>,\n"
+        "};"
+    ) in generated
+    assert (
+        "struct OutputBlock {\n"
+        "    values: array<f32>,\n"
+        "};"
+    ) in generated
+    assert "@group(1) @binding(2)\nvar<storage, read> inputBlock: InputBlock;" in generated
+    assert (
+        "@group(0) @binding(3)\nvar<storage, read_write> outputBlock: OutputBlock;"
+        in generated
+    )
+    assert "outputBlock.values[gid.x] = inputBlock.values[gid.x];" in generated
+
+
+def test_wgsl_codegen_lowers_layoutless_buffer_blocks_as_std430_storage():
+    shader = """
+    shader WGSLImplicitBufferBlock {
+        struct ParticleBuffer {
+            float positions[];
+        }
+        buffer ParticleBuffer particleBuffer;
+        compute {
+            void main(uint3 gid @ gl_GlobalInvocationID) {
+                particleBuffer.positions[gid.x] = 1.0;
+                return;
+            }
+        }
+    }
+    """
+
+    generated = WGSLCodeGen().generate(parse_shader(shader))
+
+    assert (
+        "struct ParticleBuffer {\n"
+        "    positions: array<f32>,\n"
+        "};"
+    ) in generated
+    assert (
+        "@group(0) @binding(0)\n"
+        "var<storage, read_write> particleBuffer: ParticleBuffer;"
+    ) in generated
+    assert "particleBuffer.positions[gid.x] = 1.0;" in generated
+
+
+def test_wgsl_codegen_rejects_glsl_buffer_block_parameters():
+    shader = """
+    shader WGSLBufferBlockParameters {
+        struct InputBlock {
+            float values[];
+        };
+        float readFirst(InputBlock block @glsl_buffer_block(std430) @readonly) {
+            return block.values[0];
+        }
+        InputBlock inputBlock @glsl_buffer_block(std430) @binding(0) @readonly;
+        InputBlock outputBlock @glsl_buffer_block(std430) @binding(1);
+        compute {
+            void main() {
+                outputBlock.values[0] = readFirst(inputBlock);
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match="does not support GLSL buffer block parameters yet",
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
+@pytest.mark.parametrize(
+    ("declaration", "expected"),
+    [
+        (
+            """
+            layout(std140, binding = 0) buffer BadBlock {
+                vec4 value;
+            } badBlock;
+            """,
+            "only supports std430 GLSL buffer block layout",
+        ),
+        (
+            """
+            struct BadBlock {
+                float values[];
+            };
+            BadBlock badBlocks[2] @glsl_buffer_block(std430) @binding(0);
+            """,
+            "does not support GLSL buffer block arrays yet",
+        ),
+        (
+            """
+            layout(std430, binding = 0) buffer BadBlock {
+                sampler2D colorTex;
+            } badBlock;
+            """,
+            r"does not support resource member BadBlock\.colorTex",
+        ),
+    ],
+)
+def test_wgsl_codegen_rejects_unsupported_glsl_buffer_block_shapes(
+    declaration, expected
+):
+    shader = f"""
+    shader WGSLUnsupportedBufferBlocks {{
+        {declaration}
+        compute {{
+            void main() {{
+                return;
+            }}
+        }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match=expected):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
+def test_wgsl_codegen_rejects_writes_to_readonly_glsl_buffer_blocks():
+    shader = """
+    shader WGSLReadonlyBufferBlockWrite {
+        layout(std430, binding = 0) readonly buffer ReadBlock {
+            float values[];
+        } readBlock;
+        compute {
+            void main() {
+                readBlock.values[0] = 1.0;
+                return;
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=r"cannot write read-only GLSL buffer block resource readBlock",
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
 def test_wgsl_codegen_lowers_structured_buffers_to_storage_bindings():
     shader = """
     shader WGSLStructuredBuffers {


### PR DESCRIPTION
## Summary
- lower std430 GLSL buffer blocks and explicit @glsl_buffer_block variables to WGSL storage struct bindings
- preserve deterministic WGSL diagnostics for unsupported layouts, block arrays, helper parameters, resource members, and read-only writes
- update support-matrix evidence/status for resources.glsl_buffer_blocks

## Tests
- pytest tests/test_translator/test_codegen/test_wgsl_codegen.py tests/test_translator/test_codegen/test_external_shader_validators.py::test_generated_wgsl_validates_with_naga -q
- python3 tools/support_matrix.py check

closes #884