### PR TITLE
Lower unsigned texelFetch for CUDA, HIP, and Slang

### DIFF
--- a/crosstl/translator/codegen/cuda_codegen.py
+++ b/crosstl/translator/codegen/cuda_codegen.py
@@ -6453,6 +6453,24 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             "samplerCubeArrayShadow": "cudaTextureObject_t",
             "sampler2DMS": "cudaTextureObject_t",
             "sampler2DMSArray": "cudaTextureObject_t",
+            "isampler1D": "cudaTextureObject_t",
+            "isampler1DArray": "cudaTextureObject_t",
+            "isampler2D": "cudaTextureObject_t",
+            "isampler3D": "cudaTextureObject_t",
+            "isamplerCube": "cudaTextureObject_t",
+            "isampler2DArray": "cudaTextureObject_t",
+            "isamplerCubeArray": "cudaTextureObject_t",
+            "isampler2DMS": "cudaTextureObject_t",
+            "isampler2DMSArray": "cudaTextureObject_t",
+            "usampler1D": "cudaTextureObject_t",
+            "usampler1DArray": "cudaTextureObject_t",
+            "usampler2D": "cudaTextureObject_t",
+            "usampler3D": "cudaTextureObject_t",
+            "usamplerCube": "cudaTextureObject_t",
+            "usampler2DArray": "cudaTextureObject_t",
+            "usamplerCubeArray": "cudaTextureObject_t",
+            "usampler2DMS": "cudaTextureObject_t",
+            "usampler2DMSArray": "cudaTextureObject_t",
             "image1D": "cudaSurfaceObject_t",
             "image1DArray": "cudaSurfaceObject_t",
             "image2D": "cudaSurfaceObject_t",
@@ -7254,6 +7272,15 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
 
     def resource_call_result_type(self, func_name, raw_args):
         """Infer CUDA-specific resource diagnostic result types."""
+        if func_name in {"texelFetch", "texelFetchOffset"} and raw_args:
+            resource_type = self.resource_base_type(
+                self.resource_expression_type(raw_args[0])
+            )
+            if self.is_shadow_resource_type(resource_type):
+                return "float"
+            if self.is_sampled_texture_family_type(resource_type):
+                return self.sampled_texture_value_type(resource_type)
+
         result_type = super().resource_call_result_type(func_name, raw_args)
         if result_type is not None:
             return result_type
@@ -11008,7 +11035,35 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             coord_type = self.expression_result_type(raw_coord)
         return self.vector_component_count_for_type(coord_type)
 
+    def sampled_texture_shape_type(self, texture_type):
+        """Return the float sampler shape spelling for typed sampled textures."""
+        texture_type = self.resource_base_type(texture_type)
+        if not isinstance(texture_type, str):
+            return None
+        for prefix in ("isampler", "usampler"):
+            if texture_type.startswith(prefix):
+                return f"sampler{texture_type[len(prefix):]}"
+        return texture_type
+
+    def sampled_texture_value_type(self, texture_type):
+        """Return the CUDA vector type read from a sampled texture."""
+        texture_type = self.resource_base_type(texture_type)
+        if isinstance(texture_type, str) and texture_type.startswith("isampler"):
+            return "int4"
+        if isinstance(texture_type, str) and texture_type.startswith("usampler"):
+            return "uint4"
+        return "float4"
+
+    def is_sampled_texture_family_type(self, texture_type):
+        texture_type = self.resource_base_type(texture_type)
+        return (
+            isinstance(texture_type, str)
+            and texture_type != "sampler"
+            and texture_type.startswith(("sampler", "isampler", "usampler"))
+        )
+
     def expected_texel_fetch_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -11018,6 +11073,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         }.get(texture_type)
 
     def expected_texture_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -11055,6 +11111,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         }.get(func_name)
 
     def expected_texture_offset_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 1,
