### PR TITLE
Fix Mojo vector overload resolution for GLSL helpers

### DIFF
--- a/crosstl/translator/codegen/mojo_codegen.py
+++ b/crosstl/translator/codegen/mojo_codegen.py
@@ -1223,6 +1223,7 @@ class MojoCodeGen:
         self.struct_types = {}
         self.function_return_types = {}
         self.function_parameter_types = {}
+        self.function_overload_signatures = {}
         self.function_return_resource_aliases = {}
         self.function_return_resource_static_aliases = {}
         self.function_return_resource_field_aliases = {}
@@ -1484,6 +1485,7 @@ class MojoCodeGen:
         self.struct_types = {}
         self.function_return_types = {}
         self.function_parameter_types = {}
+        self.function_overload_signatures = {}
         self.function_return_resource_aliases = {}
         self.function_return_resource_static_aliases = {}
         self.function_return_resource_field_aliases = {}
@@ -2797,11 +2799,23 @@ class MojoCodeGen:
             return_type = self.convert_type_node_to_string(func.return_type)
         else:
             return_type = "void"
-        self.function_return_types[func.name] = return_type
-        self.function_parameter_types[func.name] = [
+        parameter_types = [
             self.function_parameter_type_name(param)
             for param in getattr(func, "parameters", getattr(func, "params", []))
         ]
+        self.function_return_types[func.name] = return_type
+        self.function_parameter_types[func.name] = parameter_types
+        signature = {
+            "return_type": return_type,
+            "parameter_types": parameter_types,
+        }
+        overloads = self.function_overload_signatures.setdefault(func.name, [])
+        if not any(
+            existing["return_type"] == return_type
+            and existing["parameter_types"] == parameter_types
+            for existing in overloads
+        ):
+            overloads.append(signature)
 
     def register_function_return_resource_aliases(self, func):
         if not hasattr(func, "name"):
@@ -10257,7 +10271,7 @@ class MojoCodeGen:
         return args, None
 
     def generate_user_function_call_arguments(self, func_name, args):
-        parameter_types = self.function_parameter_types.get(func_name, [])
+        parameter_types = self.selected_function_parameter_types(func_name, args)
         generated_args = []
         for index, arg in enumerate(args):
             target_type = (
@@ -14461,15 +14475,9 @@ class MojoCodeGen:
         if isinstance(expr, BinaryOpNode):
             left_type = self.expression_result_type(expr.left)
             right_type = self.expression_result_type(expr.right)
-            left_info = self.vector_type_info(left_type)
-            right_info = self.vector_type_info(right_type)
-            if left_info is not None and right_info is not None:
-                return left_type if left_info == right_info else left_type
-            if left_info is not None:
-                return left_type
-            if right_info is not None:
-                return right_type
-            return left_type if left_type == right_type else left_type or right_type
+            return self.binary_expression_result_type(
+                expr.op, left_type, right_type
+            )
         if isinstance(expr, TernaryOpNode):
             true_type = self.expression_result_type(expr.true_expr)
             false_type = self.expression_result_type(expr.false_expr)
@@ -14498,7 +14506,7 @@ class MojoCodeGen:
             if func_name in MOJO_MATRIX_TYPES:
                 return func_name
             if func_name in self.function_return_types:
-                return self.function_return_types[func_name]
+                return self.selected_function_return_type(func_name, expr.args)
             if func_name in self.scalar_constructor_map:
                 return func_name
             if func_name in {"fract", "frac"} and expr.args:
@@ -14754,6 +14762,113 @@ class MojoCodeGen:
             return func_expr
         return None
 
+    def binary_expression_result_type(self, op, left_type, right_type):
+        left_info = self.vector_type_info(left_type)
+        right_info = self.vector_type_info(right_type)
+        mapped_op = self.map_operator(op)
+        if left_info is not None and right_info is not None:
+            if left_info == right_info:
+                return left_type
+            if (
+                mapped_op in MOJO_VECTOR_ARITHMETIC_OPS
+                and left_info[0] == right_info[0]
+                and left_info[2] == right_info[2]
+                and left_info[0] != "DType.bool"
+            ):
+                return self.vector_type_name_for_dtype_width(
+                    left_info[0], max(left_info[1], right_info[1])
+                )
+            return left_type
+        if left_info is not None:
+            return left_type
+        if right_info is not None:
+            return right_type
+        return left_type if left_type == right_type else left_type or right_type
+
+    def selected_function_return_type(self, func_name, args):
+        signature = self.select_function_overload_signature(func_name, args)
+        if signature is not None:
+            return signature["return_type"]
+        return self.function_return_types.get(func_name)
+
+    def selected_function_parameter_types(self, func_name, args):
+        signature = self.select_function_overload_signature(func_name, args)
+        if signature is not None:
+            return signature["parameter_types"]
+        return self.function_parameter_types.get(func_name, [])
+
+    def select_function_overload_signature(self, func_name, args):
+        overloads = self.function_overload_signatures.get(func_name) or []
+        if not overloads:
+            return None
+
+        indexed = list(enumerate(overloads))
+        matching_arity = [
+            item
+            for item in indexed
+            if len(item[1]["parameter_types"]) == len(args)
+        ]
+        candidates = matching_arity or indexed
+        arg_types = [self.expression_result_type(arg) for arg in args]
+        best = None
+        for index, signature in candidates:
+            score = self.function_overload_match_score(
+                arg_types, signature["parameter_types"]
+            )
+            if score is None:
+                continue
+            key = (score, index)
+            if best is None or key < best[0]:
+                best = (key, signature)
+
+        if best is not None:
+            return best[1]
+        return candidates[-1][1] if candidates else None
+
+    def function_overload_match_score(self, arg_types, parameter_types):
+        score = 0
+        for arg_type, parameter_type in zip(arg_types, parameter_types):
+            part_score = self.function_overload_argument_match_score(
+                arg_type, parameter_type
+            )
+            if part_score is None:
+                return None
+            score += part_score
+        return score + abs(len(arg_types) - len(parameter_types)) * 100
+
+    def function_overload_argument_match_score(self, arg_type, parameter_type):
+        if arg_type is None or parameter_type is None:
+            return 10
+
+        arg_name = self.type_name(arg_type)
+        parameter_name = self.type_name(parameter_type)
+        if arg_name == parameter_name:
+            return 0
+
+        arg_vector = self.vector_type_info(arg_name)
+        parameter_vector = self.vector_type_info(parameter_name)
+        if arg_vector is not None or parameter_vector is not None:
+            if arg_vector is None or parameter_vector is None:
+                return None
+            if arg_vector == parameter_vector:
+                return 0
+            if self.compatible_numeric_vector_target(arg_vector, parameter_vector):
+                return 1
+            if self.compatible_storage_vector_target(arg_vector, parameter_vector):
+                return 2
+            return None
+
+        arg_dtype = MOJO_SCALAR_DTYPES.get(arg_name)
+        parameter_dtype = MOJO_SCALAR_DTYPES.get(parameter_name)
+        if arg_dtype is not None or parameter_dtype is not None:
+            if arg_dtype is None or parameter_dtype is None:
+                return None
+            if "DType.bool" in {arg_dtype, parameter_dtype}:
+                return None
+            return 1
+
+        return None
+
     def buffer_op_result_type(self, expr):
         operation = MOJO_BUFFER_OP_ALIASES.get(getattr(expr, "operation", ""))
         if operation is None:
@@ -14938,6 +15053,17 @@ class MojoCodeGen:
         if "DType.bool" in {source_dtype, target_dtype}:
             return False
         return source_dtype in MOJO_DTYPE_SUFFIX and target_dtype in MOJO_DTYPE_SUFFIX
+
+    def compatible_storage_vector_target(self, source_info, target_info):
+        if source_info is None or target_info is None:
+            return False
+        source_dtype, source_width, source_storage_width, _ = source_info
+        target_dtype, target_width, target_storage_width, _ = target_info
+        if source_dtype != target_dtype or source_dtype == "DType.bool":
+            return False
+        if source_storage_width != target_storage_width:
+            return False
+        return source_width <= target_width
 
     def generate_numeric_vector_binary_op(self, expr, target_type, target_context=None):
         op = self.map_operator(expr.op)

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -30,7 +30,7 @@ implicitly supported.
    "Vulkan SPIR-V", "", "", ".spvasm", "crosstl/translator/codegen/SPIRV_codegen.py", "native", "crosstl/backend/SPIRV", "tests/test_translator/test_codegen/test_SPIRV_codegen.py, tests/test_backend/test_SPIRV", "1003", "46", "SPIR-V unified grammar; Khronos SPIR-V headers"
    "CUDA", "", "", ".cu", "crosstl/translator/codegen/cuda_codegen.py", "native", "crosstl/backend/CUDA", "tests/test_translator/test_codegen/test_CUDA_codegen.py, tests/test_backend/test_CUDA", "779", "194", "CUDA C++ programming guide"
    "HIP", "", "", ".hip", "crosstl/translator/codegen/hip_codegen.py", "native", "crosstl/backend/HIP", "tests/test_translator/test_codegen/test_hip_codegen.py, tests/test_backend/test_HIP", "828", "136", "ROCm HIP documentation"
-   "Mojo", "", "", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "922", "100", "Mojo manual"
+   "Mojo", "", "", ".mojo", "crosstl/translator/codegen/mojo_codegen.py", "native", "crosstl/backend/Mojo", "tests/test_translator/test_codegen/test_mojo_codegen.py, tests/test_backend/test_mojo", "925", "100", "Mojo manual"
    "Rust", "", "", ".rs", "crosstl/translator/codegen/rust_codegen.py", "native", "crosstl/backend/Rust", "tests/test_translator/test_codegen/test_rust_codegen.py, tests/test_backend/test_rust", "985", "69", "Rust reference"
    "Slang", "", "", ".slang", "crosstl/translator/codegen/slang_codegen.py", "native", "crosstl/backend/slang", "tests/test_translator/test_codegen/test_slang_codegen.py, tests/test_backend/test_slang", "789", "410", "Slang user guide"
 

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -1088,7 +1088,7 @@
           "tests/test_translator/test_codegen/test_mojo_codegen.py",
           "tests/test_backend/test_mojo"
         ],
-        "test_count": 922
+        "test_count": 925
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_mojo_codegen.py
+++ b/tests/test_translator/test_codegen/test_mojo_codegen.py
@@ -5,6 +5,7 @@ from typing import List
 
 import pytest
 
+import crosstl
 import crosstl.translator
 from crosstl.translator.ast import (
     ArrayAccessNode,
@@ -27048,6 +27049,89 @@ def test_texture2d_sampler2d_resource_declarations_produce_mojo_types():
     assert "var envMap: TextureCube" in generated_code
     assert "sample(diffuseMap, uv)" in generated_code
     assert "fn sample(tex: Texture2D" in generated_code
+
+
+def test_vector_helper_overload_uses_wider_binary_result_for_mojo():
+    code = """
+    float linearToSrgb(float color) {
+        return color;
+    }
+    vec3 linearToSrgb(vec3 color) {
+        return color;
+    }
+    vec4 linearToSrgb(vec4 color) {
+        return color;
+    }
+
+    vec4 shade(vec3 light, vec4 texel) {
+        return linearToSrgb(light * texel);
+    }
+    """
+    generated_code = generate_code(parse_code(tokenize_code(code)))
+
+    assert (
+        "fn shade(light: SIMD[DType.float32, 4], texel: SIMD[DType.float32, 4])"
+        in generated_code
+    )
+    assert "return linearToSrgb((light * texel))" in generated_code
+
+
+def test_vector_helper_overload_selects_vec4_after_scalar_multiply_for_mojo():
+    code = """
+    float linearToSrgb(float color) {
+        return color;
+    }
+    vec4 linearToSrgb(vec4 color) {
+        return color;
+    }
+    vec3 linearToSrgb(vec3 color) {
+        return color;
+    }
+
+    vec4 shade(float light, vec4 texel) {
+        return linearToSrgb(light * texel);
+    }
+    """
+    generated_code = generate_code(parse_code(tokenize_code(code)))
+
+    assert "fn shade(light: Float32, texel: SIMD[DType.float32, 4])" in generated_code
+    assert "return linearToSrgb((light * texel))" in generated_code
+
+
+def test_glsl_overloaded_vector_helper_texture_call_translates_to_mojo(tmp_path):
+    source = """
+    #version 450
+    layout(binding = 0) uniform sampler2D tex;
+    layout(location = 0) in vec2 texcoord;
+    layout(location = 0) out vec4 fragColor;
+
+    float linearToSrgb(float color) {
+        return color;
+    }
+    vec3 linearToSrgb(vec3 color) {
+        return color;
+    }
+    vec4 linearToSrgb(vec4 color) {
+        return color;
+    }
+
+    void main() {
+        vec3 light = vec3(0.5);
+        fragColor = linearToSrgb(light * texture(tex, texcoord.xy));
+    }
+    """
+    source_path = tmp_path / "linear_to_srgb.frag"
+    source_path.write_text(source, encoding="utf-8")
+
+    generated_code = crosstl.translate(
+        str(source_path),
+        backend="mojo",
+        source_backend="opengl",
+        format_output=False,
+    )
+
+    assert "fragColor = linearToSrgb((light * sample(tex," in generated_code
+    assert "Invalid aggregate target" not in generated_code
 
 
 def test_combined_texture_sampler_sampling_in_mojo():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -611,6 +611,59 @@ def test_translate_project_glslang_spec_constant_vertex_to_directx(tmp_path):
     assert "foo(input.ucol, input, output);" in generated
 
 
+def test_translate_project_glsl_overloaded_vector_helper_to_mojo(tmp_path):
+    repo = tmp_path / "repo"
+    shader_dir = repo / "shaders"
+    shader_dir.mkdir(parents=True)
+    (shader_dir / "linear_to_srgb.frag").write_text(
+        textwrap.dedent("""
+        #version 450
+        layout(binding = 0) uniform sampler2D tex;
+        layout(location = 0) in vec2 texcoord;
+        layout(location = 0) out vec4 fragColor;
+
+        float linearToSrgb(float color) {
+            return color;
+        }
+        vec3 linearToSrgb(vec3 color) {
+            return color;
+        }
+        vec4 linearToSrgb(vec4 color) {
+            return color;
+        }
+
+        void main() {
+            vec3 light = vec3(0.5);
+            fragColor = linearToSrgb(light * texture(tex, texcoord.xy));
+        }
+        """).strip(),
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+        [project]
+        source_roots = ["shaders"]
+        include = ["shaders/*.frag"]
+        targets = ["mojo"]
+        output_dir = "translated"
+        """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo), format_output=False)
+    payload = report.to_json()
+    generated = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 0
+    assert not [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if "Invalid aggregate target" in diagnostic.get("message", "")
+    ]
+    assert "fragColor = linearToSrgb((light * sample(tex," in generated
+
+
 @pytest.mark.parametrize("target_backend", ("opengl", "metal"))
 def test_translate_project_lowers_slang_default_parameter_calls(
     tmp_path, target_backend


### PR DESCRIPTION
## Summary
- Preserve Mojo overload metadata for user-defined helper functions and select matching signatures from inferred argument types.
- Infer same-storage vector arithmetic with the wider logical vector so GLSL helper calls validate against the vec4 overload.
- Add Mojo codegen, GLSL-to-Mojo, and project translation regression coverage; refresh the Mojo support matrix test count.

## Validation
- `python3.11 -m pytest tests/test_translator/test_codegen/test_mojo_codegen.py`
- `python3.11 -m pytest tests/test_translator/test_project_translation.py -k 'mojo'`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`

closes #1048
