### PR TITLE
Lower Mojo sampled texture bindings

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -1555,6 +1555,8 @@ PLACEHOLDER_DIAGNOSTIC_MISSING_CODE = (
 )
 PLACEHOLDER_MISSING_CAPABILITY = "target.native-placeholder-lowering"
 PLACEHOLDER_DIAGNOSTIC_CAPABILITY = "project.placeholder-diagnostics"
+MOJO_RESOURCE_PLACEHOLDER_CAPABILITY = "mojo.resource-binding"
+MOJO_RESOURCE_PLACEHOLDER_KIND = "crossgl-resource-placeholders"
 PLACEHOLDER_MARKER_RULES = (
     (
         "crossgl-builtin-placeholders",
@@ -10714,12 +10716,47 @@ def _artifact_diagnostic_context(artifact: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _generated_placeholder_diagnostic_message(
-    target: str, artifact_path: str, label: str, action: str
+    target: str,
+    artifact_path: str,
+    label: str,
+    action: str,
+    provenance: str = "",
 ) -> str:
     return (
-        f"Generated {target} artifact contains {label}: {artifact_path}. "
+        f"Generated {target} artifact contains {label}: {artifact_path}{provenance}. "
         f"{action}"
     )
+
+
+def _artifact_provenance_message_suffix(artifact: Mapping[str, Any]) -> str:
+    provenance = artifact.get("provenance")
+    if not isinstance(provenance, Mapping):
+        return ""
+    parts = []
+    for field_name in ("pipeline", "intermediate"):
+        value = provenance.get(field_name)
+        if _is_non_empty_string(value):
+            parts.append(f"{field_name}={value}")
+    return f" ({', '.join(parts)})" if parts else ""
+
+
+def _placeholder_marker_missing_capabilities(
+    kind: str, target: str
+) -> list[str]:
+    capabilities = [PLACEHOLDER_MISSING_CAPABILITY, kind]
+    if target == "mojo" and kind == MOJO_RESOURCE_PLACEHOLDER_KIND:
+        capabilities.append(MOJO_RESOURCE_PLACEHOLDER_CAPABILITY)
+    return capabilities
+
+
+def _placeholder_marker_action(kind: str, target: str, action: str) -> str:
+    if target == "mojo" and kind == MOJO_RESOURCE_PLACEHOLDER_KIND:
+        return (
+            "Mojo resource placeholders are compile-only scaffolding for "
+            "resource helpers. Replace them with Mojo-native resource "
+            "bindings or host integration before relying on runtime behavior."
+        )
+    return action
 
 
 def _generated_placeholder_diagnostics_for_artifact(
@@ -10751,15 +10788,17 @@ def _generated_placeholder_diagnostics_for_artifact(
             column = match.start() + 1
             length = max(match.end() - match.start(), 1)
             context = _artifact_diagnostic_context(artifact)
+            target = str(artifact.get("target", ""))
             diagnostics.append(
                 ProjectDiagnostic(
                     severity="warning",
                     code=GENERATED_PLACEHOLDER_DIAGNOSTIC_CODE,
                     message=_generated_placeholder_diagnostic_message(
-                        str(artifact.get("target", "")),
+                        target,
                         str(artifact_path_value),
                         label,
-                        action,
+                        _placeholder_marker_action(kind, target, action),
+                        _artifact_provenance_message_suffix(artifact),
                     ),
                     location=SourceLocation(
                         file=str(artifact_path_value),
@@ -10774,7 +10813,9 @@ def _generated_placeholder_diagnostics_for_artifact(
                     original_location=SourceLocation(
                         file=str(artifact.get("source", ""))
                     ),
-                    missing_capabilities=[PLACEHOLDER_MISSING_CAPABILITY, kind],
+                    missing_capabilities=_placeholder_marker_missing_capabilities(
+                        kind, target
+                    ),
                     **context,
                 )
             )

--- a/crosstl/translator/codegen/mojo_codegen.py
+++ b/crosstl/translator/codegen/mojo_codegen.py
@@ -410,6 +410,12 @@ MOJO_RESOURCE_TYPE_MAPPING = {
     "RayTracingAccelerationStructure": "RayTracingAccelerationStructure",
 }
 
+MOJO_CONCRETE_SAMPLED_TEXTURE_TYPES = frozenset({"Texture2D"})
+MOJO_CONCRETE_RESOURCE_TYPES = frozenset(
+    {"Sampler", *MOJO_CONCRETE_SAMPLED_TEXTURE_TYPES}
+)
+
+
 MOJO_HLSL_WRITABLE_TEXTURE_TYPE_MAPPING = {
     "RWTexture1D": ("Image1D", "IImage1D", "UImage1D"),
     "RWTexture1DArray": ("Image1DArray", "IImage1DArray", "UImage1DArray"),
@@ -1244,6 +1250,7 @@ class MojoCodeGen:
         self.mojo_resource_binding_cursors = {}
         self.mojo_source_resource_bindings = {}
         self.mojo_used_resource_bindings = {}
+        self.mojo_resource_binding_initializers = {}
         self.required_resource_types = set()
         self.required_resource_sample_types = set()
         self.required_resource_sample_sampler_types = set()
@@ -1506,6 +1513,7 @@ class MojoCodeGen:
         self.mojo_resource_binding_cursors = {}
         self.mojo_source_resource_bindings = {}
         self.mojo_used_resource_bindings = {}
+        self.mojo_resource_binding_initializers = {}
         self.required_resource_types = set()
         self.required_resource_sample_types = set()
         self.required_resource_sample_sampler_types = set()
@@ -1641,9 +1649,12 @@ class MojoCodeGen:
                 elif self.is_resource_type_name(vtype):
                     code += resource_comment
                     mapped_type = self.map_type(vtype)
+                    init_value = self.resource_binding_initial_value(
+                        node.name, mapped_type, vtype
+                    )
                     code += (
                         f"var {var_name}: {mapped_type} = "
-                        f"{self.zero_value_for_type(vtype)}\n"
+                        f"{init_value}\n"
                     )
                 else:
                     code += (
@@ -4455,6 +4466,11 @@ class MojoCodeGen:
         memory_qualifiers = self.resource_memory_qualifiers(node)
         if memory_qualifiers:
             parts.append(f"memory={','.join(memory_qualifiers)}")
+        self.mojo_resource_binding_initializers[name] = {
+            "kind": resource_kind,
+            "set": set_index,
+            "binding": binding,
+        }
         return " ".join(parts) + "\n"
 
     def register_resource_access_metadata(self, node, type_name):
@@ -4464,6 +4480,22 @@ class MojoCodeGen:
         access = self.normalized_resource_access_metadata(node)
         if access:
             self.resource_access_qualifiers[name] = access
+
+    def resource_binding_initial_value(self, name, mapped_type, fallback_type):
+        if mapped_type not in MOJO_CONCRETE_RESOURCE_TYPES:
+            return self.zero_value_for_type(fallback_type)
+
+        initializer = self.mojo_resource_binding_initializers.get(name)
+        if not isinstance(initializer, dict):
+            return self.zero_value_for_type(fallback_type)
+
+        set_index = initializer.get("set", 0)
+        binding = initializer.get("binding", 0)
+        if mapped_type == "Texture2D":
+            return f"Texture2D({set_index}, {binding})"
+        if mapped_type == "Sampler":
+            return f"Sampler({set_index}, {binding})"
+        return self.zero_value_for_type(fallback_type)
 
     def register_resource_access_alias_metadata(self, name, type_name, initializer):
         if not name or initializer is None:
@@ -12346,68 +12378,77 @@ class MojoCodeGen:
             or self.required_byte_address_vector_load_helpers
             or self.required_byte_address_vector_store_helpers
         ):
-            code += "# CrossGL resource placeholders\n"
-            for resource_type in sorted(resource_types):
-                code += self.generate_resource_type(resource_type)
-            for buffer_type in sorted(self.required_buffer_resource_types):
-                code += self.generate_buffer_resource_type(buffer_type)
-            for resource_type in sorted(self.required_resource_sample_types):
-                code += self.generate_resource_sample_helper(resource_type)
-            for resource_type in sorted(self.required_resource_sample_sampler_types):
-                code += self.generate_resource_sample_sampler_helper(resource_type)
-            for resource_type in sorted(self.required_resource_lod_types):
-                code += self.generate_resource_lod_helper(resource_type)
-            for resource_type in sorted(self.required_resource_lod_sampler_types):
-                code += self.generate_resource_lod_sampler_helper(resource_type)
-            for resource_type in sorted(self.required_resource_grad_types):
-                code += self.generate_resource_grad_helper(resource_type)
-            for resource_type in sorted(self.required_resource_grad_sampler_types):
-                code += self.generate_resource_grad_sampler_helper(resource_type)
-            if any(
-                helper_name == "texture_size"
-                for helper_name, _resource_type in self.required_resource_size_helpers
-            ):
-                code += self.generate_mip_dimension_helper()
-            for helper_name, resource_type in sorted(
-                self.required_resource_size_helpers
-            ):
-                code += self.generate_resource_size_helper(helper_name, resource_type)
-            for resource_type in sorted(self.required_resource_query_level_types):
-                code += self.generate_resource_query_levels_helper(resource_type)
-            for helper_name, resource_type in sorted(
-                self.required_resource_sample_count_helpers
-            ):
-                code += self.generate_resource_sample_count_helper(
-                    helper_name, resource_type
-                )
-            for resource_type in sorted(self.required_resource_texel_fetch_types):
-                code += self.generate_texel_fetch_helper(resource_type)
-            for resource_type in sorted(
-                self.required_resource_texel_fetch_offset_types
-            ):
-                code += self.generate_texel_fetch_offset_helper(resource_type)
-            for resource_type in sorted(self.required_image_load_types):
-                code += self.generate_image_load_helper(resource_type)
-            for resource_type in sorted(self.required_image_store_types):
-                code += self.generate_image_store_helper(resource_type)
-            for key in sorted(self.required_resource_builtin_helpers):
-                code += self.generate_resource_builtin_helper(
-                    self.required_resource_builtin_helpers[key]
-                )
-            for key in sorted(self.required_buffer_load_helpers):
-                code += self.generate_buffer_load_helper(*key)
-            for key in sorted(self.required_buffer_store_helpers):
-                code += self.generate_buffer_store_helper(*key)
-            for key in sorted(self.required_buffer_append_helpers):
-                code += self.generate_buffer_append_helper(*key)
-            for key in sorted(self.required_buffer_consume_helpers):
-                code += self.generate_buffer_consume_helper(*key)
-            for key in sorted(self.required_buffer_dimensions_helpers):
-                code += self.generate_buffer_dimensions_helper(*key)
-            for key in sorted(self.required_byte_address_vector_load_helpers):
-                code += self.generate_byte_address_vector_load_helper(*key)
-            for key in sorted(self.required_byte_address_vector_store_helpers):
-                code += self.generate_byte_address_vector_store_helper(*key)
+            if self.resource_requirements_use_concrete_bindings(resource_types):
+                code += "# CrossGL resource bindings\n"
+                for resource_type in sorted(resource_types):
+                    code += self.generate_concrete_resource_type(resource_type)
+                for resource_type in sorted(self.required_resource_sample_sampler_types):
+                    code += self.generate_concrete_resource_sample_sampler_helper(
+                        resource_type
+                    )
+            else:
+                code += "# CrossGL resource placeholders\n"
+                for resource_type in sorted(resource_types):
+                    code += self.generate_resource_type(resource_type)
+                for buffer_type in sorted(self.required_buffer_resource_types):
+                    code += self.generate_buffer_resource_type(buffer_type)
+                for resource_type in sorted(self.required_resource_sample_types):
+                    code += self.generate_resource_sample_helper(resource_type)
+                for resource_type in sorted(self.required_resource_sample_sampler_types):
+                    code += self.generate_resource_sample_sampler_helper(resource_type)
+                for resource_type in sorted(self.required_resource_lod_types):
+                    code += self.generate_resource_lod_helper(resource_type)
+                for resource_type in sorted(self.required_resource_lod_sampler_types):
+                    code += self.generate_resource_lod_sampler_helper(resource_type)
+                for resource_type in sorted(self.required_resource_grad_types):
+                    code += self.generate_resource_grad_helper(resource_type)
+                for resource_type in sorted(self.required_resource_grad_sampler_types):
+                    code += self.generate_resource_grad_sampler_helper(resource_type)
+                if any(
+                    helper_name == "texture_size"
+                    for helper_name, _resource_type in self.required_resource_size_helpers
+                ):
+                    code += self.generate_mip_dimension_helper()
+                for helper_name, resource_type in sorted(
+                    self.required_resource_size_helpers
+                ):
+                    code += self.generate_resource_size_helper(helper_name, resource_type)
+                for resource_type in sorted(self.required_resource_query_level_types):
+                    code += self.generate_resource_query_levels_helper(resource_type)
+                for helper_name, resource_type in sorted(
+                    self.required_resource_sample_count_helpers
+                ):
+                    code += self.generate_resource_sample_count_helper(
+                        helper_name, resource_type
+                    )
+                for resource_type in sorted(self.required_resource_texel_fetch_types):
+                    code += self.generate_texel_fetch_helper(resource_type)
+                for resource_type in sorted(
+                    self.required_resource_texel_fetch_offset_types
+                ):
+                    code += self.generate_texel_fetch_offset_helper(resource_type)
+                for resource_type in sorted(self.required_image_load_types):
+                    code += self.generate_image_load_helper(resource_type)
+                for resource_type in sorted(self.required_image_store_types):
+                    code += self.generate_image_store_helper(resource_type)
+                for key in sorted(self.required_resource_builtin_helpers):
+                    code += self.generate_resource_builtin_helper(
+                        self.required_resource_builtin_helpers[key]
+                    )
+                for key in sorted(self.required_buffer_load_helpers):
+                    code += self.generate_buffer_load_helper(*key)
+                for key in sorted(self.required_buffer_store_helpers):
+                    code += self.generate_buffer_store_helper(*key)
+                for key in sorted(self.required_buffer_append_helpers):
+                    code += self.generate_buffer_append_helper(*key)
+                for key in sorted(self.required_buffer_consume_helpers):
+                    code += self.generate_buffer_consume_helper(*key)
+                for key in sorted(self.required_buffer_dimensions_helpers):
+                    code += self.generate_buffer_dimensions_helper(*key)
+                for key in sorted(self.required_byte_address_vector_load_helpers):
+                    code += self.generate_byte_address_vector_load_helper(*key)
+                for key in sorted(self.required_byte_address_vector_store_helpers):
+                    code += self.generate_byte_address_vector_store_helper(*key)
             code += "\n"
 
         if self.required_geometry_stream_helpers:
@@ -12698,19 +12739,137 @@ class MojoCodeGen:
             return self.zero_mojo_value(return_type)
         return "value"
 
+    def resource_requirements_use_concrete_bindings(self, resource_types):
+        if not set(resource_types).issubset(MOJO_CONCRETE_RESOURCE_TYPES):
+            return False
+        if not self.required_resource_sample_sampler_types.issubset(
+            MOJO_CONCRETE_SAMPLED_TEXTURE_TYPES
+        ):
+            return False
+        unsupported_resource_requirements = (
+            self.required_resource_sample_types
+            or self.required_resource_lod_types
+            or self.required_resource_lod_sampler_types
+            or self.required_resource_grad_types
+            or self.required_resource_grad_sampler_types
+            or self.required_resource_size_types
+            or self.required_resource_query_level_types
+            or self.required_resource_sample_count_helpers
+            or self.required_resource_texel_fetch_types
+            or self.required_resource_texel_fetch_offset_types
+            or self.required_image_load_types
+            or self.required_image_store_types
+            or self.required_resource_builtin_helpers
+            or self.required_buffer_resource_types
+            or self.required_buffer_load_helpers
+            or self.required_buffer_store_helpers
+            or self.required_buffer_append_helpers
+            or self.required_buffer_consume_helpers
+            or self.required_buffer_dimensions_helpers
+            or self.required_byte_address_vector_load_helpers
+            or self.required_byte_address_vector_store_helpers
+        )
+        return not unsupported_resource_requirements
+
+    def generate_concrete_resource_type(self, resource_type):
+        if resource_type == "Sampler":
+            return (
+                "@value\n"
+                "struct Sampler:\n"
+                "    var set: Int32\n"
+                "    var binding: Int32\n"
+                "    var linear_filter: Bool\n"
+                "    fn __init__(inout self, set: Int32 = 0, "
+                "binding: Int32 = 0, linear_filter: Bool = False):\n"
+                "        self.set = set\n"
+                "        self.binding = binding\n"
+                "        self.linear_filter = linear_filter\n\n"
+            )
+        if resource_type == "Texture2D":
+            return (
+                "fn _crossgl_texture_coord_index(coord: Float32, extent: Int32) "
+                "-> Int:\n"
+                "    if int(extent) <= 1:\n"
+                "        return 0\n"
+                "    var clamped = coord\n"
+                "    if clamped < 0.0:\n"
+                "        clamped = 0.0\n"
+                "    if clamped >= 1.0:\n"
+                "        clamped = 0.999999\n"
+                "    var index = int(Int32(floor(clamped * Float32(int(extent)))))\n"
+                "    if index < 0:\n"
+                "        return 0\n"
+                "    if index >= int(extent):\n"
+                "        return int(extent) - 1\n"
+                "    return index\n\n"
+                "@value\n"
+                "struct Texture2D:\n"
+                "    var set: Int32\n"
+                "    var binding: Int32\n"
+                "    var width: Int32\n"
+                "    var height: Int32\n"
+                "    var texels: List[SIMD[DType.float32, 4]]\n"
+                "    fn __init__(inout self, set: Int32 = 0, "
+                "binding: Int32 = 0, width: Int32 = 0, height: Int32 = 0, "
+                "owned texels: List[SIMD[DType.float32, 4]] = "
+                "List[SIMD[DType.float32, 4]]()):\n"
+                "        self.set = set\n"
+                "        self.binding = binding\n"
+                "        self.width = width\n"
+                "        self.height = height\n"
+                "        self.texels = texels\n\n"
+                "    fn sample(self, coord: SIMD[DType.float32, 2], "
+                "sampler: Sampler) -> SIMD[DType.float32, 4]:\n"
+                "        if int(self.width) <= 0 or int(self.height) <= 0 "
+                "or self.texels.size == 0:\n"
+                "            return SIMD[DType.float32, 4](0.0, 0.0, 0.0, 1.0)\n"
+                "        var x = _crossgl_texture_coord_index(coord[0], self.width)\n"
+                "        var y = _crossgl_texture_coord_index(coord[1], self.height)\n"
+                "        var index = y * int(self.width) + x\n"
+                "        if index < 0 or index >= self.texels.size:\n"
+                "            return SIMD[DType.float32, 4](0.0, 0.0, 0.0, 1.0)\n"
+                "        return self.texels[index]\n\n"
+            )
+        return self.generate_resource_type(resource_type)
+
+    def generate_concrete_resource_sample_sampler_helper(self, resource_type):
+        coord_type = self.resource_sample_coord_type(resource_type)
+        return_type = self.resource_sample_return_type(resource_type)
+        code = (
+            f"fn sample_sampler(tex: {resource_type}, sampler: Sampler, "
+            f"coord: {coord_type}) -> {return_type}:\n"
+        )
+        code += "    return tex.sample(coord, sampler)\n\n"
+        return code
+
     def generate_resource_type(self, resource_type):
         code = f"@value\nstruct {resource_type}:\n"
+        if resource_type == "Sampler":
+            code += "    var set: Int32\n"
+            code += "    var binding: Int32\n"
+            code += (
+                "    fn __init__(inout self, set: Int32 = 0, "
+                "binding: Int32 = 0):\n"
+            )
+            code += "        self.set = set\n"
+            code += "        self.binding = binding\n\n"
+            return code
         if self.resource_size_return_type(resource_type) is not None:
+            code += "    var set: Int32\n"
+            code += "    var binding: Int32\n"
             code += "    var width: Int32\n"
             code += "    var height: Int32\n"
             code += "    var depth_or_layers: Int32\n"
             code += "    var levels: Int32\n"
             code += "    var samples: Int32\n"
             code += (
-                "    fn __init__(inout self, width: Int32 = 0, "
-                "height: Int32 = 0, depth_or_layers: Int32 = 0, "
-                "levels: Int32 = 1, samples: Int32 = 1):\n"
+                "    fn __init__(inout self, set: Int32 = 0, "
+                "binding: Int32 = 0, width: Int32 = 0, height: Int32 = 0, "
+                "depth_or_layers: Int32 = 0, levels: Int32 = 1, "
+                "samples: Int32 = 1):\n"
             )
+            code += "        self.set = set\n"
+            code += "        self.binding = binding\n"
             code += "        self.width = width\n"
             code += "        self.height = height\n"
             code += "        self.depth_or_layers = depth_or_layers\n"

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -30,7 +30,7 @@ implicitly supported.
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "1003", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "779", "194", "CUDA C++ programming guide"
    "HIP", "", "", ".hip", "crosstl/translator/codegen/hip_codegen.py", "native", "crosstl/backend/HIP", "tests/test_translator/test_codegen/test_hip_codegen.py, tests/test_backend/test_HIP", "828", "136", "ROCm HIP documentation"
-   "Mojo", "", "", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "921", "98", "Mojo manual"
+   "Mojo", "", "", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "922", "100", "Mojo manual"
    "Rust", "", "", ".rs", "crosstl/translator/codegen/rust_codegen.py", "native", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "985", "69", "Rust reference"
    "Slang", "", "", ".slang", "crosstl/translator/codegen/slang_codegen.py", "native", "crosstl/backend/slang", "tests/test_translator/test_codegen/test_slang_codegen.py, tests/test_backend/test_slang", "789", "410", "Slang user guide"
 

--- a/support/features.json
+++ b/support/features.json
@@ -2100,8 +2100,9 @@
         },
         "mojo": {
           "status": "supported",
-          "notes": "Covers separate texture and sampler declarations, split-sampler texture calls through Mojo placeholder helpers, HLSL sampled-texture and sampler-state aliases, shadow sampler result typing, resource-array sampler indexing, independent texture/sampler binding namespaces, and duplicate binding diagnostics within each namespace. Mojo models the CrossGL texture/sampler object contract for compile-smoke output; real GPU sampler filtering and target-native resource binding ABI remain placeholder semantics.",
+          "notes": "Covers separate texture and sampler declarations, concrete Mojo resource-binding scaffolding for HLSL Texture2D.Sample with SamplerState, placeholder helpers for unsupported split-sampler texture shapes, shadow sampler result typing, resource-array sampler indexing, independent texture/sampler binding namespaces, and duplicate binding diagnostics within each namespace. Mojo models the CrossGL texture/sampler object contract for compile-smoke output; advanced sampler filtering and target-native host resource ABI integration remain outside the current scope.",
           "evidence": [
+            "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_resource_placeholders_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_sampled_texture_aliases_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_texture_and_sampler_binding_namespaces_are_independent_for_mojo_codegen",
@@ -2520,8 +2521,10 @@
         },
         "mojo": {
           "status": "supported",
-          "notes": "For the repo-owned compile-oriented Mojo contract, basic sampled texture and shadow-sampler calls lower to compile-smoke placeholder helpers across common dimensions, fixed and unsized arrays, HLSL sampled texture aliases, SamplerState aliases, split-sampler member calls, and independent texture/sampler binding namespaces. The Mojo backend models CrossGL texture call shape rather than target-native sampler filtering semantics.",
+          "notes": "For the repo-owned compile-oriented Mojo contract, HLSL Texture2D.Sample with SamplerState lowers to concrete resource-binding structs with set/binding provenance and a non-placeholder sample method. Other sampled texture and shadow-sampler shapes continue to lower to explicit compile-smoke placeholder helpers across common dimensions, fixed and unsized arrays, HLSL sampled texture aliases, SamplerState aliases, split-sampler member calls, and independent texture/sampler binding namespaces.",
           "evidence": [
+            "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_resource_placeholders_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_sampled_texture_aliases_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_unsized_resource_arrays_use_mojo_lists_bindings_and_compile",

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -995,7 +995,7 @@
         "path": "crosstl/backend/Mojo"
       },
       "signals": {
-        "unsupported_marker_count": 98,
+        "unsupported_marker_count": 100,
         "unsupported_marker_samples": [
           {
             "path": "crosstl/translator/codegen/mojo_codegen.py",
@@ -1088,7 +1088,7 @@
           "tests/test_translator/test_codegen/test_mojo_codegen.py",
           "tests/test_backend/test_mojo"
         ],
-        "test_count": 921
+        "test_count": 922
       },
       "translator_codegen": {
         "exists": true,
@@ -3467,12 +3467,13 @@
         },
         "mojo": {
           "evidence": [
+            "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_resource_placeholders_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_sampled_texture_aliases_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_texture_and_sampler_binding_namespaces_are_independent_for_mojo_codegen",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_shadow_sampler_texture_calls_return_float_and_compile_with_mojo"
           ],
-          "notes": "Covers separate texture and sampler declarations, split-sampler texture calls through Mojo placeholder helpers, HLSL sampled-texture and sampler-state aliases, shadow sampler result typing, resource-array sampler indexing, independent texture/sampler binding namespaces, and duplicate binding diagnostics within each namespace. Mojo models the CrossGL texture/sampler object contract for compile-smoke output; real GPU sampler filtering and target-native resource binding ABI remain placeholder semantics.",
+          "notes": "Covers separate texture and sampler declarations, concrete Mojo resource-binding scaffolding for HLSL Texture2D.Sample with SamplerState, placeholder helpers for unsupported split-sampler texture shapes, shadow sampler result typing, resource-array sampler indexing, independent texture/sampler binding namespaces, and duplicate binding diagnostics within each namespace. Mojo models the CrossGL texture/sampler object contract for compile-smoke output; advanced sampler filtering and target-native host resource ABI integration remain outside the current scope.",
           "status": "supported"
         },
         "opengl": {
@@ -3898,13 +3899,15 @@
         },
         "mojo": {
           "evidence": [
+            "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_resource_placeholders_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_hlsl_sampled_texture_aliases_compile_with_mojo",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_unsized_resource_arrays_use_mojo_lists_bindings_and_compile",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_texture_and_sampler_binding_namespaces_are_independent_for_mojo_codegen",
             "tests/test_translator/test_codegen/test_mojo_codegen.py::def test_shadow_sampler_texture_calls_return_float_and_compile_with_mojo"
           ],
-          "notes": "For the repo-owned compile-oriented Mojo contract, basic sampled texture and shadow-sampler calls lower to compile-smoke placeholder helpers across common dimensions, fixed and unsized arrays, HLSL sampled texture aliases, SamplerState aliases, split-sampler member calls, and independent texture/sampler binding namespaces. The Mojo backend models CrossGL texture call shape rather than target-native sampler filtering semantics.",
+          "notes": "For the repo-owned compile-oriented Mojo contract, HLSL Texture2D.Sample with SamplerState lowers to concrete resource-binding structs with set/binding provenance and a non-placeholder sample method. Other sampled texture and shadow-sampler shapes continue to lower to explicit compile-smoke placeholder helpers across common dimensions, fixed and unsized arrays, HLSL sampled texture aliases, SamplerState aliases, split-sampler member calls, and independent texture/sampler binding namespaces.",
           "status": "supported"
         },
         "opengl": {

--- a/tests/test_translator/test_codegen/test_mojo_codegen.py
+++ b/tests/test_translator/test_codegen/test_mojo_codegen.py
@@ -2877,12 +2877,12 @@ def test_resource_placeholders_emit_for_sampler_types():
     assert "struct Sampler:" in generated_code
     assert "var ramp: Texture1D = Texture1D()" in generated_code
     assert "var lineArray: Texture1DArray = Texture1DArray()" in generated_code
-    assert "var colorMap: Texture2D = Texture2D()" in generated_code
+    assert "var colorMap: Texture2D = Texture2D(0, 2)" in generated_code
     assert "var layerMap: Texture2DArray = Texture2DArray()" in generated_code
     assert "var volumeMap: Texture3D = Texture3D()" in generated_code
     assert "var cubeMap: TextureCube = TextureCube()" in generated_code
     assert "var probeArray: TextureCubeArray = TextureCubeArray()" in generated_code
-    assert "var linearSampler: Sampler = Sampler()" in generated_code
+    assert "var linearSampler: Sampler = Sampler(0, 0)" in generated_code
     assert "fn sample(tex: Texture1D, coord: Float32)" in generated_code
     assert (
         "fn sample(tex: Texture1DArray, coord: SIMD[DType.float32, 2])"
@@ -2941,6 +2941,61 @@ def test_resource_placeholders_emit_for_sampler_types():
     assert "sampler linearSampler" not in generated_code
     assert "textureLod" not in generated_code
     assert "textureGrad" not in generated_code
+
+
+def test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings(tmp_path):
+    mojo = find_mojo_compiler()
+
+    code = """
+    Texture2D g_texture : register(t0);
+    SamplerState g_sampler : register(s0);
+
+    vec4 sampleColor(vec2 uv) {
+        return g_texture.Sample(g_sampler, uv);
+    }
+    """
+    generated_code = generate_code(parse_code(tokenize_code(code)))
+
+    assert "# CrossGL resource bindings" in generated_code
+    assert "# CrossGL resource placeholders" not in generated_code
+    assert "struct Texture2D:" in generated_code
+    assert "struct Sampler:" in generated_code
+    assert "var set: Int32" in generated_code
+    assert "var binding: Int32" in generated_code
+    assert "var texels: List[SIMD[DType.float32, 4]]" in generated_code
+    assert "fn _crossgl_texture_coord_index(coord: Float32, extent: Int32)" in (
+        generated_code
+    )
+    assert "var g_texture: Texture2D = Texture2D(0, 0)" in generated_code
+    assert "var g_sampler: Sampler = Sampler(0, 0)" in generated_code
+    assert "fn sample_sampler(tex: Texture2D, sampler: Sampler" in generated_code
+    assert "return tex.sample(coord, sampler)" in generated_code
+    assert "return SIMD[DType.float32, 4](0.0, 0.0, 0.0, 0.0)" not in generated_code
+    assert "return sample_sampler(g_texture, g_sampler, uv)" in generated_code
+
+    generated_code += """
+fn main():
+    var texels = List[SIMD[DType.float32, 4]]()
+    texels.append(SIMD[DType.float32, 4](1.0, 0.0, 0.0, 1.0))
+    texels.append(SIMD[DType.float32, 4](0.0, 2.0, 0.0, 1.0))
+    texels.append(SIMD[DType.float32, 4](0.0, 0.0, 3.0, 1.0))
+    texels.append(SIMD[DType.float32, 4](4.0, 4.0, 4.0, 1.0))
+    var tex = Texture2D(0, 0, 2, 2, texels)
+    var state = Sampler(0, 0)
+    print(sample_sampler(tex, state, SIMD[DType.float32, 2](0.75, 0.25))[1])
+    print(sample_sampler(tex, state, SIMD[DType.float32, 2](0.25, 0.75))[2])
+"""
+    source_path = tmp_path / "hlsl_texture2d_sampler_bindings.mojo"
+    source_path.write_text(generated_code)
+    result = subprocess.run(
+        [mojo, "run", str(source_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["2.0", "3.0"]
 
 
 def test_mojo_integer_texture_lod_uses_integer_vector_result_types():
@@ -3092,10 +3147,10 @@ def test_hlsl_sampled_texture_aliases_compile_with_mojo(tmp_path):
     assert "struct Sampler:" in generated_code
     assert "struct Texture2D:" in generated_code
     assert "struct Texture2DMS:" in generated_code
-    assert "var colorMap: Texture2D = Texture2D()" in generated_code
+    assert "var colorMap: Texture2D = Texture2D(1, 0)" in generated_code
     assert "var samples: Texture2DMS = Texture2DMS()" in generated_code
-    assert "var linearSampler: Sampler = Sampler()" in generated_code
-    assert "var compareSampler: Sampler = Sampler()" in generated_code
+    assert "var linearSampler: Sampler = Sampler(0, 0)" in generated_code
+    assert "var compareSampler: Sampler = Sampler(0, 1)" in generated_code
     assert (
         "# CrossGL resource metadata: name=linearSampler kind=sampler set=0 "
         "binding=0 binding_source=explicit register=s0" in generated_code
@@ -4919,7 +4974,9 @@ def test_resource_query_helpers_use_mojo_metadata_fields(tmp_path):
     generated_code = generate_code(parse_code(tokenize_code(code)))
 
     assert "struct Texture2D:" in generated_code
-    assert "fn __init__(inout self, width: Int32 = 0" in generated_code
+    assert "fn __init__(inout self, set: Int32 = 0, binding: Int32 = 0" in (
+        generated_code
+    )
     assert "fn _crossgl_mip_dimension(value: Int32, lod: Int32) -> Int32:" in (
         generated_code
     )

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -6580,7 +6580,7 @@ def test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets
             [project]
             source_roots = ["gpu"]
             include = ["gpu/*.hlsl"]
-            targets = ["cgl", "opengl", "metal", "directx", "vulkan"]
+            targets = ["cgl", "opengl", "metal", "directx", "vulkan", "mojo"]
             output_dir = "translated"
             """).strip(),
         encoding="utf-8",
@@ -6604,11 +6604,14 @@ def test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets
     vulkan = (
         repo / "translated" / "vulkan" / "gpu" / "hello_texture.spvasm"
     ).read_text(encoding="utf-8")
+    mojo = (repo / "translated" / "mojo" / "gpu" / "hello_texture.mojo").read_text(
+        encoding="utf-8"
+    )
 
     assert payload["summary"]["unitCount"] == 1
-    assert payload["summary"]["translatedCount"] == 5
+    assert payload["summary"]["translatedCount"] == 6
     assert payload["summary"]["failedCount"] == 0
-    assert len(payload["artifacts"]) == 5
+    assert len(payload["artifacts"]) == 6
 
     assert "PSInput VSMain(vec4 position @ Position, vec2 uv @ TexCoord)" in cgl
     assert "vec4 PSMain(PSInput input) @ gl_FragColor @ stage_entry" in cgl
@@ -6643,6 +6646,29 @@ def test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets
     assert "BuiltIn FragCoord" in vulkan
     assert "OpImageSampleImplicitLod" in vulkan
     assert "WARNING: SPIR-V builtin gl_Position" not in vulkan
+
+    assert "# CrossGL resource bindings" in mojo
+    assert "# CrossGL resource placeholders" not in mojo
+    assert (
+        "# CrossGL resource metadata: name=g_texture kind=texture set=0 "
+        "binding=0 binding_source=explicit register=t0"
+    ) in mojo
+    assert (
+        "# CrossGL resource metadata: name=g_sampler kind=sampler set=0 "
+        "binding=0 binding_source=explicit register=s0"
+    ) in mojo
+    assert "var g_texture: Texture2D = Texture2D(0, 0)" in mojo
+    assert "var g_sampler: Sampler = Sampler(0, 0)" in mojo
+    assert "return sample_sampler(g_texture, g_sampler, input.uv)" in mojo
+    assert not [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"]
+        == project_pipeline.GENERATED_PLACEHOLDER_DIAGNOSTIC_CODE
+        and diagnostic.get("target") == "mojo"
+        and diagnostic["location"]["file"]
+        == "translated/mojo/gpu/hello_texture.mojo"
+    ]
 
     assert_metal_validates_if_available(metal, tmp_path)
     assert_guarded_glsl_validates_if_available(opengl, tmp_path)
@@ -7797,6 +7823,17 @@ def test_translate_project_reports_generated_placeholder_markers(
     assert any(
         "resource placeholders" in diagnostic["message"]
         for diagnostic in placeholder_diagnostics
+    )
+    mojo_resource_diagnostic = next(
+        diagnostic
+        for diagnostic in placeholder_diagnostics
+        if diagnostic["target"] == "mojo"
+        and "resource placeholder prelude" in diagnostic["message"]
+    )
+    assert "pipeline=single-file-translate" in mojo_resource_diagnostic["message"]
+    assert (
+        project_pipeline.MOJO_RESOURCE_PLACEHOLDER_CAPABILITY
+        in mojo_resource_diagnostic["missingCapabilities"]
     )
     assert any(
         "unsupported fallback expression" in diagnostic["message"]


### PR DESCRIPTION
## Summary
- Add concrete Mojo resource-binding lowering for supported HLSL `Texture2D.Sample(SamplerState, uv)` paths: generated `Texture2D`/`Sampler` values preserve set/binding provenance, `Texture2D` stores texels, and `sample()` performs a clamped nearest lookup instead of returning a hardcoded zero.
- Keep explicit `# CrossGL resource placeholders` output for unsupported Mojo resource shapes, while extending the merged generic placeholder diagnostics with Mojo-specific missing capability data and artifact provenance.
- Extend DirectX Hello Texture project coverage to target Mojo and update support metadata for the narrowed supported/placeholder split.

## Validation
- `python3.11 -m pytest tests/test_translator/test_codegen/test_mojo_codegen.py::test_hlsl_texture2d_sampler_uses_concrete_mojo_resource_bindings tests/test_translator/test_codegen/test_mojo_codegen.py::test_resource_placeholders_emit_for_sampler_types tests/test_translator/test_codegen/test_mojo_codegen.py::test_resource_placeholders_compile_with_mojo tests/test_translator/test_codegen/test_mojo_codegen.py::test_hlsl_sampled_texture_aliases_compile_with_mojo tests/test_translator/test_codegen/test_mojo_codegen.py::test_resource_query_helpers_use_mojo_metadata_fields -q`
- `python3.11 -m pytest tests/test_translator/test_project_translation.py::test_translate_project_lowers_hlsl_texture_sampling_pair_to_graphics_targets tests/test_translator/test_project_translation.py::test_translate_project_generates_metal_and_spirv_for_modular_mojo_vector_add tests/test_translator/test_project_translation.py::test_translate_project_reports_generated_placeholder_markers tests/test_translator/test_project_translation.py::test_validate_project_report_fails_placeholder_marker_without_diagnostic tests/test_translator/test_project_translation.py::test_translate_project_batches_real_units_targets_and_variants tests/test_translator/test_project_translation.py::test_project_cli_inspect_report_text_marks_invalid_reports -q`
- `python3.11 -m pytest tests/test_translator/test_codegen/test_mojo_codegen.py -q`
- Equivalent DirectX Hello Texture `translate-project --target mojo --validate --no-format` CLI probe; `rg -n "CrossGL resource placeholders"` returned no matches for the generated Mojo artifact.
- `python3.11 tools/support_matrix.py check`
- `git diff --check origin/main..HEAD`

closes #1050
