### PR TITLE
Emit Rust-GPU resource parameters

### DIFF
--- a/crosstl/translator/codegen/rust_codegen.py
+++ b/crosstl/translator/codegen/rust_codegen.py
@@ -583,6 +583,9 @@ class RustCodeGen:
         self.glsl_buffer_block_layouts = {}
         self.rust_resource_binding_cursors = {}
         self.rust_used_resource_bindings = {}
+        self.rust_resource_binding_infos = {}
+        self.rust_entry_resource_params_by_function_id = {}
+        self.rust_promoted_resource_node_ids = set()
         self.struct_member_types = {}
         self.struct_member_semantics = {}
         self.struct_generic_params = {}
@@ -636,6 +639,9 @@ class RustCodeGen:
         self.glsl_buffer_block_layouts = {}
         self.rust_resource_binding_cursors = {}
         self.rust_used_resource_bindings = {}
+        self.rust_resource_binding_infos = {}
+        self.rust_entry_resource_params_by_function_id = {}
+        self.rust_promoted_resource_node_ids = set()
         self.struct_member_types = {}
         self.struct_member_semantics = {}
         self.struct_generic_params = {}
@@ -683,6 +689,14 @@ class RustCodeGen:
         self.force_move_lambda_depth = 0
         self.nested_lambda_capture_preclone_depth = 0
         self.reserve_explicit_rust_resource_bindings(ast)
+        self.rust_entry_resource_params_by_function_id = (
+            self.collect_rust_entry_resource_params(ast)
+        )
+        self.rust_promoted_resource_node_ids = {
+            id(info["node"])
+            for params in self.rust_entry_resource_params_by_function_id.values()
+            for info in params
+        }
         code = "// Generated Rust GPU Shader Code\n"
         code += "use gpu::*;\n"
         code += "use math::*;\n\n"
@@ -708,6 +722,12 @@ class RustCodeGen:
         for node in global_vars:
             if isinstance(node, ArrayNode):
                 code += self.generate_global_array_declaration(node)
+                emitted_static_names.add(node.name)
+            elif self.is_promoted_rust_entry_resource(node):
+                var_type = self.rust_variable_source_type(node)
+                self.register_glsl_buffer_block_metadata(node)
+                self.register_variable_type(node.name, var_type, scope="static")
+                code += self.rust_resource_metadata_comment(node, var_type)
                 emitted_static_names.add(node.name)
             else:
                 code += self.generate_variable_static_declaration(node)
@@ -2124,6 +2144,160 @@ class RustCodeGen:
             used_symbols.add(symbol)
         return symbol_names
 
