### PR TITLE
Preserve HIP bit-extract loops in Metal and SPIR-V

### DIFF
--- a/crosstl/translator/parser.py
+++ b/crosstl/translator/parser.py
@@ -3205,6 +3205,31 @@ class Parser:
 
     def parse_for_loop_variable_declaration(self):
         """Parse variable declarations in for loops (without consuming semicolon)."""
+        if (
+            self.current_token[0] == "VAR"
+            and self.peek()[0] != "LESS_THAN"
+            and self.peek(2)[0] == "COLON"
+        ):
+            self.eat("VAR")
+            name = self.parse_binding_identifier()
+            self.eat("COLON")
+            var_type = self.parse_type()
+            var_type = self.parse_array_suffixes(var_type)
+            attributes = self.parse_post_declaration_attributes()
+            var_type = self.parse_array_suffixes(var_type)
+
+            initial_value = None
+            if self.current_token[0] == "EQUALS":
+                self.eat("EQUALS")
+                initial_value = self.parse_expression()
+
+            return VariableNode(
+                name=name,
+                var_type=var_type,
+                initial_value=initial_value,
+                attributes=attributes,
+            )
+
         qualifiers = self.parse_variable_qualifiers()
         var_type = self.parse_type()
         declarations = []

--- a/tests/test_translator/test_parser.py
+++ b/tests/test_translator/test_parser.py
@@ -696,6 +696,37 @@ def test_for_statement():
         pytest.fail("for parsing not implemented.")
 
 
+def test_for_statement_accepts_colon_style_var_initializer():
+    code = """
+    shader main {
+        @compute
+        @stage_entry
+        fn bit_extract_kernel(
+            @group(0) @binding(0) var<storage, read_write> d_output: array<u32>,
+            @group(0) @binding(1) var<storage, read> d_input: array<u32>,
+            @group(0) @binding(2) var<uniform> size: u32
+        ) {
+            var offset: u32 = 0u;
+            var stride: u32 = 1u;
+            for (var i: u32 = offset; i < size; i += stride) {
+                d_output[i] = (d_input[i] >> 8u) & 0xfu;
+            }
+        }
+    }
+    """
+
+    ast = parse_code(tokenize_code(code))
+    function = ast.functions[0]
+    loop = function.body.statements[2]
+
+    assert isinstance(loop, ForNode)
+    assert isinstance(loop.init, VariableNode)
+    assert loop.init.name == "i"
+    assert isinstance(loop.init.var_type, PrimitiveType)
+    assert loop.init.var_type.name == "u32"
+    assert isinstance(loop.body.statements[0], ExpressionStatementNode)
+
+
 def test_loop_statement_parses_to_loop_node():
     code = """
     shader main {

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -370,6 +370,83 @@ def test_native_source_extension_aliases_translate_to_parseable_crossgl(
     crosstl.translator.parse(generated)
 
 
+def test_hip_bit_extract_kernel_body_survives_metal_and_spirv_targets(tmp_path):
+    source_path = _write_source(
+        tmp_path,
+        "bit_extract.hip",
+        """
+        #include <hip/hip_runtime.h>
+        #include <iostream>
+
+        __global__ void bit_extract_kernel(
+            uint32_t* d_output,
+            const uint32_t* d_input,
+            size_t size
+        ) {
+            const size_t offset = blockIdx.x * blockDim.x + threadIdx.x;
+            const size_t stride = blockDim.x * gridDim.x;
+            for (size_t i = offset; i < size; i += stride) {
+                d_output[i] = ((d_input[i] >> 8) & 0xfu);
+            }
+        }
+
+        int main() {
+            constexpr size_t size = 1024;
+            uint32_t *d_input, *d_output;
+            hipMalloc(&d_input, size * sizeof(uint32_t));
+            hipMalloc(&d_output, size * sizeof(uint32_t));
+            hipMemcpy(d_input, d_output, size, hipMemcpyHostToDevice);
+            bit_extract_kernel<<<dim3(1), dim3(256), 0, hipStreamDefault>>>(
+                d_output,
+                d_input,
+                size
+            );
+            hipDeviceSynchronize();
+            std::cout << "done" << std::endl;
+            hipFree(d_input);
+            hipFree(d_output);
+        }
+        """,
+    )
+
+    metal = crosstl.translate(
+        str(source_path),
+        backend="metal",
+        source_backend="hip",
+        format_output=False,
+    )
+    spirv = crosstl.translate(
+        str(source_path),
+        backend="vulkan",
+        source_backend="hip",
+        format_output=False,
+    )
+
+    _assert_generated_output_is_usable(metal)
+    assert "device uint* d_output [[buffer(0)]]" in metal
+    assert "const device uint* d_input [[buffer(1)]]" in metal
+    assert "constant uint& size [[buffer(2)]]" in metal
+    assert "for (uint i = offset; i < size; i += stride)" in metal
+    assert "d_output[i] = d_input[i] >> 8 & 15u;" in metal
+
+    _assert_generated_output_is_usable(spirv)
+    assert 'OpEntryPoint GLCompute' in spirv
+    assert 'OpName %' in spirv and '"d_outputBuffer"' in spirv
+    assert '"d_inputBuffer"' in spirv
+    assert "OpLoopMerge" in spirv
+    assert "OpShiftRightLogical" in spirv
+    assert "OpBitwiseAnd" in spirv
+    assert spirv.index("OpLoopMerge") < spirv.index("OpShiftRightLogical")
+    assert spirv.index("OpShiftRightLogical") < spirv.index("OpBitwiseAnd")
+    assert spirv.rindex("OpStore") < spirv.rindex("OpReturn")
+
+    for shader_artifact in (metal, spirv):
+        assert "hipMalloc" not in shader_artifact
+        assert "hipMemcpy" not in shader_artifact
+        assert "hipDeviceSynchronize" not in shader_artifact
+        assert "std::cout" not in shader_artifact
+
+
 def test_metal_vertex_struct_return_preserves_view_dir_outputs(tmp_path):
     source_path = _write_source(
         tmp_path,


### PR DESCRIPTION
## Summary
- Parse CrossGL `for (var name: type = ...)` initializers so HIP reverse-generated compute loops survive the intermediate reparse.
- Add a HIP bit-extract regression covering Metal and SPIR-V resource parameters, loop lowering, bit extraction, stores, and host runtime filtering.

## Validation
- `python3.11 -m pytest tests/test_translator/test_parser.py tests/test_translator/test_translation_pipeline.py::test_hip_bit_extract_kernel_body_survives_metal_and_spirv_targets`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- Raw ROCm bit-extract sample translated to Metal and Vulkan/SPIR-V with resources, loop, bit extraction, and store preserved.

closes #1096
