### PR TITLE
Report OpenCL reduce helper target contracts

### DIFF
--- a/crosstl/backend/OpenCL/target_lowering.py
+++ b/crosstl/backend/OpenCL/target_lowering.py
@@ -1,5 +1,7 @@
 """OpenCL-specific CrossGL AST lowering for target backend code generation."""
 
+from dataclasses import dataclass
+
 from crosstl.translator.ast import (
     ArrayType,
     AttributeNode,
@@ -18,6 +20,9 @@ from crosstl.translator.ast import (
 )
 
 OPENCL_TARGET_UNSUPPORTED_CODE = "opencl.target.unsupported"
+OPENCL_TARGET_UNRESOLVED_HELPER_CODE = "opencl.target.unresolved-helper"
+OPENCL_TARGET_POINTER_HELPER_CODE = "opencl.target.pointer-helper-parameter"
+OPENCL_TARGET_BUILTIN_CODE = "opencl.target.unsupported-builtin"
 DIRECTX_BINDING_PROVENANCE_ANNOTATION = "directx.binding_provenance"
 DIRECTX_RELOCATABLE_BINDING_ANNOTATION = "directx.relocatable_binding"
 _TARGET_SCALAR_TYPE_ALIASES = {
@@ -41,6 +46,45 @@ _SYNTHETIC_BUILTIN_ALIASES = {
 
 class OpenCLTargetUnsupportedError(ValueError):
     """Raised when OpenCL target lowering would emit invalid target code."""
+
+    project_diagnostic_code = OPENCL_TARGET_UNSUPPORTED_CODE
+    missing_capabilities = ("opencl.target-lowering",)
+
+    def __init__(self, message, *, contracts=()):
+        super().__init__(message)
+        self.contracts = tuple(contracts)
+
+
+@dataclass(frozen=True)
+class OpenCLTargetUnsupportedContract:
+    """One unsupported OpenCL contract discovered before target codegen."""
+
+    code: str
+    kind: str
+    name: str
+    signature: str
+    reason: str
+    action: str
+    missing_capabilities: tuple[str, ...]
+
+    def format_project_message(self, target_backend=None):
+        target = _target_backend_label(target_backend)
+        subject = self.signature or self.name
+        return (
+            f"OpenCL target lowering cannot lower {subject} to {target}: "
+            f"{self.reason}. Suggested action: {self.action}"
+        )
+
+    def to_json(self):
+        return {
+            "code": self.code,
+            "kind": self.kind,
+            "name": self.name,
+            "signature": self.signature,
+            "reason": self.reason,
+            "action": self.action,
+            "missingCapabilities": list(self.missing_capabilities),
+        }
 
 
 def _target_backend_label(target_backend):
@@ -96,6 +140,16 @@ def _pointer_parameter_labels(function):
     return labels
 
 
+def _function_signature_label(function):
+    params = []
+    for parameter in getattr(function, "parameters", []) or []:
+        params.append(f"{parameter.name}: {_type_label(parameter.param_type)}")
+    return (
+        f"{function.name}({', '.join(params)}) -> "
+        f"{_type_label(function.return_type)}"
+    )
+
+
 def _function_call_name(call):
     function = getattr(call, "function", None)
     if isinstance(function, IdentifierNode):
@@ -119,9 +173,7 @@ def _format_list(values):
     return ", ".join(sorted(set(values)))
 
 
-def validate_opencl_intermediate_for_target(cgl_ast, target_backend=None):
-    """Reject OpenCL intermediates that target codegen cannot lower correctly."""
-
+def _opencl_target_contracts(cgl_ast):
     functions = [
         function
         for function in getattr(cgl_ast, "functions", []) or []
@@ -131,10 +183,84 @@ def validate_opencl_intermediate_for_target(cgl_ast, target_backend=None):
     for function in functions:
         called_names.update(_collect_called_function_names(function))
 
-    unsupported = []
+    contracts = []
+    for function in functions:
+        if not _is_empty_nonvoid_function(function):
+            continue
+        contracts.append(
+            OpenCLTargetUnsupportedContract(
+                code=OPENCL_TARGET_UNRESOLVED_HELPER_CODE,
+                kind="unresolved-helper-declaration",
+                name=function.name,
+                signature=_function_signature_label(function),
+                reason=(
+                    "non-void helper declaration has no body, so reduction "
+                    "semantics would be lost before target codegen"
+                ),
+                action=(
+                    "provide an OpenCL helper body, materialize a known reduction "
+                    "helper specialization, or keep the source on an OpenCL path"
+                ),
+                missing_capabilities=("opencl.helper-resolution",),
+            )
+        )
 
+    for function in functions:
+        labels = _pointer_parameter_labels(function)
+        for label in labels:
+            contracts.append(
+                OpenCLTargetUnsupportedContract(
+                    code=OPENCL_TARGET_POINTER_HELPER_CODE,
+                    kind="pointer-helper-parameter",
+                    name=function.name,
+                    signature=f"{function.name}({label})",
+                    reason=(
+                        "helper pointer parameters do not preserve OpenCL "
+                        "address-space and local-memory aliasing semantics in "
+                        "target codegen"
+                    ),
+                    action=(
+                        "rewrite the helper as kernel-local logic, pass scalar "
+                        "values explicitly, or keep the source on an OpenCL path"
+                    ),
+                    missing_capabilities=("opencl.local-pointer-helper",),
+                )
+            )
+
+    for builtin_name in sorted(called_names.intersection(_EVENT_LOCAL_MEMORY_BUILTINS)):
+        contracts.append(
+            OpenCLTargetUnsupportedContract(
+                code=OPENCL_TARGET_BUILTIN_CODE,
+                kind="event-local-memory-builtin",
+                name=builtin_name,
+                signature=f"{builtin_name}(...)",
+                reason=(
+                    "event/local-memory builtin semantics are not preserved by "
+                    "target lowering"
+                ),
+                action=(
+                    "replace the builtin with explicit target synchronization and "
+                    "copy logic, or keep the source on an OpenCL path"
+                ),
+                missing_capabilities=("opencl.event-local-memory",),
+            )
+        )
+
+    return tuple(contracts)
+
+
+def validate_opencl_intermediate_for_target(cgl_ast, target_backend=None):
+    """Reject OpenCL intermediates that target codegen cannot lower correctly."""
+
+    contracts = _opencl_target_contracts(cgl_ast)
+    if not contracts:
+        return
+
+    unsupported = []
     empty_helpers = [
-        function.name for function in functions if _is_empty_nonvoid_function(function)
+        contract.name
+        for contract in contracts
+        if contract.kind == "unresolved-helper-declaration"
     ]
     if empty_helpers:
         unsupported.append(
@@ -142,32 +268,34 @@ def validate_opencl_intermediate_for_target(cgl_ast, target_backend=None):
             f"{_format_list(empty_helpers)}"
         )
 
-    pointer_helpers = []
-    for function in functions:
-        labels = _pointer_parameter_labels(function)
-        if labels:
-            pointer_helpers.append(f"{function.name}({', '.join(labels)})")
+    pointer_helpers = [
+        contract.signature
+        for contract in contracts
+        if contract.kind == "pointer-helper-parameter"
+    ]
     if pointer_helpers:
         unsupported.append(
             "OpenCL pointer helper parameters are not representable in target "
             f"codegen: {_format_list(pointer_helpers)}"
         )
 
-    event_local_calls = called_names.intersection(_EVENT_LOCAL_MEMORY_BUILTINS)
+    event_local_calls = [
+        contract.name
+        for contract in contracts
+        if contract.kind == "event-local-memory-builtin"
+    ]
     if event_local_calls:
         unsupported.append(
             "OpenCL event/local-memory builtins require semantics not preserved by "
             f"target lowering: {_format_list(event_local_calls)}"
         )
 
-    if not unsupported:
-        return
-
     target = _target_backend_label(target_backend)
     details = "; ".join(unsupported)
     raise OpenCLTargetUnsupportedError(
         f"{OPENCL_TARGET_UNSUPPORTED_CODE}: cannot lower OpenCL source to "
-        f"{target} because target lowering would produce invalid artifacts: {details}"
+        f"{target} because target lowering would produce invalid artifacts: {details}",
+        contracts=contracts,
     )
 
 

--- a/crosstl/backend/OpenCL/target_lowering.py
+++ b/crosstl/backend/OpenCL/target_lowering.py
@@ -1,6 +1,7 @@
 """OpenCL-specific CrossGL AST lowering for target backend code generation."""
 
 from dataclasses import dataclass
+from typing import Tuple
 
 from crosstl.translator.ast import (
     ArrayType,
@@ -65,7 +66,7 @@ class OpenCLTargetUnsupportedContract:
     signature: str
     reason: str
     action: str
-    missing_capabilities: tuple[str, ...]
+    missing_capabilities: Tuple[str, ...]
 
     def format_project_message(self, target_backend=None):
         target = _target_backend_label(target_backend)

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -9986,6 +9986,67 @@ def _translation_failure_missing_capabilities(
     return ["batch.translation"]
 
 
+def _translation_failure_project_diagnostics(
+    exc: Exception,
+    target: str,
+    unit: ProjectTranslationUnit,
+    variant: str | None,
+    message: str,
+) -> list[ProjectDiagnostic]:
+    contracts = getattr(exc, "contracts", None)
+    if contracts:
+        diagnostics: list[ProjectDiagnostic] = []
+        location = _translation_failure_location(exc, unit)
+        for contract in contracts:
+            code = getattr(contract, "code", None)
+            if not _is_non_empty_string(code):
+                code = _translation_failure_code(exc, target)
+            format_message = getattr(contract, "format_project_message", None)
+            if callable(format_message):
+                diagnostic_message = format_message(target)
+            else:
+                diagnostic_message = str(contract)
+            capabilities = getattr(contract, "missing_capabilities", None)
+            if isinstance(capabilities, str):
+                missing_capabilities = [capabilities]
+            elif capabilities:
+                missing_capabilities = [
+                    str(capability) for capability in capabilities
+                ]
+            else:
+                missing_capabilities = _translation_failure_missing_capabilities(
+                    exc, target
+                )
+            diagnostics.append(
+                ProjectDiagnostic(
+                    severity="error",
+                    code=code,
+                    message=diagnostic_message,
+                    location=location,
+                    target=target,
+                    source_backend=unit.source_backend,
+                    variant=variant,
+                    missing_capabilities=missing_capabilities,
+                )
+            )
+        return diagnostics
+
+    return [
+        ProjectDiagnostic(
+            severity="error",
+            code=_translation_failure_code(exc, target),
+            message=message,
+            location=_translation_failure_location(exc, unit),
+            target=target,
+            source_backend=unit.source_backend,
+            variant=variant,
+            missing_capabilities=_translation_failure_missing_capabilities(
+                exc, target
+            ),
+        )
+    ]
+
+
 def _is_metal_template_failure(exc: Exception, unit: ProjectTranslationUnit) -> bool:
     return (
         unit.source_backend == "metal"
@@ -10436,18 +10497,13 @@ def translate_project(
                     )
                     artifact["status"] = "failed"
                     artifact["error"] = failure_message
-                    diagnostics.append(
-                        ProjectDiagnostic(
-                            severity="error",
-                            code=_translation_failure_code(exc, target),
-                            message=failure_message,
-                            location=_translation_failure_location(exc, unit),
-                            target=target,
-                            source_backend=unit.source_backend,
-                            variant=variant,
-                            missing_capabilities=_translation_failure_missing_capabilities(
-                                exc, target
-                            ),
+                    diagnostics.extend(
+                        _translation_failure_project_diagnostics(
+                            exc,
+                            target,
+                            unit,
+                            variant,
+                            failure_message,
                         )
                     )
                     artifacts.append(artifact)
@@ -10532,18 +10588,13 @@ def translate_project(
                     artifact.pop("sourceMap", None)
                     artifact.pop("sourceRemap", None)
                     artifact_records = [artifact]
-                    diagnostics.append(
-                        ProjectDiagnostic(
-                            severity="error",
-                            code=_translation_failure_code(exc, target),
-                            message=failure_message,
-                            location=_translation_failure_location(exc, unit),
-                            target=target,
-                            source_backend=unit.source_backend,
-                            variant=variant,
-                            missing_capabilities=_translation_failure_missing_capabilities(
-                                exc, target
-                            ),
+                    diagnostics.extend(
+                        _translation_failure_project_diagnostics(
+                            exc,
+                            target,
+                            unit,
+                            variant,
+                            failure_message,
                         )
                     )
                 finally:

--- a/tests/test_backend/test_OpenCL/test_codegen.py
+++ b/tests/test_backend/test_OpenCL/test_codegen.py
@@ -1,16 +1,27 @@
+import pytest
+
 import crosstl
 from crosstl.backend.OpenCL.OpenCLCrossGLCodeGen import OpenCLToCrossGLConverter
 from crosstl.backend.OpenCL.OpenCLLexer import OpenCLLexer
 from crosstl.backend.OpenCL.OpenCLParser import OpenCLParser
+from crosstl.backend.OpenCL.target_lowering import (
+    OpenCLTargetUnsupportedError,
+    validate_opencl_intermediate_for_target,
+)
 from crosstl.translator.lexer import Lexer as CrossGLLexer
 from crosstl.translator.parser import Parser as CrossGLParser
 
 
-def generate_crossgl(source):
+def parse_crossgl_from_opencl(source):
     tokens = OpenCLLexer(source).tokenize()
     ast = OpenCLParser(tokens).parse()
     crossgl = OpenCLToCrossGLConverter().generate(ast)
-    CrossGLParser(CrossGLLexer(crossgl).tokens).parse()
+    cgl_ast = CrossGLParser(CrossGLLexer(crossgl).tokens).parse()
+    return cgl_ast, crossgl
+
+
+def generate_crossgl(source):
+    _cgl_ast, crossgl = parse_crossgl_from_opencl(source)
     return crossgl
 
 
@@ -138,6 +149,57 @@ def test_opencl_local_pointer_kernel_param_uses_workgroup_storage():
     assert "@group(0) @binding(0) var<storage, read_write> out: array<f32>" in crossgl
     assert "var<storage, read_write> scratch" not in crossgl
     assert "@binding(1) var<storage, read_write> out" not in crossgl
+
+
+def test_opencl_reduce_helpers_report_structured_target_contracts():
+    cgl_ast, _crossgl = parse_crossgl_from_opencl("""
+        int op(int lhs, int rhs);
+        int work_group_reduce_op(int val);
+        int sub_group_reduce_op(int val);
+
+        int read_local(local int* shared, size_t i) {
+            return shared[i];
+        }
+
+        kernel void reduce(global int* front, global int* back, local int* shared) {
+            event_t read;
+            async_work_group_copy(shared, front, 1, read);
+            wait_group_events(1, &read);
+            int temp = work_group_reduce_op(
+                op(read_local(shared, 0), read_local(shared, 1))
+            );
+            back[0] = sub_group_reduce_op(temp);
+        }
+        """)
+
+    with pytest.raises(OpenCLTargetUnsupportedError) as error:
+        validate_opencl_intermediate_for_target(cgl_ast, "opengl")
+
+    contracts = [contract.to_json() for contract in error.value.contracts]
+
+    assert str(error.value).startswith(
+        "opencl.target.unsupported: cannot lower OpenCL source to opengl"
+    )
+    assert {
+        contract["signature"]
+        for contract in contracts
+        if contract["code"] == "opencl.target.unresolved-helper"
+    } == {
+        "op(lhs: i32, rhs: i32) -> i32",
+        "work_group_reduce_op(val: i32) -> i32",
+        "sub_group_reduce_op(val: i32) -> i32",
+    }
+    assert {
+        contract["signature"]
+        for contract in contracts
+        if contract["code"] == "opencl.target.pointer-helper-parameter"
+    } == {"read_local(shared_: ptr<i32>)"}
+    assert {
+        contract["signature"]
+        for contract in contracts
+        if contract["code"] == "opencl.target.unsupported-builtin"
+    } == {"async_work_group_copy(...)", "wait_group_events(...)"}
+    assert all(contract["action"] for contract in contracts)
 
 
 def test_opencl_vector_constructor_cast_codegen_reparse():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -37258,9 +37258,14 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
     } == {(target, "failed") for target in expected_targets}
     assert payload["summary"]["translatedCount"] == 0
     assert payload["summary"]["failedCount"] == 4
-    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 4}
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 24}
+    assert payload["summary"]["diagnosticsByCode"] == {
+        "opencl.target.pointer-helper-parameter": 4,
+        "opencl.target.unresolved-helper": 12,
+        "opencl.target.unsupported-builtin": 8,
+    }
     assert payload["summary"]["diagnosticsByTarget"] == {
-        target: 1 for target in expected_targets
+        target: 6 for target in expected_targets
     }
 
     for artifact in payload["artifacts"]:
@@ -37272,13 +37277,92 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
         ) in artifact["error"]
         assert "read_local(shared_: ptr<i32>)" in artifact["error"]
 
-    assert len(payload["diagnostics"]) == 4
+    assert len(payload["diagnostics"]) == 24
+    for target in expected_targets:
+        target_diagnostics = [
+            diagnostic
+            for diagnostic in payload["diagnostics"]
+            if diagnostic["target"] == target
+        ]
+        assert len(target_diagnostics) == 6
+        assert {
+            diagnostic["code"] for diagnostic in target_diagnostics
+        } == {
+            "opencl.target.unresolved-helper",
+            "opencl.target.pointer-helper-parameter",
+            "opencl.target.unsupported-builtin",
+        }
+        assert sum(
+            diagnostic["code"] == "opencl.target.unresolved-helper"
+            for diagnostic in target_diagnostics
+        ) == 3
+        assert sum(
+            diagnostic["code"] == "opencl.target.pointer-helper-parameter"
+            for diagnostic in target_diagnostics
+        ) == 1
+        assert sum(
+            diagnostic["code"] == "opencl.target.unsupported-builtin"
+            for diagnostic in target_diagnostics
+        ) == 2
+
     for diagnostic in payload["diagnostics"]:
-        assert diagnostic["code"] == "project.translate.failed"
         assert diagnostic["sourceBackend"] == "opencl"
         assert diagnostic["location"]["file"] == "reduce.cl"
         assert diagnostic["target"] in expected_targets
-        assert "opencl.target.unsupported" in diagnostic["message"]
+        assert "Suggested action:" in diagnostic["message"]
+
+    messages = [diagnostic["message"] for diagnostic in payload["diagnostics"]]
+    assert any("op(lhs: i32, rhs: i32) -> i32" in message for message in messages)
+    assert any(
+        "work_group_reduce_op(val: i32) -> i32" in message
+        for message in messages
+    )
+    assert any(
+        "sub_group_reduce_op(val: i32) -> i32" in message
+        for message in messages
+    )
+    assert any("read_local(shared_: ptr<i32>)" in message for message in messages)
+    assert any("async_work_group_copy(...)" in message for message in messages)
+    assert any("wait_group_events(...)" in message for message in messages)
+
+
+def test_translate_project_opencl_local_pointer_helper_reports_contract(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "local_helper.cl").write_text(
+        textwrap.dedent("""
+            int read_local(local int* shared, size_t i) {
+                return shared[i];
+            }
+
+            kernel void copy(global int* out, local int* shared) {
+                size_t lid = get_local_id(0);
+                out[lid] = read_local(shared, lid);
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(repo, targets=["opengl"], output_dir="out").to_json()
+
+    assert payload["artifacts"][0]["status"] == "failed"
+    assert not (repo / payload["artifacts"][0]["path"]).exists()
+    assert "read_local(shared_: ptr<i32>)" in payload["artifacts"][0]["error"]
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 1}
+    assert payload["summary"]["diagnosticsByCode"] == {
+        "opencl.target.pointer-helper-parameter": 1
+    }
+
+    diagnostic = payload["diagnostics"][0]
+    assert diagnostic["code"] == "opencl.target.pointer-helper-parameter"
+    assert diagnostic["sourceBackend"] == "opencl"
+    assert diagnostic["target"] == "opengl"
+    assert diagnostic["location"]["file"] == "local_helper.cl"
+    assert diagnostic["missingCapabilities"] == ["opencl.local-pointer-helper"]
+    assert "read_local(shared_: ptr<i32>)" in diagnostic["message"]
+    assert "Suggested action:" in diagnostic["message"]
 
 
 def test_translate_project_opencl_to_opengl_casts_signed_global_id_local(


### PR DESCRIPTION
## Summary

- Split OpenCL target-lowering rejection into per-contract records for unresolved non-void helpers, local pointer helper parameters, and event/local-memory builtins.
- Expand project translation failures into one actionable diagnostic per OpenCL target contract while preserving the aggregate artifact error.
- Cover OpenCL reduce helper declarations and local pointer helper project reporting.

## Validation

- `PYTHONPATH=$PWD pytest -q tests/test_backend/test_OpenCL/test_codegen.py tests/test_translator/test_project_translation.py -k opencl`
  - 27 passed, 797 deselected
- `python3.11 tools/support_matrix.py check`
  - Support matrix catalogs and generated artifacts are current.
- `git diff --check`
  - passed

closes #1088