### PR TITLE
Add OpenGL Metal matmul target override regression

### DIFF
--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -34621,6 +34621,107 @@ def test_translate_project_metal_matmul_opengl_buffers_before_params_validate(
     assert_compute_glsl_validates_if_available(output, tmp_path)
 
 
+def test_project_cli_metal_matmul_explicit_opengl_target_declares_resources(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "mat_mul_simple1.metal").write_text(
+        textwrap.dedent("""
+            #include <metal_stdlib>
+            using namespace metal;
+
+            struct MatMulParams {
+                uint row_dim_x;
+                uint col_dim_x;
+                uint inner_dim;
+            };
+
+            kernel void mat_mul_simple1(
+                device const float* A [[buffer(0)]],
+                device const float* B [[buffer(1)]],
+                device float* X [[buffer(2)]],
+                constant MatMulParams& params [[buffer(3)]],
+                uint2 id [[thread_position_in_grid]]
+            ) {
+                const uint row_dim_x = params.row_dim_x;
+                const uint col_dim_x = params.col_dim_x;
+                const uint inner_dim = params.inner_dim;
+                uint row = id.y;
+                uint col = id.x;
+                float sum = 0.0;
+
+                if (row < row_dim_x && col < col_dim_x) {
+                    for (uint inner = 0; inner < inner_dim; inner++) {
+                        uint index_A = (row * inner_dim) + inner;
+                        uint index_B = (inner * col_dim_x) + col;
+                        sum += A[index_A] * B[index_B];
+                    }
+
+                    uint index = (row * col_dim_x) + col;
+                    X[index] = sum;
+                }
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report_path = repo / "issue-probe-out" / "report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "translate-project",
+            str(repo),
+            "--output-dir",
+            "issue-probe-out",
+            "--report",
+            str(report_path),
+            "--validate",
+            "--no-format",
+            "--target",
+            "opengl",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "Wrote" in result.stdout
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("opengl", "translated")}
+    assert payload["summary"]["diagnosticCounts"].get("error", 0) == 0
+
+    output_path = repo / "issue-probe-out" / "opengl" / "mat_mul_simple1.glsl"
+    output = output_path.read_text(encoding="utf-8")
+
+    assert (
+        "layout(std430, binding = 0) readonly buffer ABuffer { float A[]; };" in output
+    )
+    assert (
+        "layout(std430, binding = 1) readonly buffer BBuffer { float B[]; };" in output
+    )
+    assert "layout(std430, binding = 2) buffer XBuffer { float X[]; };" in output
+    assert (
+        "layout(std140, binding = 3) uniform MatMulParams {\n"
+        "    uint row_dim_x;\n"
+        "    uint col_dim_x;\n"
+        "    uint inner_dim;\n"
+        "} params;"
+    ) in output
+    assert "const uint row_dim_x = params.row_dim_x;" in output
+    assert "const uint col_dim_x = params.col_dim_x;" in output
+    assert "const uint inner_dim = params.inner_dim;" in output
+    assert "A[index_A]" in output
+    assert "B[index_B]" in output
+    assert "X[index] = sum;" in output
+    assert_compute_glsl_validates_if_available(output, tmp_path)
+
+
 def test_translate_project_metal_matmul_constant_pointer_params_lower_to_resources(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

Add a project CLI regression for the Metal matmul case when OpenGL is requested explicitly with `--target opengl`.

The test drives `python -m crosstl._crosstl translate-project` with `--validate` and `--no-format`, then verifies the generated compute GLSL declares the Metal resources as OpenGL bindings: readonly SSBOs for `A` and `B`, a writable SSBO for `X`, and a std140 uniform block for `params`.

## Context

Issue #1069 reported that the explicit OpenGL project target override could emit a compute shader that referenced `params`, `A`, `B`, and `X` without declarations. On the current mainline resource lowering path, the reduced repro now emits valid declarations and passes `glslangValidator`; this regression locks that behavior to the exact CLI surface from the issue.

## Validation

- `python3.11 -m pytest tests/test_translator/test_project_translation.py::test_project_cli_metal_matmul_explicit_opengl_target_declares_resources -q`
- `python3.11 -m pytest tests/test_translator/test_project_translation.py -k "metal_matmul" -q`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`

closes #1069