+    def rust_variable_source_type(self, node):
+        """Return the source-level type string used for Rust resource metadata."""
+        if isinstance(node, ArrayNode):
+            element_type_name = self.convert_type_node_to_string(
+                getattr(node, "element_type", "float")
+            )
+            element_type_name = self.resource_type_with_attributes(
+                element_type_name,
+                node,
+            )
+            size = self.format_array_size(getattr(node, "size", None))
+            return (
+                f"{element_type_name}[{size}]"
+                if size is not None
+                else f"{element_type_name}[]"
+            )
+        return self.get_variable_type(node) or "float"
+
+    def rust_function_stage_name(self, func):
+        """Return the normalized shader stage name for a function, if any."""
+        qualifiers = list(getattr(func, "qualifiers", []) or [])
+        qualifier = getattr(func, "qualifier", None)
+        if qualifier:
+            qualifiers.append(qualifier)
+
+        stage_names = {
+            "vertex",
+            "fragment",
+            "compute",
+            "geometry",
+            "tessellation_control",
+            "tessellation_evaluation",
+            *self.rust_mesh_stage_names(),
+            *self.rust_ray_stage_names(),
+        }
+        for qualifier in qualifiers:
+            stage_name = normalize_stage_name(qualifier)
+            if stage_name in stage_names:
+                return stage_name
+        return None
+
+    def rust_global_entry_resource_infos(self, ast):
+        """Collect global resources that can be promoted to entry parameters."""
+        resources = {}
+        for node in getattr(ast, "global_variables", []) or []:
+            name = getattr(node, "name", None)
+            if not name:
+                continue
+            type_name = self.rust_variable_source_type(node)
+            if not self.can_promote_rust_entry_resource(node, type_name):
+                continue
+            resources[name] = {"node": node, "type_name": type_name}
+        return resources
+
+    def can_promote_rust_entry_resource(self, node, type_name):
+        """Return whether a resource can replace a Rust placeholder static."""
+        if isinstance(node, ArrayNode):
+            return False
+        if self.explicit_rust_resource_binding_index(node) is None:
+            return False
+        if getattr(node, "initial_value", getattr(node, "value", None)) is not None:
+            return False
+
+        resource_kind = self.rust_resource_kind(type_name, node=node)
+        if resource_kind not in {"texture", "sampler"}:
+            return False
+
+        _base_type, count = self.rust_resource_base_type_and_count(type_name)
+        return count == 1
+
+    def collect_rust_entry_resource_params(self, ast):
+        """Map stage entry functions to promoted Rust resource parameters."""
+        resources = self.rust_global_entry_resource_infos(ast)
+        if not resources:
+            return {}
+
+        stage_entry_ids = set()
+        for stage in (
+            getattr(ast, "stages", {}).values() if hasattr(ast, "stages") else []
+        ):
+            entry_point = getattr(stage, "entry_point", None)
+            if entry_point is not None:
+                stage_entry_ids.add(id(entry_point))
+
+        entry_functions = {}
+        entry_refs = {}
+        non_entry_refs = set()
+        seen_functions = set()
+
+        def visit(current):
+            nonlocal non_entry_refs
+            if current is None:
+                return
+            if isinstance(current, list):
+                for item in current:
+                    visit(item)
+                return
+            if isinstance(current, FunctionNode):
+                function_id = id(current)
+                if function_id in seen_functions:
+                    return
+                seen_functions.add(function_id)
+                is_entry = (
+                    function_id in stage_entry_ids
+                    or self.rust_function_stage_name(current) is not None
+                )
+                if is_entry:
+                    entry_functions[function_id] = current
+                    entry_refs[function_id] = self.collect_free_identifier_names(
+                        current
+                    )
+                else:
+                    non_entry_refs.update(self.collect_free_identifier_names(current))
+                return
+
+            for function in getattr(current, "functions", []) or []:
+                visit(function)
+            for function in getattr(current, "local_functions", []) or []:
+                visit(function)
+            visit(getattr(current, "entry_point", None))
+            stages = getattr(current, "stages", {})
+            if isinstance(stages, dict):
+                for stage in stages.values():
+                    visit(stage)
+
+        visit(ast)
+
+        params_by_function = {}
+        unsafe_names = set(resources) & non_entry_refs
+        for function_id, used_names in entry_refs.items():
+            function = entry_functions[function_id]
+            parameter_names = {
+                param.name
+                for param in getattr(
+                    function,
+                    "parameters",
+                    getattr(function, "params", []),
+                )
+            }
+            params = [
+                info
+                for name, info in resources.items()
+                if name in used_names
+                and name not in unsafe_names
+                and name not in parameter_names
+            ]
+            if params:
+                params_by_function[function_id] = params
+        return params_by_function
+
+    def is_promoted_rust_entry_resource(self, node):
+        """Return whether a global resource is emitted as an entry parameter."""
+        return id(node) in self.rust_promoted_resource_node_ids
+
     def uppercase_static_symbol_name(self, name):
         """Convert a CrossGL identifier to a Rust static identifier."""
         name = str(name)
@@ -2496,8 +2670,23 @@ class RustCodeGen:
                 bound.add(node.name)
                 return
             if isinstance(node, FunctionCallNode):
+                function_expr = getattr(node, "function", getattr(node, "name", None))
+                if isinstance(function_expr, MemberAccessNode):
+                    visit(function_expr, bound)
                 for arg in getattr(node, "arguments", getattr(node, "args", [])) or []:
                     visit(arg, bound)