@@ -11081,6 +11138,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         return None
 
     def expected_texture_gradient_coordinate_counts(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": {1},
             "sampler1DArray": {1},
@@ -11117,6 +11175,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         return 0
 
     def cuda_texture_gradient_argument(self, texture_type, raw_gradient, gradient):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         if texture_type not in {"sampler3D", "samplerCube", "samplerCubeArray"}:
             return gradient
 
@@ -11131,6 +11190,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
 
     def cuda_texture_coord_components(self, texture_type, coord):
         """Return CUDA texture coordinate components for a sampled resource."""
+        texture_type = self.sampled_texture_shape_type(texture_type)
         if texture_type == "sampler1D":
             return [coord]
         if texture_type == "sampler1DArray":
@@ -11182,6 +11242,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
 
     def cuda_projected_texture_coord_components(self, texture_type, raw_coord, coord):
         """Return projected CUDA texture coordinate components."""
+        texture_type = self.sampled_texture_shape_type(texture_type)
         coord_count = self.texel_fetch_coordinate_count(raw_coord)
 
         if texture_type == "sampler1D" and coord_count in {2, 4}:
@@ -11332,23 +11393,28 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         self, texture_type, texture_name, components
     ):
         """Return a CUDA texel-fetch expression from precomputed components."""
+        value_type = self.sampled_texture_value_type(texture_type)
+        texture_type = self.sampled_texture_shape_type(texture_type)
         if texture_type == "sampler1D" and len(components) >= 1:
-            return f"tex1Dfetch<float4>({texture_name}, {components[0]})"
+            return f"tex1Dfetch<{value_type}>({texture_name}, {components[0]})"
         if texture_type == "sampler1DArray" and len(components) >= 2:
             return (
-                f"tex1DLayered<float4>"
+                f"tex1DLayered<{value_type}>"
                 f"({texture_name}, {components[0]}, {components[1]})"
             )
         if texture_type == "sampler2D" and len(components) >= 2:
-            return f"tex2D<float4>({texture_name}, {components[0]}, {components[1]})"
+            return (
+                f"tex2D<{value_type}>"
+                f"({texture_name}, {components[0]}, {components[1]})"
+            )
         if texture_type == "sampler2DArray" and len(components) >= 3:
             return (
-                f"tex2DLayered<float4>"
+                f"tex2DLayered<{value_type}>"
                 f"({texture_name}, {components[0]}, {components[1]}, {components[2]})"
             )
         if texture_type == "sampler3D" and len(components) >= 3:
             return (
-                f"tex3D<float4>"
+                f"tex3D<{value_type}>"
                 f"({texture_name}, {components[0]}, {components[1]}, {components[2]})"
             )
         return None
@@ -11608,7 +11674,9 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
         )
         if texture_type is None:
             return None
-        if texture_type is not None and not self.is_sampled_resource_type(texture_type):
+        if texture_type is not None and not self.is_sampled_texture_family_type(
+            texture_type
+        ):
             return self.unsupported_sampled_resource_call(
                 "texelFetchOffset", texture_type, args
             )
@@ -11620,7 +11688,8 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             return self.unsupported_multisample_resource_call(
                 "texelFetchOffset", texture_type, args
             )
-        if texture_type in {"samplerCube", "samplerCubeArray"}:
+        texture_shape = self.sampled_texture_shape_type(texture_type)
+        if texture_shape in {"samplerCube", "samplerCubeArray"}:
             return self.unsupported_sampled_resource_call(
                 "texelFetchOffset", texture_type, args
             )
