### PR TITLE
Support WGSL texture sampler object model

### DIFF
--- a/crosstl/translator/codegen/wgsl_codegen.py
+++ b/crosstl/translator/codegen/wgsl_codegen.py
@@ -70,10 +70,10 @@ class WGSLCodeGen:
         "ray_callable",
         "callable",
     }
-    VECTOR_TYPE_RE = re.compile(r"^(?:vec|float|int|uint|bool)([234])$")
+    VECTOR_TYPE_RE = re.compile(r"^(?:vec|float|int|uint|bool|ivec|uvec|bvec)([234])$")
     MATRIX_TYPE_RE = re.compile(r"^(?:mat|float)([234])(?:x([234]))?$")
     TYPE_CONSTRUCTOR_RE = re.compile(
-        r"^(?:vec[234]|float[234]|int[234]|uint[234]|bool[234]|mat[234](?:x[234])?|float[234]x[234])$"
+        r"^(?:vec[234]|float[234]|int[234]|uint[234]|bool[234]|ivec[234]|uvec[234]|bvec[234]|mat[234](?:x[234])?|float[234]x[234])$"
     )
 
     PRIMITIVE_TYPE_MAP = {
@@ -196,6 +196,8 @@ class WGSLCodeGen:
         "sampler3d",
         "samplercube",
         "samplercubearray",
+        "samplercubearrayshadow",
+        "samplercubeshadow",
         "samplerstate",
         "samplercomparisonstate",
         "texture1d",
@@ -261,9 +263,13 @@ class WGSLCodeGen:
         "sampler1d": "texture_1d<f32>",
         "sampler2d": "texture_2d<f32>",
         "sampler2darray": "texture_2d_array<f32>",
+        "sampler2darrayshadow": "texture_depth_2d_array",
+        "sampler2dshadow": "texture_depth_2d",
         "sampler3d": "texture_3d<f32>",
         "samplercube": "texture_cube<f32>",
         "samplercubearray": "texture_cube_array<f32>",
+        "samplercubearrayshadow": "texture_depth_cube_array",
+        "samplercubeshadow": "texture_depth_cube",
         "texture1d": "texture_1d<f32>",
         "texture2d": "texture_2d<f32>",
         "texture2darray": "texture_2d_array<f32>",
@@ -275,8 +281,12 @@ class WGSLCodeGen:
         "sampler",
         "samplerstate",
     }
