### PR TITLE
Fix DirectX specialization constant helper lowering

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -581,6 +581,10 @@ class HLSLCodeGen:
         "nonuniform",
         "nonuniformEXT",
     }
+    # Matches glslang's default resource limit for this built-in constant.
+    HLSL_GLSL_BUILTIN_INT_CONSTANTS = {
+        "gl_MaxImageUnits": 8,
+    }
 
     def __init__(self, target_profile=None):
         """Initialize DirectX type maps and per-generation resource state."""
@@ -1085,6 +1089,9 @@ class HLSLCodeGen:
         self.literal_int_constants = collect_literal_int_constants(
             getattr(ast, "constants", [])
         )
+        self.literal_int_constants.update(
+            self.referenced_hlsl_glsl_builtin_int_constants(ast)
+        )
         self.literal_bool_constants = self.collect_hlsl_literal_bool_constants(
             getattr(ast, "constants", [])
         )
@@ -1363,6 +1370,7 @@ class HLSLCodeGen:
             )
         )
         code += self.generate_constants(ast, leading_constants)
+        code += self.generate_hlsl_glsl_builtin_constant_declarations(ast)
         code += self.generate_hlsl_ordered_struct_declarations(structs)
         code += self.generate_constants(ast, struct_dependent_constants)
         code += generate_enum_constructor_functions(self, self.struct_payload_enums)
@@ -3036,6 +3044,34 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             code += f"static const {declaration} = {value_code};\n"
 
         return f"{code}\n" if code else ""
+
+    def referenced_hlsl_glsl_builtin_int_constants(self, ast):
+        declared_names = {
+            getattr(node, "name", None)
+            for node in getattr(ast, "constants", []) or []
+        }
+        declared_names.update(
+            getattr(node, "name", getattr(node, "variable_name", None))
+            for node in getattr(ast, "global_variables", []) or []
+        )
+        used_names = {
+            getattr(node, "name", None)
+            for node in self.walk_ast(ast)
+            if hasattr(node, "__class__") and "Identifier" in str(node.__class__)
+        }
+        return {
+            name: value
+            for name, value in self.HLSL_GLSL_BUILTIN_INT_CONSTANTS.items()
+            if name in used_names and name not in declared_names
+        }
+
+    def generate_hlsl_glsl_builtin_constant_declarations(self, ast):
+        declarations = []
+        for name, value in sorted(
+            self.referenced_hlsl_glsl_builtin_int_constants(ast).items()
+        ):
+            declarations.append(f"static const int {name} = {value};")
+        return "\n".join(declarations) + "\n\n" if declarations else ""
 
     def generate_constant_expression(self, expr):
         value_code = self.generate_expression(expr)
@@ -13616,6 +13652,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 )
                 if getattr(parameter, "name", None)
             }
+            stage_parameters.update(
+                self.collect_hlsl_stage_entry_local_dependencies(entry_point)
+            )
             parameter_nodes.update(stage_parameters)
 
             stage_functions = list(getattr(stage, "local_functions", []) or [])
@@ -13655,6 +13694,19 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             if dependency_names
         }
 
+    def collect_hlsl_stage_entry_local_dependencies(self, entry_point):
+        dependencies = {}
+        if entry_point is None:
+            return dependencies
+
+        for node in self.hlsl_statement_body_items(getattr(entry_point, "body", [])):
+            if not isinstance(node, VariableNode):
+                continue
+            name = getattr(node, "name", None)
+            if name:
+                dependencies[name] = node
+        return dependencies
+
     def required_hlsl_stage_parameters(self, func_name):
         return self.function_stage_parameter_dependencies.get(func_name, [])
 
@@ -13670,6 +13722,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         )
         param_type = self.directx_resource_declaration_type(param_type)
         param_type = self.apply_hlsl_parameter_qualifiers(param_type, parameter)
+        if isinstance(parameter, VariableNode) and "const" not in getattr(
+            parameter, "qualifiers", []
+        ):
+            param_type = f"inout {param_type}"
         return format_c_style_array_declaration(
             param_type, self.hlsl_declaration_identifier_name(parameter.name)
         )

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1093", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1094", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "69", "69", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1093
+        "test_count": 1094
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -33324,6 +33324,44 @@ def test_hlsl_local_helpers_capture_stage_input_parameters():
     assert "shadow(input.worldPosition.xy, input)" in generated_code
 
 