+                return
+            if isinstance(node, TextureNode):
+                visit(getattr(node, "texture_expr", None), bound)
+                visit(getattr(node, "sampler_expr", None), bound)
+                visit(getattr(node, "coordinates", None), bound)
+                visit(getattr(node, "level", None), bound)
+                visit(getattr(node, "offset", None), bound)
+                return
+            if isinstance(node, TextureOpNode):
+                visit(getattr(node, "texture_expr", None), bound)
+                visit(getattr(node, "sampler_expr", None), bound)
+                visit(getattr(node, "arguments", []), bound)
                 return
             if isinstance(node, MemberAccessNode):
                 visit(
@@ -4020,11 +4209,22 @@ class RustCodeGen:
         param_list = list(getattr(func, "parameters", getattr(func, "params", [])))
         if extra_params:
             param_list.extend(extra_params)
+        promoted_resource_params = (
+            self.rust_entry_resource_params_by_function_id.get(id(func), [])
+            if shader_type
+            else []
+        )
         for p in param_list:
             self.register_glsl_buffer_block_metadata(p)
             self.register_variable_type(
                 p.name,
                 self.function_parameter_type(p),
+                scope="local",
+            )
+        for resource_info in promoted_resource_params:
+            self.register_variable_type(
+                resource_info["node"].name,
+                resource_info["type_name"],
                 scope="local",
             )
         self.current_mutated_names = self.collect_mutated_binding_names(
@@ -4074,6 +4274,10 @@ class RustCodeGen:
                 f"{param_name}: "
                 f"{self.map_function_parameter_type_with_lifetime(param_type, reference_lifetime)}"
             )
+        params.extend(
+            self.generate_rust_resource_parameter(info)
+            for info in promoted_resource_params
+        )
 
         params_str = ", ".join(params) if params else ""
 
@@ -5898,6 +6102,20 @@ class RustCodeGen:
             if isinstance(current, FunctionCallNode):
                 collect(current.function)
                 collect(getattr(current, "arguments", getattr(current, "args", [])))
+                return
+
+            if isinstance(current, TextureNode):
+                collect(getattr(current, "texture_expr", None))
+                collect(getattr(current, "sampler_expr", None))
+                collect(getattr(current, "coordinates", None))
+                collect(getattr(current, "level", None))
+                collect(getattr(current, "offset", None))
+                return
+
+            if isinstance(current, TextureOpNode):
+                collect(getattr(current, "texture_expr", None))
+                collect(getattr(current, "sampler_expr", None))
+                collect(getattr(current, "arguments", []))
                 return
 
             if isinstance(current, MemberAccessNode):
@@ -13170,11 +13388,16 @@ class RustCodeGen:
             self.rust_resource_binding_cursors.get(key, 0), end + 1
         )
 
-    def rust_resource_metadata_comment(self, node, type_name, kind=None):
+    def rust_resource_binding_info(self, node, type_name, kind=None):
         name = getattr(node, "name", None)
         resource_kind = self.rust_resource_kind(type_name, node=node, forced_kind=kind)
         if not name or resource_kind is None:
-            return ""
+            return None
+
+        cache_key = (id(node), resource_kind)
+        cached_info = self.rust_resource_binding_infos.get(cache_key)
+        if cached_info is not None:
+            return cached_info
 
         _base_type, count = self.rust_resource_base_type_and_count(type_name)
         validation_count = self.rust_resource_binding_validation_count(
@@ -13197,27 +13420,71 @@ class RustCodeGen:
                 namespace, set_index, binding, validation_count, name
             )
 