+    COMPARISON_SAMPLER_TYPE_NAMES = {
+        "samplercomparisonstate",
+    }
     TEXTURE_FUNCTION_NAMES = {
         "texture",
+        "texturebias",
         "texturecompare",
         "texturecomparegrad",
         "texturecompareoffset",
@@ -587,10 +597,11 @@ class WGSLCodeGen:
         if sampled_texture_type is not None:
             return (
                 f"{prefix}{node.name}: {sampled_texture_type}, "
-                f"{self.texture_sampler_name(node.name)}: sampler"
+                f"{self.texture_sampler_name(node.name)}: "
+                f"{self.companion_sampler_type(node.param_type)}"
             )
         if self.is_sampler_type(node.param_type):
-            return f"{prefix}{node.name}: sampler"
+            return f"{prefix}{node.name}: {self.sampler_type(node.param_type)}"
         if self.is_buffer_pointer_type(node.param_type, node.qualifiers):
             return f"{prefix}{node.name}: {self.buffer_pointer_parameter_type(node.param_type)}"
         parameter = f"{prefix}{node.name}: {self.type_name_string(node.param_type)}"
@@ -855,7 +866,8 @@ class WGSLCodeGen:
         sampler_name = self.texture_sampler_name(node.name)
         return (
             f"{texture_attributes}\nvar {node.name}: {texture_type};\n"
-            f"{sampler_attributes}\nvar {sampler_name}: sampler;"
+            f"{sampler_attributes}\nvar {sampler_name}: "
+            f"{self.companion_sampler_type(node.var_type)};"
         )
 
     def generate_sampler_global_variable(self, node):
@@ -867,7 +879,7 @@ class WGSLCodeGen:
         attributes = (
             self.explicit_binding_attributes(node) or self.next_binding_attributes()
         )
-        return f"{attributes}\nvar {node.name}: sampler;"
+        return f"{attributes}\nvar {node.name}: {self.sampler_type(node.var_type)};"
 
     def generate_resource_member_global_variables(self, root_name, root_type):
         declarations = []
@@ -894,14 +906,18 @@ class WGSLCodeGen:
             sampler_name = self.texture_sampler_name(binding_name)
             return (
                 f"{texture_attributes}\nvar {binding_name}: {sampled_texture_type};\n"
-                f"{sampler_attributes}\nvar {sampler_name}: sampler;"
+                f"{sampler_attributes}\nvar {sampler_name}: "
+                f"{self.companion_sampler_type(info['member_type'])};"
             )
         if self.is_sampler_type(info["member_type"]):
             attributes = (
                 self.explicit_binding_attributes(member)
                 or self.next_binding_attributes()
             )
-            return f"{attributes}\nvar {binding_name}: sampler;"
+            return (
+                f"{attributes}\nvar {binding_name}: "
+                f"{self.sampler_type(info['member_type'])};"
+            )
         raise ValueError(
             "WGSL target does not support resource member "
             f"{info['owner_struct']}.{member.name} of type {info['resource_type_name']}; "
@@ -1340,11 +1356,60 @@ class WGSLCodeGen:
             return self.generate_texture_sample_call(function_name, args)
         if normalized_name == "texturelod":
             return self.generate_texture_sample_level_call(function_name, args)
+        if normalized_name == "texturelodoffset":
+            return self.generate_texture_sample_level_offset_call(function_name, args)
+        if normalized_name == "texturegrad":
+            return self.generate_texture_sample_grad_call(function_name, args)
+        if normalized_name == "texturegradoffset":
+            return self.generate_texture_sample_grad_offset_call(function_name, args)
+        if normalized_name == "textureoffset":
+            return self.generate_texture_sample_offset_call(function_name, args)
+        if normalized_name == "texturecompare":
+            return self.generate_texture_sample_compare_call(function_name, args)
+        if normalized_name == "texturecompareoffset":
+            return self.generate_texture_sample_compare_offset_call(function_name, args)
+        if normalized_name == "texturecomparelod":
+            return self.generate_texture_sample_compare_level_call(function_name, args)
+        if normalized_name == "texturecomparelodoffset":
+            return self.generate_texture_sample_compare_level_offset_call(
+                function_name, args
+            )
         if normalized_name == "texturesize":
             return self.generate_texture_dimensions_call(args)
         raise ValueError(
             "WGSL target does not support CrossGL texture function "
             f"{function_name} yet"
+        )
+
+    def generate_texture_call_args(self, args, *, function_name, implicit, explicit):
+        if len(args) == implicit:
+            texture = args[0]
+            return [
+                self.generate_expression(texture),
+                self.texture_sampler_expression(texture),
+                *(self.generate_expression(arg) for arg in args[1:]),
+            ]
+        if len(args) == explicit:
+            return [self.generate_expression(arg) for arg in args]
+        raise ValueError(
+            f"WGSL target supports {function_name}() calls with {implicit} or "
+            f"{explicit} argument(s); got {len(args)}"
+        )
+
+    def generate_texture_builtin_call(
+        self, builtin_name, function_name, args, *, implicit, explicit
+    ):
+        return (
+            f"{builtin_name}("
+            + ", ".join(
+                self.generate_texture_call_args(
+                    args,
+                    function_name=function_name,
+                    implicit=implicit,
+                    explicit=explicit,
+                )
+            )
+            + ")"
         )
 
     def generate_texture_sample_call(self, function_name, args):
@@ -1391,6 +1456,90 @@ class WGSLCodeGen:
             f"{len(args)} argument(s) for {function_name}"
         )
 
+    def generate_texture_sample_level_offset_call(self, function_name, args):
+        return self.generate_texture_builtin_call(
+            "textureSampleLevel", function_name, args, implicit=4, explicit=5
+        )
+
+    def generate_texture_sample_grad_call(self, function_name, args):
+        return self.generate_texture_builtin_call(
+            "textureSampleGrad", function_name, args, implicit=4, explicit=5
+        )
+
+    def generate_texture_sample_grad_offset_call(self, function_name, args):
+        return self.generate_texture_builtin_call(
+            "textureSampleGrad", function_name, args, implicit=5, explicit=6
+        )
+
+    def generate_texture_sample_offset_call(self, function_name, args):
+        if len(args) == 3:
+            return self.generate_texture_builtin_call(
+                "textureSample", function_name, args, implicit=3, explicit=4
+            )
+        if len(args) == 4:
+            if self.is_sampler_type(self.expression_type(args[1])):
+                return self.generate_texture_builtin_call(
+                    "textureSample", function_name, args, implicit=3, explicit=4
+                )
+            texture, coords, offset, bias = (
+                self.generate_expression(arg) for arg in args
+            )
+            return (
+                "textureSampleBias("
+                f"{texture}, {self.texture_sampler_expression(args[0])}, "
+                f"{coords}, {bias}, {offset})"
+            )
+        if len(args) == 5:
+            call_args = self.generate_texture_call_args(
+                args, function_name=function_name, implicit=4, explicit=5
+            )
+            texture, sampler, coords, offset, bias = call_args
+            return (
+                "textureSampleBias("
+                f"{texture}, {sampler}, {coords}, {bias}, {offset})"
+            )
+        raise ValueError(
+            "WGSL target supports textureOffset() calls with texture/coords/offset, "
+            "texture/sampler/coords/offset, or texture/sampler/coords/offset/bias "
+            f"arguments; got {len(args)} argument(s)"
+        )
+
+    def generate_texture_sample_compare_call(self, function_name, args):
+        self.require_depth_texture_operand(args[0], function_name)
+        self.require_comparison_sampler_operand(args, function_name, implicit=3)
+        return self.generate_texture_builtin_call(
+            "textureSampleCompare", function_name, args, implicit=3, explicit=4
+        )
+
+    def generate_texture_sample_compare_offset_call(self, function_name, args):
+        self.require_depth_texture_operand(args[0], function_name)
+        self.require_comparison_sampler_operand(args, function_name, implicit=4)
+        return self.generate_texture_builtin_call(
+            "textureSampleCompare", function_name, args, implicit=4, explicit=5
+        )
+
+    def generate_texture_sample_compare_level_call(self, function_name, args):
+        self.require_depth_texture_operand(args[0], function_name)
+        self.require_comparison_sampler_operand(args, function_name, implicit=4)
+        self.require_zero_compare_level_operand(args, function_name, implicit=4)
+        call_args = self.generate_texture_call_args(
+            args, function_name=function_name, implicit=4, explicit=5
+        )
+        call_args.pop()
+        return "textureSampleCompareLevel(" + ", ".join(call_args) + ")"
+
+    def generate_texture_sample_compare_level_offset_call(self, function_name, args):
+        self.require_depth_texture_operand(args[0], function_name)
+        self.require_comparison_sampler_operand(args, function_name, implicit=5)
+        self.require_zero_compare_level_operand(args, function_name, implicit=5)
+        call_args = self.generate_texture_call_args(
+            args, function_name=function_name, implicit=5, explicit=6
+        )
+        offset = call_args.pop()
+        call_args.pop()
+        call_args.append(offset)
+        return "textureSampleCompareLevel(" + ", ".join(call_args) + ")"
+
     def generate_texture_dimensions_call(self, args):
         if len(args) not in {1, 2}:
             raise ValueError(
@@ -1412,6 +1561,42 @@ class WGSLCodeGen:
         raise ValueError(
             "WGSL target cannot infer a companion sampler for texture expression "
             f"{self.generate_expression(texture_expr)}; pass an explicit sampler"
+        )
+
+    def require_depth_texture_operand(self, texture_expr, function_name):
+        texture_type = self.expression_type(texture_expr)
+        if not self.is_depth_texture_type(texture_type):
+            raise ValueError(
+                f"WGSL target requires {function_name}() to use a shadow/depth "
+                "texture resource"
+            )
+
+    def require_comparison_sampler_operand(self, args, function_name, *, implicit):
+        if len(args) == implicit:
+            return
+        if len(args) != implicit + 1:
+            return
+        sampler_type = self.expression_type(args[1])
+        if not self.is_comparison_sampler_type(sampler_type):
+            raise ValueError(
+                f"WGSL target requires {function_name}() explicit sampler operand "
+                "to use samplerComparisonState"
+            )
+
+    def require_zero_compare_level_operand(self, args, function_name, *, implicit):
+        if self.semantic_key(function_name).endswith("offset"):
+            level_index = len(args) - 2
+        else:
+            level_index = len(args) - 1
+        if len(args) <= level_index:
+            return
+        level_expr = args[level_index]
+        if isinstance(level_expr, LiteralNode) and level_expr.value in {0, 0.0}:
+            return
+        raise ValueError(
+            f"WGSL target only lowers {function_name}() when the explicit LOD "
+            "operand is literal 0 because textureSampleCompareLevel samples "
+            "mip level 0"
         )
 
     def pointer_argument_expression(self, pointer_expr):
@@ -1500,11 +1685,11 @@ class WGSLCodeGen:
         if vector_match:
             size = vector_match.group(1)
             element = "f32"
-            if lower.startswith("int"):
+            if lower.startswith(("int", "ivec")):
                 element = "i32"
-            elif lower.startswith("uint"):
+            elif lower.startswith(("uint", "uvec")):
                 element = "u32"
-            elif lower.startswith("bool"):
+            elif lower.startswith(("bool", "bvec")):
                 element = "bool"
             return f"vec{size}<{element}>"
 
@@ -1649,9 +1834,34 @@ class WGSLCodeGen:
             return None
         return self.SAMPLED_TEXTURE_TYPE_MAP.get(type_name)
 
+    def is_depth_texture_type(self, vtype):
+        type_name = self.resource_type_name(vtype)
+        return type_name in {
+            "sampler2darrayshadow",
+            "sampler2dshadow",
+            "samplercubearrayshadow",
+            "samplercubeshadow",
+        }
+
     def is_sampler_type(self, vtype):
         type_name = self.resource_type_name(vtype)
-        return type_name in self.SAMPLER_TYPE_NAMES
+        return (
+            type_name in self.SAMPLER_TYPE_NAMES
+            or type_name in self.COMPARISON_SAMPLER_TYPE_NAMES
+        )
+
+    def is_comparison_sampler_type(self, vtype):
+        return self.resource_type_name(vtype) in self.COMPARISON_SAMPLER_TYPE_NAMES
+
+    def sampler_type(self, vtype):
+        if self.is_comparison_sampler_type(vtype):
+            return "sampler_comparison"
+        return "sampler"
+
+    def companion_sampler_type(self, texture_type):
+        if self.is_depth_texture_type(texture_type):
+            return "sampler_comparison"
+        return "sampler"
 
     def resource_type_name(self, vtype):
         if isinstance(vtype, NamedType) and not vtype.generic_args:
@@ -1862,10 +2072,13 @@ class WGSLCodeGen:
             if sampled_texture_type is not None:
                 declarations.append(f"{binding_name}: {sampled_texture_type}")
                 declarations.append(
-                    f"{self.texture_sampler_name(binding_name)}: sampler"
+                    f"{self.texture_sampler_name(binding_name)}: "
+                    f"{self.companion_sampler_type(info['member_type'])}"
                 )
             elif self.is_sampler_type(info["member_type"]):
-                declarations.append(f"{binding_name}: sampler")
+                declarations.append(
+                    f"{binding_name}: {self.sampler_type(info['member_type'])}"
+                )
         return declarations
 
     def resource_member_call_arguments(self, arg, resource_paths):

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -25,7 +25,7 @@ implicitly supported.
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1093", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "37", "23", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
-   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "54", "58", "WGSL specification; WebGPU specification"
+   "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "58", "58", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "996", "496", "Apple Metal resources; Metal Shading Language specification"
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "997", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "778", "194", "CUDA C++ programming guide"
@@ -40,7 +40,7 @@ implicitly supported.
    "DirectX / HLSL", "65", "0", "2", "0", "0", "0"
    "OpenGL / GLSL", "65", "0", "2", "0", "0", "0"
    "WebGL / GLSL ES", "36", "0", "22", "9", "0", "0"
-   "WebGPU / WGSL", "38", "2", "20", "7", "0", "0"
+   "WebGPU / WGSL", "39", "1", "20", "7", "0", "0"
    "Metal", "64", "0", "3", "0", "0", "0"
    "Vulkan SPIR-V", "65", "0", "2", "0", "0", "0"
    "CUDA", "60", "0", "7", "0", "0", "0"
@@ -133,7 +133,7 @@ Each category below uses the status codes from the legend.
    "Constant/uniform buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Structured/storage buffers", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource arrays", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
-   "Texture and sampler object model", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Texture and sampler object model", "Y", "Y", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "GLSL buffer block lowering", "Y", "Y", "D", "P", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Resource memory qualifiers", "Y", "Y", "D", "D", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
 
@@ -216,7 +216,6 @@ implementation work can be scoped accurately.
 .. csv-table:: Actionable backlog rows
    :header: "Backend", "Category", "Feature", "Status", "Current gap", "Next scope", "Notes"
 
-   "WebGPU / WGSL", "resources", "Texture and sampler object model", "partial", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.", "", "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work."
    "WebGPU / WGSL", "resources", "GLSL buffer block lowering", "partial", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work.", "", "textureSize calls lower to WGSL textureDimensions for sampled texture resources with optional mip-level operands. LOD queries, level-count queries, sample-count queries, storage-image queries, multisample resources, and array/cube-array coordinate-specialization edge cases remain deterministic diagnostics or future work."
 
 Documentation Sources

--- a/support/features.json
+++ b/support/features.json
@@ -2139,10 +2139,14 @@
           ]
         },
         "wgsl": {
-          "status": "partial",
-          "notes": "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.",
+          "status": "supported",
+          "notes": "Covers WGSL split texture and sampler module bindings, automatic companion samplers without binding collisions, explicit sampler operands, helper texture-parameter sampler threading, non-arrayed LOD/gradient/offset call-site sampler threading, depth texture bindings, comparison sampler bindings, and textureCompare lowering with deterministic diagnostics for invalid depth texture or comparison sampler operands. Resource arrays and broader projected/gather/query/multisample texture-operation coverage remain tracked by their dedicated support rows.",
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_split_sampler_lod_grad_and_offset_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_shadow_textures_and_comparison_samplers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_plain_sampler_for_explicit_shadow_compare",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_nonzero_shadow_compare_lod"
           ]
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -493,7 +493,7 @@
         "paths": [
           "tests/test_translator/test_codegen/test_wgsl_codegen.py"
         ],
