### PR TITLE
Fix DirectX GLSL location semantics

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -12765,7 +12765,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         used_semantics = set()
         for member in getattr(struct_node, "members", []) or []:
             semantic = self.hlsl_struct_member_declared_semantic(member)
-            if semantic is not None:
+            if (
+                semantic is not None
+                and self.hlsl_location_attribute_index(member) is None
+            ):
                 used_semantics.add(self.hlsl_semantic_key(semantic))
 
         defaults = {}
@@ -12792,13 +12795,18 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             member_name = getattr(member, "name", None)
             if not member_name or member_name in defaults:
                 continue
-            if self.hlsl_struct_member_declared_semantic(member) is not None:
+
+            declared_semantic = self.hlsl_struct_member_declared_semantic(member)
+            location_index = self.hlsl_location_attribute_index(member)
+            if declared_semantic is not None and location_index is None:
                 continue
             if not self.hlsl_can_default_fragment_input_semantic(
                 self.hlsl_struct_member_type_name(member)
             ):
                 continue
 
+            if location_index is not None:
+                next_texcoord = location_index
             while self.hlsl_semantic_key(f"TEXCOORD{next_texcoord}") in used_semantics:
                 next_texcoord += 1
             semantic = f"TEXCOORD{next_texcoord}"

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1094", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1095", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1184", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "69", "69", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1094
+        "test_count": 1095
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -289,6 +289,37 @@ def test_glsl_vertex_output_locations_lower_to_distinct_hlsl_semantics(tmp_path)
     assert generated_code.count(": TEXCOORD1") == 1
 
 
+def test_glsl_vertex_input_locations_lower_to_distinct_hlsl_semantics(tmp_path):
+    shader = """
+    #version 450
+    layout(location = 0) in vec4 inPosition;
+    layout(location = 1) in vec3 inNormal;
+    layout(location = 2) in vec2 inUV;
+    layout(location = 0) out vec2 outUV;
+
+    void main() {
+        outUV = inUV;
+        gl_Position = inPosition;
+    }
+    """
+    shader_path = tmp_path / "conservative.vert"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="opengl",
+    )
+
+    assert "float4 inPosition: TEXCOORD0;" in generated_code
+    assert "float3 inNormal: TEXCOORD1;" in generated_code
+    assert "float2 inUV: TEXCOORD2;" in generated_code
+    assert "float2 outUV: TEXCOORD0;" in generated_code
+    assert "float4 gl_Position: SV_POSITION;" in generated_code
+    assert ": location" not in generated_code
+
+
 def test_directx_user_defined_synchronization_names_are_not_lowered():
     shader = """
     shader SynchronizationShadowing {


### PR DESCRIPTION
## Summary
- Map GLSL `layout(location = N)` vertex inputs to distinct HLSL `TEXCOORDN` semantics instead of emitting raw `: location`.
- Keep GLSL vertex `gl_Position` output on `SV_POSITION` in the reduced vertex IO regression.
- Refresh the generated DirectX support-matrix test count after adding coverage.

## Tests
- `python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py -q`
- `python3.11 tools/support_matrix.py check`
- `git diff --check origin/main..HEAD`

closes #1097