@@ -11651,7 +11720,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             return offset_diagnostic
 
         components = self.cuda_texture_offset_components(
-            texture_type, args[coord_index], args[offset_index]
+            texture_shape, args[coord_index], args[offset_index]
         )
         if components is None:
             return self.unsupported_sampled_resource_call(
@@ -12200,7 +12269,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             texture_type = self.resource_base_type(
                 self.resource_expression_type(raw_args[0])
             )
-            if texture_type is not None and not self.is_sampled_resource_type(
+            if texture_type is not None and not self.is_sampled_texture_family_type(
                 texture_type
             ):
                 return self.unsupported_sampled_resource_call(
@@ -12214,7 +12283,8 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
                 return self.unsupported_multisample_resource_call(
                     func_name, texture_type, args
                 )
-            if texture_type in {"samplerCube", "samplerCubeArray"}:
+            texture_shape = self.sampled_texture_shape_type(texture_type)
+            if texture_shape in {"samplerCube", "samplerCubeArray"}:
                 return self.unsupported_sampled_resource_call(
                     func_name, texture_type, args
                 )
@@ -12227,7 +12297,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
             texture_name = args[0]
             coord = args[coord_index]
             expected_coord_count = self.expected_texel_fetch_coordinate_count(
-                texture_type
+                texture_shape
             )
             actual_coord_count = self.texel_fetch_coordinate_count(
                 raw_args[coord_index]
@@ -12242,7 +12312,7 @@ class CudaCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticM
                     texture_type,
                     args,
                 )
-            components = self.cuda_texture_coord_components(texture_type, coord)
+            components = self.cuda_texture_coord_components(texture_shape, coord)
             if components is not None:
                 return self.cuda_texel_fetch_call_from_components(
                     texture_type, texture_name, components

--- a/crosstl/translator/codegen/hip_codegen.py
+++ b/crosstl/translator/codegen/hip_codegen.py
@@ -415,6 +415,24 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
             "samplerCubeArrayShadow": "hipTextureObject_t",
             "sampler2DMS": "hipTextureObject_t",
             "sampler2DMSArray": "hipTextureObject_t",
+            "isampler1D": "hipTextureObject_t",
+            "isampler1DArray": "hipTextureObject_t",
+            "isampler2D": "hipTextureObject_t",
+            "isampler3D": "hipTextureObject_t",
+            "isamplerCube": "hipTextureObject_t",
+            "isampler2DArray": "hipTextureObject_t",
+            "isamplerCubeArray": "hipTextureObject_t",
+            "isampler2DMS": "hipTextureObject_t",
+            "isampler2DMSArray": "hipTextureObject_t",
+            "usampler1D": "hipTextureObject_t",
+            "usampler1DArray": "hipTextureObject_t",
+            "usampler2D": "hipTextureObject_t",
+            "usampler3D": "hipTextureObject_t",
+            "usamplerCube": "hipTextureObject_t",
+            "usampler2DArray": "hipTextureObject_t",
+            "usamplerCubeArray": "hipTextureObject_t",
+            "usampler2DMS": "hipTextureObject_t",
+            "usampler2DMSArray": "hipTextureObject_t",
             "image1D": "hipSurfaceObject_t",
             "image1DArray": "hipSurfaceObject_t",
             "image2D": "hipSurfaceObject_t",
@@ -6064,7 +6082,35 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
             coord_type = self.expression_result_type(raw_coord)
         return self.vector_component_count_for_type(coord_type)
 
+    def sampled_texture_shape_type(self, texture_type):
+        """Return the float sampler shape spelling for typed sampled textures."""
+        texture_type = self.resource_base_type(texture_type)
+        if not isinstance(texture_type, str):
+            return None
+        for prefix in ("isampler", "usampler"):
+            if texture_type.startswith(prefix):
+                return f"sampler{texture_type[len(prefix):]}"
+        return texture_type
+
+    def sampled_texture_value_type(self, texture_type):
+        """Return the HIP vector type read from a sampled texture."""
+        texture_type = self.resource_base_type(texture_type)
+        if isinstance(texture_type, str) and texture_type.startswith("isampler"):
+            return "int4"
+        if isinstance(texture_type, str) and texture_type.startswith("usampler"):
+            return "uint4"
+        return "float4"
+
+    def is_sampled_texture_family_type(self, texture_type):
+        texture_type = self.resource_base_type(texture_type)
+        return (
+            isinstance(texture_type, str)
+            and texture_type != "sampler"
+            and texture_type.startswith(("sampler", "isampler", "usampler"))
+        )
+
     def expected_texel_fetch_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -6074,6 +6120,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         }.get(texture_type)
 
     def expected_texture_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -6100,6 +6147,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         return None
 
     def expected_texture_gradient_coordinate_counts(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": {1},
             "sampler1DArray": {1},
@@ -6131,6 +6179,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         return None
 
     def expected_projected_texture_coordinate_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 2,
             "sampler2D": 3,
@@ -6158,6 +6207,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         return None
 
     def projected_coord_args(self, texture_type, texture_name, coord):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         projection_component = {
             "sampler1D": "y",
             "sampler2D": "z",
@@ -6180,6 +6230,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         return ", ".join([texture_name, *projected_components])
 
     def expected_texel_fetch_offset_count(self, texture_type):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 1,
@@ -6210,6 +6261,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         )
 
     def hip_texture_gradient_argument(self, texture_type, raw_gradient, gradient):
+        texture_type = self.sampled_texture_shape_type(texture_type)
         if texture_type not in {"sampler3D", "samplerCube", "samplerCubeArray"}:
             return gradient
 
@@ -6798,7 +6850,7 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
             texture_type = self.resource_base_type(
                 self.get_expression_type(raw_args[0])
             )
-            if texture_type is not None and not self.is_sampled_resource_type(
+            if texture_type is not None and not self.is_sampled_texture_family_type(
                 texture_type
             ):
                 return self.unsupported_sampled_resource_call(
@@ -6812,15 +6864,17 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
                 return self.unsupported_multisample_resource_call(
                     func_name, texture_type, args
                 )
-            if texture_type in {"samplerCube", "samplerCubeArray"}:
+            texture_shape = self.sampled_texture_shape_type(texture_type)
+            if texture_shape in {"samplerCube", "samplerCubeArray"}:
                 return self.unsupported_sampled_resource_call(
                     func_name, texture_type, args
                 )
 
             texture_name = args[0]
             coord = args[1]
+            value_type = self.sampled_texture_value_type(texture_type)
             expected_coord_count = self.expected_texel_fetch_coordinate_count(
-                texture_type
+                texture_shape
             )
             actual_coord_count = self.texel_fetch_coordinate_count(raw_args[1])
             if (
@@ -6833,30 +6887,30 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
                     texture_type,
                     args,
                 )
-            if texture_type == "sampler1D":
-                return f"tex1Dfetch<float4>({texture_name}, {coord})"
-            if texture_type == "sampler1DArray":
+            if texture_shape == "sampler1D":
+                return f"tex1Dfetch<{value_type}>({texture_name}, {coord})"
+            if texture_shape == "sampler1DArray":
                 return (
-                    f"tex1DLayered<float4>({texture_name}, "
+                    f"tex1DLayered<{value_type}>({texture_name}, "
                     f"{self.coord_component(coord, 'x')}, "
                     f"{self.coord_component(coord, 'y')})"
                 )
-            if texture_type == "sampler2D":
+            if texture_shape == "sampler2D":
                 return (
-                    f"tex2D<float4>({texture_name}, "
+                    f"tex2D<{value_type}>({texture_name}, "
                     f"{self.coord_component(coord, 'x')}, "
                     f"{self.coord_component(coord, 'y')})"
                 )
-            if texture_type == "sampler2DArray":
+            if texture_shape == "sampler2DArray":
                 return (
-                    f"tex2DLayered<float4>({texture_name}, "
+                    f"tex2DLayered<{value_type}>({texture_name}, "
                     f"{self.coord_component(coord, 'x')}, "
                     f"{self.coord_component(coord, 'y')}, "
                     f"{self.coord_component(coord, 'z')})"
                 )
-            if texture_type == "sampler3D":
+            if texture_shape == "sampler3D":
                 return (
-                    f"tex3D<float4>({texture_name}, "
+                    f"tex3D<{value_type}>({texture_name}, "
                     f"{self.coord_component(coord, 'x')}, "
                     f"{self.coord_component(coord, 'y')}, "
                     f"{self.coord_component(coord, 'z')})"
@@ -6981,7 +7035,9 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
 
     def generate_texel_fetch_offset_call(self, raw_args, args):
         texture_type = self.resource_base_type(self.get_expression_type(raw_args[0]))
-        if texture_type is not None and not self.is_sampled_resource_type(texture_type):
+        if texture_type is not None and not self.is_sampled_texture_family_type(
+            texture_type
+        ):
             return self.unsupported_sampled_resource_call(
                 "texelFetchOffset", texture_type, args
             )
@@ -6993,7 +7049,8 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
             return self.unsupported_multisample_resource_call(
                 "texelFetchOffset", texture_type, args
             )
-        if texture_type in {"samplerCube", "samplerCubeArray"}:
+        texture_shape = self.sampled_texture_shape_type(texture_type)
+        if texture_shape in {"samplerCube", "samplerCubeArray"}:
             return self.unsupported_sampled_resource_call(
                 "texelFetchOffset", texture_type, args
             )
@@ -7016,30 +7073,31 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         texture_name = args[0]
         coord = args[1]
         offset = args[3]
-        if texture_type == "sampler1D":
-            return f"tex1Dfetch<float4>({texture_name}, ({coord} + {offset}))"
-        if texture_type == "sampler1DArray":
+        value_type = self.sampled_texture_value_type(texture_type)
+        if texture_shape == "sampler1D":
+            return f"tex1Dfetch<{value_type}>({texture_name}, ({coord} + {offset}))"
+        if texture_shape == "sampler1DArray":
             return (
-                f"tex1DLayered<float4>({texture_name}, "
+                f"tex1DLayered<{value_type}>({texture_name}, "
                 f"({self.coord_component(coord, 'x')} + {offset}), "
                 f"{self.coord_component(coord, 'y')})"
             )
-        if texture_type == "sampler2D":
+        if texture_shape == "sampler2D":
             return (
-                f"tex2D<float4>({texture_name}, "
+                f"tex2D<{value_type}>({texture_name}, "
                 f"{self.offset_coord_component(coord, offset, 'x')}, "
                 f"{self.offset_coord_component(coord, offset, 'y')})"
             )
-        if texture_type == "sampler2DArray":
+        if texture_shape == "sampler2DArray":
             return (
-                f"tex2DLayered<float4>({texture_name}, "
+                f"tex2DLayered<{value_type}>({texture_name}, "
                 f"{self.offset_coord_component(coord, offset, 'x')}, "
                 f"{self.offset_coord_component(coord, offset, 'y')}, "
                 f"{self.coord_component(coord, 'z')})"
             )
-        if texture_type == "sampler3D":
+        if texture_shape == "sampler3D":
             return (
-                f"tex3D<float4>({texture_name}, "
+                f"tex3D<{value_type}>({texture_name}, "
                 f"{self.offset_coord_component(coord, offset, 'x')}, "
                 f"{self.offset_coord_component(coord, offset, 'y')}, "
                 f"{self.offset_coord_component(coord, offset, 'z')})"
@@ -9603,6 +9661,15 @@ class HipCodeGen(VectorArithmeticMixin, ResourceQueryMixin, ResourceDiagnosticMi
         return None
 
     def resource_call_result_type(self, func_name, raw_args):
+        if func_name in {"texelFetch", "texelFetchOffset"} and raw_args:
+            resource_type = self.resource_base_type(
+                self.resource_expression_type(raw_args[0])
+            )
+            if self.is_shadow_resource_type(resource_type):
+                return "float"
+            if self.is_sampled_texture_family_type(resource_type):
+                return self.sampled_texture_value_type(resource_type)
+
         if func_name in {
             "textureProj",
             "textureProjLod",

--- a/crosstl/translator/codegen/slang_codegen.py
+++ b/crosstl/translator/codegen/slang_codegen.py
@@ -10354,6 +10354,24 @@ class SlangCodeGen:
             "samplerCubeArray": "SamplerCubeArray<float4>",
             "sampler2DMS": "Sampler2DMS<float4>",
             "sampler2DMSArray": "Sampler2DMSArray<float4>",
+            "isampler1D": "Sampler1D<int4>",
+            "isampler1DArray": "Sampler1DArray<int4>",
+            "isampler2D": "Sampler2D<int4>",
+            "isampler3D": "Sampler3D<int4>",
+            "isamplerCube": "SamplerCube<int4>",
+            "isampler2DArray": "Sampler2DArray<int4>",
+            "isamplerCubeArray": "SamplerCubeArray<int4>",
+            "isampler2DMS": "Sampler2DMS<int4>",
+            "isampler2DMSArray": "Sampler2DMSArray<int4>",
+            "usampler1D": "Sampler1D<uint4>",
+            "usampler1DArray": "Sampler1DArray<uint4>",
+            "usampler2D": "Sampler2D<uint4>",
+            "usampler3D": "Sampler3D<uint4>",
+            "usamplerCube": "SamplerCube<uint4>",
+            "usampler2DArray": "Sampler2DArray<uint4>",
+            "usamplerCubeArray": "SamplerCubeArray<uint4>",
+            "usampler2DMS": "Sampler2DMS<uint4>",
+            "usampler2DMSArray": "Sampler2DMSArray<uint4>",
             "sampler2DShadow": "Sampler2DShadow",
             "sampler2DArrayShadow": "Sampler2DArrayShadow",
             "samplerCubeShadow": "SamplerCubeShadow",
@@ -10652,6 +10670,24 @@ class SlangCodeGen:
             "sampler3D": "Texture3D<float4>",
             "samplerCube": "TextureCube<float4>",
             "samplerCubeArray": "TextureCubeArray<float4>",
+            "isampler1D": "Texture1D<int4>",
+            "isampler1DArray": "Texture1DArray<int4>",
+            "isampler2D": "Texture2D<int4>",
+            "isampler2DArray": "Texture2DArray<int4>",
+            "isampler3D": "Texture3D<int4>",
+            "isamplerCube": "TextureCube<int4>",
+            "isamplerCubeArray": "TextureCubeArray<int4>",
+            "isampler2DMS": "Texture2DMS<int4>",
+            "isampler2DMSArray": "Texture2DMSArray<int4>",
+            "usampler1D": "Texture1D<uint4>",
+            "usampler1DArray": "Texture1DArray<uint4>",
+            "usampler2D": "Texture2D<uint4>",
+            "usampler2DArray": "Texture2DArray<uint4>",
+            "usampler3D": "Texture3D<uint4>",
+            "usamplerCube": "TextureCube<uint4>",
+            "usamplerCubeArray": "TextureCubeArray<uint4>",
+            "usampler2DMS": "Texture2DMS<uint4>",
+            "usampler2DMSArray": "Texture2DMSArray<uint4>",
             "sampler2DShadow": "Texture2D<float>",
             "sampler2DArrayShadow": "Texture2DArray<float>",
             "samplerCubeShadow": "TextureCube<float>",
@@ -12849,13 +12885,14 @@ class SlangCodeGen:
                     return self.unsupported_sampled_texture_call(
                         func_name, offset_reason
                     )
+            texture_type = self.get_expression_type(args[0])
+            result_type = self.sampled_texture_value_type(texture_type)
             expected_reason = self.texture_result_expected_type_unsupported_reason(
-                func_name, "float4"
+                func_name, result_type
             )
             if expected_reason:
                 return self.unsupported_sampled_texture_call(func_name, expected_reason)
             lod_or_sample = self.generate_expression(extra_args[0])
-            texture_type = self.get_expression_type(args[0])
             if self.is_multisample_sampler_type(texture_type):
                 return f"{texture_name}[{coord}, {lod_or_sample}]"
             coord_constructor = self.texel_fetch_coord_constructor(texture_type)
@@ -14124,6 +14161,7 @@ class SlangCodeGen:
         return info["size"]
 
     def sampled_texture_coordinate_rank(self, resource_type):
+        resource_type = self.sampled_texture_shape_type(resource_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -14135,6 +14173,7 @@ class SlangCodeGen:
         }.get(resource_type)
 
     def texel_fetch_coordinate_rank(self, resource_type):
+        resource_type = self.sampled_texture_shape_type(resource_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 2,
@@ -14146,6 +14185,7 @@ class SlangCodeGen:
         }.get(resource_type)
 
     def texture_offset_rank(self, resource_type):
+        resource_type = self.sampled_texture_shape_type(resource_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 1,
@@ -14155,6 +14195,7 @@ class SlangCodeGen:
         }.get(resource_type)
 
     def texture_gradient_rank(self, resource_type):
+        resource_type = self.sampled_texture_shape_type(resource_type)
         return {
             "sampler1D": 1,
             "sampler1DArray": 1,
@@ -14166,6 +14207,7 @@ class SlangCodeGen:
         }.get(resource_type)
 
     def gather_offset_rank(self, resource_type):
+        resource_type = self.sampled_texture_shape_type(resource_type)
         return {
             "sampler2D": 2,
             "sampler2DArray": 2,
@@ -14555,11 +14597,28 @@ class SlangCodeGen:
             and "Shadow" not in resource_type
         )
 
+    def sampled_texture_shape_type(self, type_name):
+        resource_type = self.resource_base_type(type_name)
+        if not isinstance(resource_type, str):
+            return None
+        for prefix in ("isampler", "usampler"):
+            if resource_type.startswith(prefix):
+                return f"sampler{resource_type[len(prefix):]}"
+        return resource_type
+
+    def sampled_texture_value_type(self, type_name):
+        resource_type = self.resource_base_type(type_name)
+        if isinstance(resource_type, str) and resource_type.startswith("isampler"):
+            return "int4"
+        if isinstance(resource_type, str) and resource_type.startswith("usampler"):
+            return "uint4"
+        return "float4"
+
     def is_sampled_texture_resource_type(self, type_name):
         resource_type = self.resource_base_type(type_name)
         return (
             isinstance(resource_type, str)
-            and resource_type.startswith("sampler")
+            and resource_type.startswith(("sampler", "isampler", "usampler"))
             and resource_type != "sampler"
         )
 
@@ -14589,13 +14648,13 @@ class SlangCodeGen:
         return type_name.split("[", 1)[0]
 
     def is_multisample_sampler_type(self, type_name):
-        return self.resource_base_type(type_name) in {
+        return self.sampled_texture_shape_type(type_name) in {
             "sampler2DMS",
             "sampler2DMSArray",
         }
 
     def is_texel_fetch_sampler_type(self, type_name):
-        return self.resource_base_type(type_name) in {
+        return self.sampled_texture_shape_type(type_name) in {
             "sampler1D",
             "sampler1DArray",
             "sampler2D",
@@ -14606,7 +14665,7 @@ class SlangCodeGen:
         }
 
     def is_texel_fetch_offset_sampler_type(self, type_name):
-        return self.resource_base_type(type_name) in {
+        return self.sampled_texture_shape_type(type_name) in {
             "sampler1D",
             "sampler1DArray",
             "sampler2D",
@@ -14615,7 +14674,7 @@ class SlangCodeGen:
         }
 
     def texel_fetch_coord_constructor(self, type_name):
-        base_type = self.resource_base_type(type_name)
+        base_type = self.sampled_texture_shape_type(type_name)
         if base_type in {"sampler1D", "sampler1DArray"}:
             return "int2" if base_type == "sampler1D" else "int3"
         if base_type in {"sampler3D", "sampler2DArray"}:

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -6912,6 +6912,94 @@ def test_translate_project_glsl_alpha_stitch_storage_image_lowers_to_wgsl(
     }
 
 
+def test_translate_project_glsl_usampler_texel_fetch_lowers_to_cuda_hip_slang(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "alpha_stitch.glsl").write_text(
+        textwrap.dedent("""
+            #version 450
+            layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+            layout(binding = 0) uniform usampler2D srcRGB;
+            layout(binding = 1) uniform usampler2D srcAlpha;
+            layout(binding = 2, rgba32ui) uniform restrict writeonly uimage2D dstTexture;
+
+            void main() {
+                uvec2 rgbBlock = texelFetch(
+                    srcRGB,
+                    ivec2(gl_GlobalInvocationID.xy),
+                    0
+                ).xy;
+                uvec2 alphaBlock = texelFetch(
+                    srcAlpha,
+                    ivec2(gl_GlobalInvocationID.xy),
+                    0
+                ).xy;
+                imageStore(
+                    dstTexture,
+                    ivec2(gl_GlobalInvocationID.xy),
+                    uvec4(rgbBlock.xy, alphaBlock.xy)
+                );
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["cuda", "hip", "slang"],
+        output_dir="out",
+    ).to_json()
+
+    assert payload["summary"]["translatedCount"] == 3
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
+    assert payload["summary"]["missingCapabilityCounts"] == {}
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {
+        ("cuda", "translated"),
+        ("hip", "translated"),
+        ("slang", "translated"),
+    }
+
+    cuda = (repo / "out" / "cuda" / "alpha_stitch.cu").read_text(
+        encoding="utf-8"
+    )
+    hip = (repo / "out" / "hip" / "alpha_stitch.hip").read_text(encoding="utf-8")
+    slang = (repo / "out" / "slang" / "alpha_stitch.slang").read_text(
+        encoding="utf-8"
+    )
+
+    assert "cudaTextureObject_t srcRGB;" in cuda
+    assert "cudaTextureObject_t srcAlpha;" in cuda
+    assert "tex2D<uint4>(srcRGB" in cuda
+    assert "tex2D<uint4>(srcAlpha" in cuda
+    assert "cgl_uint2_construct_uint4_xy" in cuda
+    assert "cgl_uint2_construct_float4_xy" not in cuda
+    assert "unsupported CUDA sampled resource call: texelFetch" not in cuda
+
+    assert "hipTextureObject_t srcRGB;" in hip
+    assert "hipTextureObject_t srcAlpha;" in hip
+    assert "tex2D<uint4>(srcRGB" in hip
+    assert "tex2D<uint4>(srcAlpha" in hip
+    assert "cgl_uint2_construct_uint4_xy" in hip
+    assert "cgl_uint2_construct_float4_xy" not in hip
+    assert "unsupported HIP sampled resource call: texelFetch" not in hip
+
+    assert "Sampler2D<uint4> srcRGB" in slang
+    assert "Sampler2D<uint4> srcAlpha" in slang
+    assert "srcRGB.Load(int3(" in slang
+    assert "srcAlpha.Load(int3(" in slang
+    assert "float4(0.0)" not in slang
+    assert "unsupported Slang sampled texture: texelFetch" not in slang
+
+    for generated in (cuda, hip, slang):
+        assert "usampler2D srcRGB" not in generated
+        assert "usampler2D srcAlpha" not in generated
+
+
 def test_translate_project_preserves_anonymous_glsl_ssbo_shape_for_targets(tmp_path):
     repo = tmp_path / "repo"
     shader_dir = repo / "gpu"


### PR DESCRIPTION
## Summary
- Map GLSL integer sampled textures to CUDA/HIP texture objects and Slang typed sampler resources.
- Lower `usampler*` texel fetches to typed CUDA/HIP texture reads and Slang `Load` calls while preserving unsigned vector results.
- Add project translation coverage for alpha-stitch-style `usampler2D` texel fetches across CUDA, HIP, and Slang.

## Validation
- `python3.11 -m pytest tests/test_translator/test_project_translation.py::test_translate_project_glsl_usampler_texel_fetch_lowers_to_uint_spirv tests/test_translator/test_project_translation.py::test_translate_project_glsl_alpha_stitch_storage_image_lowers_to_wgsl tests/test_translator/test_project_translation.py::test_translate_project_glsl_usampler_texel_fetch_lowers_to_cuda_hip_slang`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- Ran an equivalent alpha-stitch-style project translation for CUDA, HIP, and Slang; the referenced demo directory is not present in this checkout.

closes #1053