-        "test_count": 54
+        "test_count": 58
       },
       "translator_codegen": {
         "exists": true,
@@ -1331,15 +1331,6 @@
     }
   ],
   "backlog": [
-    {
-      "backend": "WebGPU / WGSL",
-      "backend_id": "wgsl",
-      "category": "resources",
-      "feature": "Texture and sampler object model",
-      "feature_id": "resources.texture_sampler_split",
-      "notes": "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.",
-      "status": "partial"
-    },
     {
       "backend": "WebGPU / WGSL",
       "backend_id": "wgsl",
@@ -3548,10 +3539,14 @@
         },
         "wgsl": {
           "evidence": [
-            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls"
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_split_sampler_lod_grad_and_offset_calls",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_lowers_shadow_textures_and_comparison_samplers",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_plain_sampler_for_explicit_shadow_compare",
+            "tests/test_translator/test_codegen/test_wgsl_codegen.py::def test_wgsl_codegen_rejects_nonzero_shadow_compare_lod"
           ],
-          "notes": "Explicit textureLod calls lower to WGSL textureSampleLevel for implicit companion samplers and explicit sampler operands. Gradient, bias, offset, projected, shadow-compare, arrayed-resource, and target-invalid coordinate forms remain deterministic diagnostics or future work.",
-          "status": "partial"
+          "notes": "Covers WGSL split texture and sampler module bindings, automatic companion samplers without binding collisions, explicit sampler operands, helper texture-parameter sampler threading, non-arrayed LOD/gradient/offset call-site sampler threading, depth texture bindings, comparison sampler bindings, and textureCompare lowering with deterministic diagnostics for invalid depth texture or comparison sampler operands. Resource arrays and broader projected/gather/query/multisample texture-operation coverage remain tracked by their dedicated support rows.",
+          "status": "supported"
         }
       }
     },