+def test_hlsl_local_helpers_capture_stage_output_parameters():
+    shader = """
+    shader LocalHelperStageOutputCapture {
+        struct VertexInput {
+            vec4 color;
+        };
+
+        struct VertexOutput {
+            vec4 color;
+            float size;
+        };
+
+        vertex {
+            void accumulate(VertexInput input) {
+                output.color += input.color;
+                output.size += 1.0;
+            }
+
+            VertexOutput main(VertexInput input) {
+                VertexOutput output;
+                output.color = vec4(0.0);
+                output.size = 0.0;
+                accumulate(input);
+                return output;
+            }
+        }
+    }
+    """
+
+    generated_code = generate_code(parse_code(tokenize_code(shader)))
+
+    assert (
+        "void accumulate(VertexInput input, inout VertexOutput output) {"
+        in generated_code
+    )
+    assert "accumulate(input, output);" in generated_code
+
+
 def test_hlsl_compute_builtins_are_auto_parameters_when_referenced_by_name():
     shader = """
     shader ComputeBuiltinAutoParameters {

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -231,6 +231,50 @@ GLSL_FRAGMENT_INVOCATION_DENSITY_SOURCE = textwrap.dedent("""
     }
     """).strip()
 
+GLSLANG_SPEC_CONSTANT_VERTEX_SOURCE = textwrap.dedent("""
+    #version 400
+    layout(constant_id = 16) const int arraySize = 5;
+    in vec4 ucol[arraySize];
+    layout(constant_id = 17) const bool spBool = true;
+    layout(constant_id = 18) const float spFloat = 3.14;
+    layout(constant_id = 19) const double spDouble = 3.1415926535897932384626433832795;
+    layout(constant_id = 22) const uint scale = 2;
+    layout(constant_id = 24) gl_MaxImageUnits;
+    out vec4 color;
+    out int size;
+
+    void foo(vec4 p[arraySize]);
+
+    void main() {
+        color = ucol[2];
+        size = arraySize;
+        if (spBool)
+            color *= scale;
+        color += float(spDouble / spFloat);
+        foo(ucol);
+    }
+
+    layout(constant_id = 116) const int dupArraySize = 12;
+    in vec4 dupUcol[dupArraySize];
+    layout(constant_id = 117) const bool spDupBool = true;
+    layout(constant_id = 118) const float spDupFloat = 3.14;
+    layout(constant_id = 119) const double spDupDouble = 3.1415926535897932384626433832795;
+    layout(constant_id = 122) const uint dupScale = 2;
+
+    void foo(vec4 p[arraySize]) {
+        color += dupUcol[2];
+        size += dupArraySize;
+        if (spDupBool)
+            color *= dupScale;
+        color += float(spDupDouble / spDupFloat);
+    }
+
+    int builtin_spec_constant() {
+        int result = gl_MaxImageUnits;
+        return result;
+    }
+    """).strip()
+
 
 class ProjectPathLike:
     def __init__(self, path):
@@ -535,6 +579,32 @@ def test_translate_project_accepts_path_like_output_dir(tmp_path):
     assert payload["project"]["outputDir"] == str((repo / "translated").resolve())
     assert payload["summary"]["translatedCount"] == 1
     assert (repo / "translated" / "cgl" / "simple.cgl").exists()
+
+
+def test_translate_project_glslang_spec_constant_vertex_to_directx(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "spv.specConstant.vert").write_text(
+        GLSLANG_SPEC_CONSTANT_VERTEX_SOURCE, encoding="utf-8"
+    )
+
+    report = translate_project(
+        repo,
+        targets=["directx"],
+        output_dir="translated",
+        format_output=False,
+    )
+    payload = report.to_json()
+    artifact_path = repo / payload["artifacts"][0]["path"]
+    generated = artifact_path.read_text(encoding="utf-8")
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert "static const int gl_MaxImageUnits = 8;" in generated
+    assert (
+        "void foo(float4 p[arraySize], VertexInput input, "
+        "inout VertexOutput output)"
+    ) in generated
+    assert "foo(input.ucol, input, output);" in generated
 
 
 @pytest.mark.parametrize("target_backend", ("opengl", "metal"))


### PR DESCRIPTION
## Summary
- pass captured DirectX stage output locals into helpers as explicit `inout` parameters
- emit a declared HLSL constant for referenced GLSL built-in specialization constants such as `gl_MaxImageUnits`
- add focused codegen and project translation regressions for the glslang specialization-constant vertex shader shape

## Validation
- `python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_local_helpers_capture_stage_input_parameters tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_local_helpers_capture_stage_output_parameters tests/test_translator/test_project_translation.py::test_translate_project_glslang_spec_constant_vertex_to_directx -q`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- raw Khronos `Test/spv.specConstant.vert` smoke translation confirmed helper output parameter, helper output call argument, and `gl_MaxImageUnits` declaration

closes #1087