### PR TITLE
Fix OpenGL Rust Option helper lowering

### DIFF
--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -1570,6 +1570,83 @@ class GLSLCodeGen:
         """Generate GLSL source for a single requested shader stage."""
         return self.generate_program(ast, target_stage=shader_type)
 
+    def with_glsl_builtin_option_prelude(self, ast):
+        if not self.glsl_ast_needs_builtin_option(ast):
+            return ast
+        if self.glsl_ast_declares_type(ast, "Option"):
+            return ast
+
+        ast = deepcopy(ast)
+        prelude_ast = self.parse_glsl_builtin_option_prelude()
+        ast.structs = list(getattr(prelude_ast, "structs", []) or []) + list(
+            getattr(ast, "structs", []) or []
+        )
+        ast.functions = list(getattr(prelude_ast, "functions", []) or []) + list(
+            getattr(ast, "functions", []) or []
+        )
+        return ast
+
+    def parse_glsl_builtin_option_prelude(self):
+        from ..lexer import Lexer
+        from ..parser import Parser
+
+        source = """
+        shader OpenGLBuiltinOption {
+            generic<T> struct Option {
+                enum OptionType { Some(T), None }
+                OptionType variant;
+            }
+
+            generic<T> bool is_Some(Option<T> item) {
+                return item.variant == Option::Some;
+            }
+
+            generic<T> bool is_None(Option<T> item) {
+                return item.variant == Option::None;
+            }
+
+            generic<T> T unwrap_Some(Option<T> item) {
+                return item.Some_0;
+            }
+        }
+        """
+        return Parser(Lexer(source).tokens).parse()
+
+    def glsl_ast_declares_type(self, ast, type_name):
+        return any(
+            getattr(struct, "name", None) == type_name
+            for struct in getattr(ast, "structs", []) or []
+        )
+
+    def glsl_ast_needs_builtin_option(self, ast):
+        option_helpers = {"is_Some", "is_None", "unwrap_Some"}
+        for node in self.walk_ast(ast):
+            if self.glsl_node_type_uses_builtin_option(node):
+                return True
+            if self.function_call_name(node) in option_helpers:
+                return True
+        return False
+
+    def glsl_node_type_uses_builtin_option(self, node):
+        for attr in (
+            "return_type",
+            "param_type",
+            "var_type",
+            "vtype",
+            "member_type",
+            "const_type",
+            "constructor_type",
+        ):
+            if self.glsl_type_uses_builtin_option(getattr(node, attr, None)):
+                return True
+        return False
+
+    def glsl_type_uses_builtin_option(self, type_value):
+        type_name = self.type_name_string(type_value)
+        return isinstance(type_name, str) and re.search(
+            r"(?:^|::|\b)Option\s*<", type_name
+        )
+
     def glsl_stage_names(self, ast, target_stage=None):
         stage_names = set()
 
@@ -2365,6 +2442,8 @@ class GLSLCodeGen:
 
     def generate_program(self, ast, target_stage=None):
         """Render an AST to GLSL, optionally filtering stage entry points."""
+        ast = self.with_glsl_builtin_option_prelude(ast)
+        self.glsl_builtin_option_available = self.glsl_ast_declares_type(ast, "Option")
         target_stage = normalize_stage_name(target_stage)
         self.validate_stage_main_helper_conflict(ast, target_stage)
 
@@ -8799,9 +8878,13 @@ class GLSLCodeGen:
         var_type = getattr(stmt, "var_type", None)
         if var_type is None:
             var_type = getattr(stmt, "vtype", None)