+        info = {
+            "name": name,
+            "kind": resource_kind,
+            "set_index": set_index,
+            "binding": binding,
+            "binding_source": binding_source,
+            "count": count,
+            "register": self.rust_resource_register_metadata(node),
+        }
+        self.rust_resource_binding_infos[cache_key] = info
+        return info
+
+    def rust_resource_metadata_comment(self, node, type_name, kind=None):
+        info = self.rust_resource_binding_info(node, type_name, kind=kind)
+        if info is None:
+            return ""
+
         parts = [
             "// CrossGL resource metadata:",
-            f"name={name}",
-            f"kind={resource_kind}",
+            f"name={info['name']}",
+            f"kind={info['kind']}",
         ]
-        if resource_kind == "glsl_buffer_block":
+        if info["kind"] == "glsl_buffer_block":
             parts.append(f"layout={self.glsl_buffer_block_layout(node)}")
             parts.append(f"access={self.explicit_resource_access(node) or 'readwrite'}")
         parts.extend(
             [
-                f"set={set_index}",
-                f"binding={binding}",
-                f"binding_source={binding_source}",
+                f"set={info['set_index']}",
+                f"binding={info['binding']}",
+                f"binding_source={info['binding_source']}",
             ]
         )
-        if count != 1:
-            parts.append(f"count={count}")
-        register_metadata = self.rust_resource_register_metadata(node)
-        if register_metadata:
-            parts.append(f"register={register_metadata}")
+        if info["count"] != 1:
+            parts.append(f"count={info['count']}")
+        if info["register"]:
+            parts.append(f"register={info['register']}")
         return " ".join(parts) + "\n"
+
+    def rust_resource_parameter_attribute(self, node, type_name):
+        info = self.rust_resource_binding_info(node, type_name)
+        if info is None:
+            return ""
+
+        spirv_args = []
+        if info["kind"] == "buffer":
+            spirv_args.append("storage_buffer")
+        spirv_args.extend(
+            [
+                f"descriptor_set = {info['set_index']}",
+                f"binding = {info['binding']}",
+            ]
+        )
+        return (
+            '#[cfg_attr(feature = "crossgl_gpu", '
+            f"spirv({', '.join(spirv_args)}))] "
+        )
+
+    def generate_rust_resource_parameter(self, resource_info):
+        node = resource_info["node"]
+        type_name = resource_info["type_name"]
+        attribute = self.rust_resource_parameter_attribute(node, type_name)
+        return (
+            f"{attribute}{self.rust_identifier(node.name)}: "
+            f"{self.map_function_parameter_type(type_name)}"
+        )
 
     def rust_resource_placeholder_diagnostic_comment(self, node, type_name):
         name = getattr(node, "name", None)

--- a/tests/test_translator/test_codegen/test_rust_codegen.py
+++ b/tests/test_translator/test_codegen/test_rust_codegen.py
@@ -16920,16 +16920,24 @@ def test_basic_sampled_texture_calls_map_to_rust_helpers_and_compile(tmp_path):
     generated_code = generate_code(parse_code(tokenize_code(code)))
 
     assert (
-        "static COLOR_MAP: std::sync::LazyLock<Texture2D<Vec4<f32>>>" in generated_code
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 1, binding = 0))] colorMap: Texture2D<Vec4<f32>>"
+        in generated_code
     )
-    assert "static LINEAR_SAMPLER: std::sync::LazyLock<Sampler>" in generated_code
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 0, binding = 0))] linearSampler: Sampler"
+        in generated_code
+    )
+    assert "static COLOR_MAP" not in generated_code
+    assert "static LINEAR_SAMPLER" not in generated_code
     assert "let combined: Vec4<f32> = sample(*DIFFUSE_MAP, uv);" in generated_code
     assert (
         "let split: Vec4<f32> = sample_sampler(*DIFFUSE_MAP, *POINT_SAMPLER, uv);"
         in generated_code
     )
     assert (
-        "let hlslSplit: Vec4<f32> = sample_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv);"
+        "let hlslSplit: Vec4<f32> = sample_sampler(colorMap, linearSampler, uv);"
         in generated_code
     )
     assert "Texture2D<float4>" not in generated_code