@@ -15259,7 +15254,7 @@
   },
   "summary": {
     "backend_count": 11,
-    "backlog_count": 2,
+    "backlog_count": 1,
     "feature_count": 67,
     "status_counts": {
       "cuda": {
@@ -15344,8 +15339,8 @@
       },
       "wgsl": {
         "diagnostic": 20,
-        "partial": 2,
-        "supported": 38,
+        "partial": 1,
+        "supported": 39,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 7

--- a/tests/test_translator/test_codegen/test_wgsl_codegen.py
+++ b/tests/test_translator/test_codegen/test_wgsl_codegen.py
@@ -1191,6 +1191,144 @@ def test_wgsl_codegen_lowers_texture_helper_parameters_and_lod_size_calls():
     assert "return sampleEnv(envMap, envMap_sampler, normal);" in generated
 
 
+def test_wgsl_codegen_lowers_split_sampler_lod_grad_and_offset_calls():
+    shader = """
+    shader WGSLTextureSamplingForms {
+        sampler2D colorTex;
+        sampler linearSampler;
+        fragment {
+            vec4 main(vec2 uv @ TEXCOORD0) @ gl_FragColor {
+                vec2 ddx = vec2(0.1, 0.0);
+                vec2 ddy = vec2(0.0, 0.1);
+                ivec2 offset = ivec2(1, 0);
+                return textureLodOffset(colorTex, linearSampler, uv, 1.0, offset)
+                    + textureGrad(colorTex, linearSampler, uv, ddx, ddy)
+                    + textureGradOffset(colorTex, linearSampler, uv, ddx, ddy, offset)
+                    + textureOffset(colorTex, linearSampler, uv, offset)
+                    + textureOffset(colorTex, linearSampler, uv, offset, 0.25)
+                    + textureOffset(colorTex, uv, offset, 0.5);
+            }
+        }
+    }
+    """
+
+    generated = WGSLCodeGen().generate(parse_shader(shader))
+
+    assert (
+        "textureSampleLevel(colorTex, linearSampler, uv, 1.0, offset)"
+        in generated
+    )
+    assert "textureSampleGrad(colorTex, linearSampler, uv, ddx, ddy)" in generated
+    assert (
+        "textureSampleGrad(colorTex, linearSampler, uv, ddx, ddy, offset)"
+        in generated
+    )
+    assert "textureSample(colorTex, linearSampler, uv, offset)" in generated
+    assert (
+        "textureSampleBias(colorTex, linearSampler, uv, 0.25, offset)"
+        in generated
+    )
+    assert "textureSampleBias(colorTex, colorTex_sampler, uv, 0.5, offset)" in generated
+
+
+def test_wgsl_codegen_lowers_shadow_textures_and_comparison_samplers():
+    shader = """
+    shader WGSLShadowTexture {
+        sampler2DShadow shadowMap;
+        samplerComparisonState compareSampler;
+        float sampleShadow(sampler2DShadow tex, vec2 uv, float depth) {
+            return textureCompare(tex, uv, depth);
+        }
+        fragment {
+            float main(vec2 uv @ TEXCOORD0) @ gl_FragColor {
+                return textureCompare(shadowMap, compareSampler, uv, 0.5)
+                    + textureCompareOffset(shadowMap, compareSampler, uv, 0.25, ivec2(1, 0))
+                    + textureCompareLod(shadowMap, compareSampler, uv, 0.75, 0)
+                    + textureCompareLodOffset(shadowMap, compareSampler, uv, 0.875, 0, ivec2(0, 1))
+                    + sampleShadow(shadowMap, uv, 0.625);
+            }
+        }
+    }
+    """
+
+    generated = WGSLCodeGen().generate(parse_shader(shader))
+
+    assert "@group(0) @binding(0)\nvar shadowMap: texture_depth_2d;" in generated
+    assert (
+        "@group(0) @binding(1)\nvar shadowMap_sampler: sampler_comparison;"
+        in generated
+    )
+    assert "@group(0) @binding(2)\nvar compareSampler: sampler_comparison;" in generated
+    assert (
+        "fn sampleShadow(tex: texture_depth_2d, tex_sampler: sampler_comparison, "
+        "uv: vec2<f32>, depth: f32) -> f32"
+    ) in generated
+    assert "return textureSampleCompare(tex, tex_sampler, uv, depth);" in generated
+    assert (
+        "textureSampleCompare(shadowMap, compareSampler, uv, 0.5)"
+        in generated
+    )
+    assert (
+        "textureSampleCompare(shadowMap, compareSampler, uv, 0.25, "
+        "vec2<i32>(1, 0))"
+    ) in generated
+    assert (
+        "textureSampleCompareLevel(shadowMap, compareSampler, uv, 0.75)"
+        in generated
+    )
+    assert (
+        "textureSampleCompareLevel(shadowMap, compareSampler, uv, 0.875, "
+        "vec2<i32>(0, 1))"
+    ) in generated
+    assert "sampleShadow(shadowMap, shadowMap_sampler, uv, 0.625)" in generated
+
+
+def test_wgsl_codegen_rejects_plain_sampler_for_explicit_shadow_compare():
+    shader = """
+    shader WGSLBadShadowSampler {
+        sampler2DShadow shadowMap;
+        sampler plainSampler;
+        fragment {
+            float main(vec2 uv @ TEXCOORD0) @ gl_FragColor {
+                return textureCompare(shadowMap, plainSampler, uv, 0.5);
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target requires textureCompare\(\) explicit sampler operand "
+            r"to use samplerComparisonState"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
+def test_wgsl_codegen_rejects_nonzero_shadow_compare_lod():
+    shader = """
+    shader WGSLBadShadowLod {
+        sampler2DShadow shadowMap;
+        samplerComparisonState compareSampler;
+        fragment {
+            float main(vec2 uv @ TEXCOORD0) @ gl_FragColor {
+                return textureCompareLod(shadowMap, compareSampler, uv, 0.5, 1);
+            }
+        }
+    }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WGSL target only lowers textureCompareLod\(\) when the explicit "
+            r"LOD operand is literal 0"
+        ),
+    ):
+        WGSLCodeGen().generate(parse_shader(shader))
+
+
 def test_wgsl_codegen_lowers_mod_builtin_to_floor_semantics_expression():
     shader = """
     shader WGSLModBuiltin {


### PR DESCRIPTION
## Summary
- add WGSL depth texture and comparison sampler declarations for shadow texture resources
- lower split texture/sampler calls for textureLodOffset, textureGrad, textureGradOffset, textureOffset, and textureCompare forms with companion sampler threading
- add deterministic diagnostics for invalid explicit shadow samplers and nonzero compare LODs
- promote the WGSL resources.texture_sampler_split support row to supported and regenerate support artifacts

closes #883

## Tests
- python3.11 -m pytest tests/test_translator/test_codegen/test_wgsl_codegen.py
- python3 tools/support_matrix.py check