-        if var_type is None:
-            var_type = self.expression_result_type(getattr(stmt, "initial_value", None))
-        return self.type_name_string(var_type) or "float"
+        var_type_name = self.type_name_string(var_type)
+        if var_type_name in {None, "auto"}:
+            inferred_type = self.expression_result_type(
+                getattr(stmt, "initial_value", None)
+            )
+            return self.type_name_string(inferred_type) or "float"
+        return var_type_name
 
     def glsl_parameter_identifier_name(self, name, parameter_names=None):
         if (
@@ -10551,11 +10634,49 @@ class GLSLCodeGen:
             return "gl_VertexID"
         return name
 
+    def is_glsl_builtin_option_none_expression(self, expr):
+        if not getattr(self, "glsl_builtin_option_available", False):
+            return False
+        if isinstance(expr, str):
+            return expr == "None"
+        return getattr(expr, "name", None) == "None"
+
+    def glsl_builtin_option_constructor_name(self, func_name):
+        if not getattr(self, "glsl_builtin_option_available", False):
+            return func_name
+        if func_name == "Some":
+            return "Option::Some"
+        if func_name == "None":
+            return "Option::None"
+        return func_name
+
+    def generate_glsl_builtin_option_none_value(self):
+        if not getattr(self, "glsl_builtin_option_available", False):
+            return None
+        return generate_enum_constructor_call(self, "Option::None", [])
+
+    def generate_glsl_builtin_option_none_comparison(self, left, op, right):
+        if op not in {"==", "!="}:
+            return None
+        left_is_none = self.is_glsl_builtin_option_none_expression(left)
+        right_is_none = self.is_glsl_builtin_option_none_expression(right)
+        if left_is_none == right_is_none:
+            return None
+
+        subject = right if left_is_none else left
+        subject_expr = self.generate_expression(subject)
+        operator = "==" if op == "==" else "!="
+        return f"({subject_expr}.variant {operator} Option_None)"
+
     def generate_expression(self, expr, is_main=False):
         """Render a CrossGL AST expression into GLSL expression syntax."""
         if expr is None:
             return ""
         if isinstance(expr, str):
+            if self.is_glsl_builtin_option_none_expression(expr):
+                none_value = self.generate_glsl_builtin_option_none_value()
+                if none_value is not None:
+                    return none_value
             return expr
         elif isinstance(expr, (int, float, bool)):
             if isinstance(expr, bool):
@@ -10563,6 +10684,10 @@ class GLSLCodeGen:
             return str(expr)
         elif hasattr(expr, "__class__") and "VariableNode" in str(type(expr)):
             if hasattr(expr, "name"):
+                if self.is_glsl_builtin_option_none_expression(expr):
+                    none_value = self.generate_glsl_builtin_option_none_value()
+                    if none_value is not None:
+                        return none_value
                 if expr.name in self.current_resource_aliases:
                     return self.current_resource_aliases[expr.name]["expression"]
                 if expr.name in getattr(self, "enum_variant_constants", {}):
@@ -10575,6 +10700,10 @@ class GLSLCodeGen:
             else:
                 return str(expr)
         elif hasattr(expr, "__class__") and "IdentifierNode" in str(type(expr)):
+            if self.is_glsl_builtin_option_none_expression(expr):
+                none_value = self.generate_glsl_builtin_option_none_value()
+                if none_value is not None:
+                    return none_value
             if expr.name in self.current_resource_aliases:
                 return self.current_resource_aliases[expr.name]["expression"]
             if expr.name in getattr(self, "enum_variant_constants", {}):
@@ -10606,6 +10735,11 @@ class GLSLCodeGen:
             return str(expr.value)
         elif hasattr(expr, "__class__") and "BinaryOpNode" in str(type(expr)):
             op = self.map_operator(expr.op)
+            option_none_comparison = self.generate_glsl_builtin_option_none_comparison(
+                expr.left, op, expr.right
+            )
+            if option_none_comparison is not None:
+                return option_none_comparison
             vector_relational = self.generate_vector_relational_expression(
                 expr.left, op, expr.right
             )
@@ -10705,6 +10839,12 @@ class GLSLCodeGen:
             else:
                 callee = self.generate_expression(func_expr)
             original_func_name = func_name
+            original_func_name = self.glsl_builtin_option_constructor_name(
+                original_func_name
+            )
+            if original_func_name != func_name:
+                func_name = original_func_name
+                callee = original_func_name
 
             mesh_output_counts_call = self.generate_mesh_output_counts_call(
                 original_func_name, expr.args

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -31,7 +31,7 @@ implicitly supported.
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "779", "194", "CUDA C++ programming guide"
    "HIP", "", "", ".hip", "crosstl/translator/codegen/hip_codegen.py", "native", "crosstl/backend/HIP", "tests/test_translator/test_codegen/test_hip_codegen.py, tests/test_backend/test_HIP", "828", "136", "ROCm HIP documentation"
    "Mojo", "", "", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "921", "98", "Mojo manual"
-   "Rust", "", "", ".rs", "crosstl/translator/codegen/rust_codegen.py", "native", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "984", "69", "Rust reference"
+   "Rust", "", "", ".rs", "crosstl/translator/codegen/rust_codegen.py", "native", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "985", "69", "Rust reference"
    "Slang", "", "", ".slang", "crosstl/translator/codegen/slang_codegen.py", "native", "crosstl/backend/slang", "tests/test_translator/test_codegen/test_slang_codegen.py, tests/test_backend/test_slang", "789", "410", "Slang user guide"
 
 .. csv-table:: Summary by backend

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -1205,7 +1205,7 @@
           "tests/test_translator/test_codegen/test_rust_codegen.py",
           "tests/test_backend/test_rust"
         ],
-        "test_count": 984
+        "test_count": 985
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_backend/test_rust/test_codegen.py
+++ b/tests/test_backend/test_rust/test_codegen.py
@@ -7841,6 +7841,52 @@ def test_option_result_constructor_conversion():
         pytest.fail(f"Option/Result constructor conversion failed: {e}")
 
 
+def test_option_constructors_lower_to_specialized_opengl_helpers(tmp_path):
+    code = """
+    fn collatz(n: u32) -> Option<u32> {
+        if n == 0u32 {
+            return None;
+        }
+        return Some(n);
+    }
+
+    fn read_option(item: Option<u32>) -> u32 {
+        match item {
+            Some(value) => { return value; },
+            None => { return 0u32; }
+        }
+    }
+
+    #[spirv(compute(threads(1, 1, 1)))]
+    pub fn main() {
+        let value = read_option(collatz(7u32));
+    }
+    """
+    rust_file = tmp_path / "collatz.rs"
+    rust_file.write_text(code, encoding="utf-8")
+
+    result = crosstl.translate(
+        str(rust_file),
+        backend="opengl",
+        source_backend="rust",
+        format_output=False,
+    )
+
+    assert "struct Option_u32" in result
+    assert "Option_u32 collatz(uint n)" in result
+    assert "return Option_u32_None_make();" in result
+    assert "return Option_u32_Some_make(n);" in result
+    assert "is_Some_u32(item)" in result
+    assert "(item.variant == Option_None)" in result
+    assert "uint value = unwrap_Some_u32(item);" in result
+    assert "Option<" not in result
+    assert "Option::" not in result
+    assert re.search(r"\bSome\s*\(", result) is None
+    assert "return None;" not in result
+    assert "== None" not in result
+    assert "auto value" not in result
+
+
 def test_option_result_payload_match_conversion():
     code = """
     fn test_payload_match(maybe: Option<i32>, result: Result<i32, i32>) -> i32 {

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -11155,6 +11155,64 @@ def test_translate_project_hip_bit_extract_artifacts_bind_scalar_and_skip_host_m
     assert re.search(r"OpDecorate %\d+ Binding 2", spirv_output)
 
 
+def test_translate_project_rust_option_helpers_lower_to_opengl_compute(tmp_path):
+    repo = tmp_path / "repo"
+    source_dir = repo / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "collatz.rs").write_text(
+        textwrap.dedent("""
+            fn collatz(n: u32) -> Option<u32> {
+                if n == 0u32 {
+                    return None;
+                }
+                return Some(n);
+            }
+
+            fn read_option(item: Option<u32>) -> u32 {
+                match item {
+                    Some(value) => { return value; },
+                    None => { return 0u32; }
+                }
+            }
+
+            #[spirv(compute(threads(1, 1, 1)))]
+            pub fn main() {
+                let value = read_option(collatz(7u32));
+            }
+            """).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["src"]
+            targets = ["opengl"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    opengl_output = (
+        repo / "translated" / "opengl" / "src" / "collatz.glsl"
+    ).read_text(encoding="utf-8")
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert "struct Option_u32" in opengl_output
+    assert "Option_u32 collatz(uint n)" in opengl_output
+    assert "uint value = unwrap_Some_u32(item);" in opengl_output
+    assert "(item.variant == Option_None)" in opengl_output
+    assert "Option<" not in opengl_output
+    assert "Option::" not in opengl_output
+    assert re.search(r"\bSome\s*\(", opengl_output) is None
+    assert "return None;" not in opengl_output
+    assert "== None" not in opengl_output
+    assert "auto value" not in opengl_output
+    assert_compute_glsl_validates_if_available(opengl_output, tmp_path)
+
+
 def test_validate_project_report_rejects_artifacts_with_undeclared_variants(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- synthesize a GLSL-only generic Option prelude when Rust-style Option helper syntax reaches OpenGL output
- lower bare Some/None usage to specialized GLSL constructors or enum tag checks
- infer OpenGL local types for CrossGL auto bindings produced by Rust match payload lowering
- add focused Rust-to-OpenGL and project translation coverage for the Collatz Option repro

## Validation
- python3.11 -m pytest tests/test_backend/test_rust/test_codegen.py -q
- python3.11 -m pytest tests/test_backend/test_rust/test_codegen.py::test_option_constructors_lower_to_specialized_opengl_helpers tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_opengl_compute tests/test_translator/test_codegen/test_GLSL_codegen.py::test_generic_enum_struct_concrete_match_and_constructors -q
- python3.11 tools/support_matrix.py check
- git diff --check HEAD~1..HEAD
- repro output validated with glslangValidator -S comp

closes #1071