@@ -17031,35 +17039,35 @@ def test_hlsl_texture_member_helpers_map_to_rust_placeholders_and_compile(tmp_pa
     generated_code = generate_code(parse_code(tokenize_code(code)))
 
     assert (
-        "let baseOffset: Vec4<f32> = sample_offset_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, offset);"
+        "let baseOffset: Vec4<f32> = sample_offset_sampler(colorMap, linearSampler, uv, offset);"
         in generated_code
     )
     assert (
-        "let biased: Vec4<f32> = sample_bias_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, 0.25);"
+        "let biased: Vec4<f32> = sample_bias_sampler(colorMap, linearSampler, uv, 0.25);"
         in generated_code
     )
     assert (
-        "let biasedOffset: Vec4<f32> = sample_offset_bias_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, offset, 0.5);"
+        "let biasedOffset: Vec4<f32> = sample_offset_bias_sampler(colorMap, linearSampler, uv, offset, 0.5);"
         in generated_code
     )
     assert (
-        "let lodOffset: Vec4<f32> = sample_lod_offset_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, lod, offset);"
+        "let lodOffset: Vec4<f32> = sample_lod_offset_sampler(colorMap, linearSampler, uv, lod, offset);"
         in generated_code
     )
     assert (
-        "let gradOffset: Vec4<f32> = sample_grad_offset_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, ddx, ddy, offset);"
+        "let gradOffset: Vec4<f32> = sample_grad_offset_sampler(colorMap, linearSampler, uv, ddx, ddy, offset);"
         in generated_code
     )
-    assert "texture_dimensions(*COLOR_MAP, (width, height));" in generated_code
+    assert "texture_dimensions(colorMap, (width, height));" in generated_code
     assert (
-        "let gatheredRedOffset: Vec4<f32> = texture_gather_offset_component_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv, offset, 0);"
+        "let gatheredRedOffset: Vec4<f32> = texture_gather_offset_component_sampler(colorMap, linearSampler, uv, offset, 0);"
         in generated_code
     )
-    assert "let loaded: Vec4<f32> = texel_fetch(*COLOR_MAP, pixel, 0);" in (
+    assert "let loaded: Vec4<f32> = texel_fetch(colorMap, pixel, 0);" in (
         generated_code
     )
     assert (
-        "let loadedOffset: Vec4<f32> = texel_fetch_offset(*COLOR_MAP, pixel, 0, offset);"
+        "let loadedOffset: Vec4<f32> = texel_fetch_offset(colorMap, pixel, 0, offset);"
         in generated_code
     )
     assert (
@@ -17067,17 +17075,29 @@ def test_hlsl_texture_member_helpers_map_to_rust_placeholders_and_compile(tmp_pa
         in generated_code
     )
     assert (
-        "let detail: f32 = texture_calculate_lod(*COLOR_MAP, *LINEAR_SAMPLER, uv);"
+        "let detail: f32 = texture_calculate_lod(colorMap, linearSampler, uv);"
         in generated_code
     )
     assert (
-        "let cmpGradOffset: f32 = texture_compare_grad_offset_sampler(*SHADOW_MAP, *LINEAR_SAMPLER, uv, depth, ddx, ddy, offset);"
+        "let cmpGradOffset: f32 = texture_compare_grad_offset_sampler(*SHADOW_MAP, linearSampler, uv, depth, ddx, ddy, offset);"
         in generated_code
     )
     assert (
-        "let gatherCmpOffset: Vec4<f32> = texture_gather_compare_offset_sampler(*SHADOW_MAP, *LINEAR_SAMPLER, uv, depth, offset);"
+        "let gatherCmpOffset: Vec4<f32> = texture_gather_compare_offset_sampler(*SHADOW_MAP, linearSampler, uv, depth, offset);"
         in generated_code
     )
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 0, binding = 0))] colorMap: Texture2D<Vec4<f32>>"
+        in generated_code
+    )
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 0, binding = 0))] linearSampler: Sampler"
+        in generated_code
+    )
+    assert "static COLOR_MAP" not in generated_code
+    assert "static LINEAR_SAMPLER" not in generated_code
     assert ".Sample" not in generated_code
     assert ".Gather" not in generated_code
     assert ".Load" not in generated_code
@@ -18712,11 +18732,25 @@ def test_texture_and_sampler_binding_namespaces_are_independent_for_rust_codegen
         "// CrossGL resource metadata: name=linearSampler kind=sampler set=0 "
         "binding=2 binding_source=explicit" in generated_code
     )
-    assert "return sample_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv);" in generated_code
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 0, binding = 2))] colorMap: Texture2D<f32>"
+        in generated_code
+    )
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 0, binding = 2))] linearSampler: Sampler"
+        in generated_code
+    )
+    assert "return sample_sampler(colorMap, linearSampler, uv);" in generated_code
+    assert "static COLOR_MAP" not in generated_code
+    assert "static LINEAR_SAMPLER" not in generated_code
+    assert "CrossGL Rust limitation: resource colorMap" not in generated_code
+    assert "CrossGL Rust limitation: resource linearSampler" not in generated_code
     assert_generated_rust_smoke_compiles(generated_code, tmp_path)
 
 
-def test_rust_resource_placeholders_diagnose_explicit_sampler_sampling(tmp_path):
+def test_rust_resource_parameters_lower_explicit_sampler_sampling(tmp_path):
     code = """
     shader RustExplicitSamplerResourceDiagnostic {
         sampler2D colorMap @set(1) @binding(4);
@@ -18732,21 +18766,20 @@ def test_rust_resource_placeholders_diagnose_explicit_sampler_sampling(tmp_path)
 
     generated_code = generate_code(parse_code(tokenize_code(code)))
 
-    assert "return sample_sampler(*COLOR_MAP, *LINEAR_SAMPLER, uv);" in generated_code
+    assert "return sample_sampler(colorMap, linearSampler, uv);" in generated_code
     assert "texture(" not in generated_code
     assert (
-        "// CrossGL Rust limitation: resource colorMap is emitted as a "
-        "compile-only placeholder static, not a rust-gpu resource binding"
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 1, binding = 4))] colorMap: Texture2D<f32>"
     ) in generated_code
     assert (
-        "// CrossGL Rust limitation: resource linearSampler is emitted as a "
-        "compile-only placeholder static, not a rust-gpu resource binding"
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 1, binding = 5))] linearSampler: Sampler"
     ) in generated_code
-    assert (
-        "resource colorMap is emitted as a compile-only placeholder static"
-        in generated_code
-        and "static COLOR_MAP: std::sync::LazyLock<Texture2D<f32>>" in generated_code
-    )
+    assert "CrossGL Rust limitation: resource colorMap" not in generated_code
+    assert "CrossGL Rust limitation: resource linearSampler" not in generated_code
+    assert "static COLOR_MAP" not in generated_code
+    assert "static LINEAR_SAMPLER" not in generated_code
     assert_generated_rust_smoke_compiles(generated_code, tmp_path)
 
 

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -7894,6 +7894,144 @@ def test_validate_project_report_fails_placeholder_marker_without_diagnostic(
     }
 
 
+def test_translate_project_rust_sampled_texture_uses_entry_resource_parameters(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    shader_dir = repo / "shaders"
+    shader_dir.mkdir(parents=True)
+    (shader_dir / "sampled.cgl").write_text(
+        textwrap.dedent("""
+            shader ProjectRustSampledTexture {
+                sampler2D colorMap @set(1) @binding(2);
+                sampler linearSampler @set(1) @binding(3);
+
+                fragment {
+                    vec4 main(vec2 uv) @ gl_FragColor {
+                        return texture(colorMap, linearSampler, uv);
+                    }
+                }
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["shaders"]
+            targets = ["rust"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    output = repo / "translated" / "rust" / "shaders" / "sampled.rs"
+
+    assert output.exists()
+    rust_code = output.read_text(encoding="utf-8")
+    assert payload["summary"]["translatedCount"] == 1
+    assert (
+        "// CrossGL resource metadata: name=colorMap kind=texture set=1 "
+        "binding=2 binding_source=explicit" in rust_code
+    )
+    assert (
+        "// CrossGL resource metadata: name=linearSampler kind=sampler set=1 "
+        "binding=3 binding_source=explicit" in rust_code
+    )
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 1, binding = 2))] colorMap: Texture2D<f32>"
+        in rust_code
+    )
+    assert (
+        '#[cfg_attr(feature = "crossgl_gpu", '
+        "spirv(descriptor_set = 1, binding = 3))] linearSampler: Sampler"
+        in rust_code
+    )
+    assert "return sample_sampler(colorMap, linearSampler, uv);" in rust_code
+    assert "CrossGL Rust limitation: resource colorMap" not in rust_code
+    assert "CrossGL Rust limitation: resource linearSampler" not in rust_code
+    assert "static COLOR_MAP" not in rust_code
+    assert "static LINEAR_SAMPLER" not in rust_code
+    assert not [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] == project_pipeline.GENERATED_PLACEHOLDER_DIAGNOSTIC_CODE
+        and diagnostic.get("target") == "rust"
+    ]
+
+
+def test_translate_project_rust_storage_buffer_placeholder_has_report_diagnostic(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    shader_dir = repo / "shaders"
+    shader_dir.mkdir(parents=True)
+    (shader_dir / "storage.cgl").write_text(
+        textwrap.dedent("""
+            shader ProjectRustStorageBuffer {
+                RWStructuredBuffer<int> values @binding(0);
+
+                compute {
+                    void main(uint index) {
+                        int value = buffer_load(values, index);
+                        buffer_store(values, index, value + 1);
+                    }
+                }
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["shaders"]
+            targets = ["rust"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    output = repo / "translated" / "rust" / "shaders" / "storage.rs"
+    report_path = repo / "translated" / "portability-report.json"
+    report.write_json(report_path)
+    placeholder_diagnostics = [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] == project_pipeline.GENERATED_PLACEHOLDER_DIAGNOSTIC_CODE
+        and diagnostic.get("target") == "rust"
+    ]
+
+    assert output.exists()
+    rust_code = output.read_text(encoding="utf-8")
+    assert "CrossGL Rust limitation: resource values" in rust_code
+    assert "static VALUES: std::sync::LazyLock<RWStructuredBuffer<i32>>" in rust_code
+    assert len(placeholder_diagnostics) == 1
+    assert placeholder_diagnostics[0]["location"]["file"] == (
+        "translated/rust/shaders/storage.rs"
+    )
+    assert "rust-gpu resource binding" in placeholder_diagnostics[0]["message"]
+    assert validate_project_report(report_path)["success"] is True
+
+    missing_payload = copy.deepcopy(payload)
+    _clear_report_diagnostics(missing_payload)
+    missing_report_path = repo / "translated" / "missing-storage-diagnostic.json"
+    missing_report_path.write_text(json.dumps(missing_payload), encoding="utf-8")
+    missing_validation = validate_project_report(missing_report_path)
+
+    assert missing_validation["success"] is False
+    assert (
+        missing_validation["diagnosticsByCode"][
+            project_pipeline.PLACEHOLDER_DIAGNOSTIC_MISSING_CODE
+        ]
+        == 1
+    )
+
+
 def test_translate_project_filters_invalid_include_dirs_before_frontend(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Lower explicitly bound sampled texture and sampler globals used directly by Rust shader entry points into attributed Rust parameters instead of placeholder statics.
- Reuse cached resource binding metadata so emitted comments and `#[spirv(...)]` parameter metadata agree.
- Add project coverage for sampled-texture Rust output and for storage-buffer placeholder diagnostics in portability reports.

## Validation
- `python3.11 -m pytest tests/test_translator/test_codegen/test_rust_codegen.py`
- `python3.11 -m pytest tests/test_translator/test_project_translation.py -k "rust_sampled_texture_uses_entry_resource_parameters or rust_storage_buffer_placeholder_has_report_diagnostic or placeholder_marker_without_diagnostic"`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

closes #1052
