### PR TITLE
Lower CUDA and HIP pointer kernel params to OpenGL resources

### DIFF
--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -288,6 +288,7 @@ from .stage_utils import (
     collect_stage_local_variables,
     compute_local_size,
     deduplicate_named_declarations,
+    function_stage_name,
     normalize_stage_name,
     order_functions_by_dependencies,
     should_emit_qualified_function,
@@ -315,7 +316,13 @@ class GLSLCodeGen:
         }
     )
     MESH_STAGE_NAMES = {"mesh", "task", "amplification", "object"}
-    UNSIGNED_VECTOR_COMPUTE_BUILTINS = {"gl_GlobalInvocationID"}
+    UNSIGNED_VECTOR_COMPUTE_BUILTINS = {
+        "gl_GlobalInvocationID",
+        "gl_LocalInvocationID",
+        "gl_WorkGroupID",
+        "gl_NumWorkGroups",
+        "gl_WorkGroupSize",
+    }
     GLSL_STAGE_GUARD_MACROS = {
         "vertex": "GL_VERTEX_SHADER",
         "fragment": "GL_FRAGMENT_SHADER",
@@ -1652,12 +1659,7 @@ class GLSLCodeGen:
         stage_names = set()
 
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if getattr(func, "qualifiers", None)
-                else getattr(func, "qualifier", None)
-            )
-            stage_name = normalize_stage_name(qualifier)
+            stage_name = function_stage_name(func)
             if should_emit_qualified_function(target_stage, stage_name):
                 stage_names.add(stage_name)
 
@@ -2171,12 +2173,7 @@ class GLSLCodeGen:
         roots.extend(getattr(ast, "constants", []) or [])
 
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if getattr(func, "qualifiers", None)
-                else getattr(func, "qualifier", None)
-            )
-            stage_name = normalize_stage_name(qualifier)
+            stage_name = function_stage_name(func)
             if should_emit_qualified_function(target_stage, stage_name):
                 roots.append(func)
 
@@ -3330,11 +3327,7 @@ class GLSLCodeGen:
         for func in functions:
             if id(func) in deferred_top_level_helper_ids:
                 continue
-            if hasattr(func, "qualifiers") and func.qualifiers:
-                qualifier = func.qualifiers[0] if func.qualifiers else None
-            else:
-                qualifier = getattr(func, "qualifier", None)
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
 
             if not should_emit_qualified_function(target_stage, qualifier_name):
                 continue
@@ -3516,10 +3509,7 @@ class GLSLCodeGen:
                 func_name = getattr(func, "name", None)
                 if not func_name or id(func) in deferred_ids:
                     continue
-                if normalize_stage_name(getattr(func, "qualifier", None)):
-                    continue
-                qualifiers = getattr(func, "qualifiers", []) or []
-                if qualifiers and normalize_stage_name(qualifiers[0]):
+                if function_stage_name(func):
                     continue
 
                 for node in self.walk_ast(getattr(func, "body", [])):
@@ -4189,12 +4179,7 @@ class GLSLCodeGen:
         stage_entry_types = self.combined_stage_entry_types()
         has_global_main_helper = False
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if hasattr(func, "qualifiers") and func.qualifiers
-                else getattr(func, "qualifier", None)
-            )
-            stage_name = normalize_stage_name(qualifier)
+            stage_name = function_stage_name(func)
             if stage_name in stage_entry_types:
                 continue
             if getattr(func, "name", None) == "main":
@@ -4234,19 +4219,29 @@ class GLSLCodeGen:
         )
         self.stage_entry_constant_value_parameter_aliases = {}
         stage_entry_types = self.combined_stage_entry_types()
-        for _entry_id, _stage_name, func in collect_stage_entry_records(
+        for _entry_id, stage_name, func in collect_stage_entry_records(
             ast, target_stage, stage_entry_types
         ):
             for parameter in getattr(func, "parameters", getattr(func, "params", [])):
                 member_type = self.stage_entry_constant_value_parameter_type(parameter)
+                if member_type is None and stage_name == "compute":
+                    member_type = self.stage_entry_compute_value_parameter_type(
+                        parameter
+                    )
                 if member_type is None:
                     continue
                 binding = self.explicit_resource_binding_index(parameter)
-                if binding is None:
-                    continue
                 parameter_name = getattr(parameter, "name", None)
                 if not parameter_name:
                     continue
+                attributes = []
+                if binding is not None:
+                    attributes.append(
+                        AttributeNode(
+                            "binding",
+                            [LiteralNode(binding, PrimitiveType("int"))],
+                        )
+                    )
                 block_name = self.unique_stage_entry_constant_value_block_name(
                     self.stage_entry_constant_value_parameter_block_name(
                         func, parameter_name
@@ -4267,12 +4262,7 @@ class GLSLCodeGen:
                 cbuffer = StructNode(
                     block_name,
                     [member],
-                    attributes=[
-                        AttributeNode(
-                            "binding",
-                            [LiteralNode(binding, PrimitiveType("int"))],
-                        )
-                    ],
+                    attributes=attributes,
                 )
                 cbuffer.is_cbuffer = True
                 cbuffers.append(cbuffer)
@@ -5797,12 +5787,7 @@ class GLSLCodeGen:
         for func in functions:
             if id(func) not in top_level_function_ids:
                 continue
-            qualifier = (
-                func.qualifiers[0]
-                if getattr(func, "qualifiers", None)
-                else getattr(func, "qualifier", None)
-            )
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
             if qualifier_name in stage_entry_types:
                 continue
             if should_emit_qualified_function(target_stage, qualifier_name):
@@ -6513,11 +6498,7 @@ class GLSLCodeGen:
         functions = []
 
         for func in getattr(ast, "functions", []) or []:
-            qualifiers = getattr(func, "qualifiers", []) or []
-            qualifier = (
-                qualifiers[0] if qualifiers else getattr(func, "qualifier", None)
-            )
-            if normalize_stage_name(qualifier) == stage_name:
+            if function_stage_name(func) == stage_name:
                 functions.append(func)
 
         for stage_type, stage in getattr(ast, "stages", {}).items():
@@ -6754,12 +6735,7 @@ class GLSLCodeGen:
                 seen.add(id(param))
 
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if hasattr(func, "qualifiers") and func.qualifiers
-                else getattr(func, "qualifier", None)
-            )
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
             if qualifier_name not in stage_entry_types:
                 continue
             if should_emit_qualified_function(target_stage, qualifier_name):
@@ -6802,6 +6778,7 @@ class GLSLCodeGen:
             "array_sizes",
             "declarator_type_suffix",
             "declarator_type_suffix_grouped",
+            "resource_qualifiers",
         ):
             if hasattr(parameter, attr_name):
                 setattr(node, attr_name, getattr(parameter, attr_name))
@@ -6998,6 +6975,27 @@ class GLSLCodeGen:
             type_name = stripped
 
     def stage_entry_constant_value_parameter_type(self, param):
+        resource_qualifiers = self.resource_parameter_qualifiers(param)
+        if "uniform" in resource_qualifiers:
+            raw_type = self.resource_node_type(param)
+            if isinstance(raw_type, (PointerType, ReferenceType)):
+                return None
+            type_name = self.type_name_string(raw_type)
+            if not type_name or type_name in self.structs_by_name:
+                return None
+            if self.is_sampler_type(type_name):
+                return None
+            if self.is_structured_buffer_type(type_name) or self.is_constant_buffer_type(
+                type_name
+            ):
+                return None
+            mapped_type = self.map_resource_type_with_format(
+                self.resource_base_type(type_name), param
+            )
+            if self.is_opaque_resource_type(mapped_type):
+                return None
+            return type_name
+
         qualifiers = {str(q).lower() for q in getattr(param, "qualifiers", []) or []}
         if "constant" not in qualifiers:
             return None
@@ -7016,6 +7014,33 @@ class GLSLCodeGen:
             self.type_name_string(raw_type)
         )
         if not type_name or type_name in self.structs_by_name:
+            return None
+        if self.is_sampler_type(type_name):
+            return None
+        if self.is_structured_buffer_type(type_name) or self.is_constant_buffer_type(
+            type_name
+        ):
+            return None
+        mapped_type = self.map_resource_type_with_format(
+            self.resource_base_type(type_name), param
+        )
+        if self.is_opaque_resource_type(mapped_type):
+            return None
+        return type_name
+
+    def stage_entry_compute_value_parameter_type(self, param):
+        if self.semantic_from_node(param) is not None:
+            return None
+        if self.is_stage_entry_resource_parameter(param):
+            return None
+
+        raw_type = self.resource_node_type(param)
+        if isinstance(raw_type, (PointerType, ReferenceType)):
+            return None
+        type_name = self.type_name_string(raw_type)
+        if not type_name or type_name in self.structs_by_name:
+            return None
+        if "[" in str(type_name) and "]" in str(type_name):
             return None
         if self.is_sampler_type(type_name):
             return None
@@ -7062,10 +7087,41 @@ class GLSLCodeGen:
         )
         return f"{buffer_type}<{element_type}>"
 
+    def resource_parameter_qualifiers(self, param):
+        return {
+            str(qualifier).lower()
+            for qualifier in getattr(param, "resource_qualifiers", []) or []
+        }
+
+    def stage_entry_storage_array_structured_buffer_type(self, param):
+        resource_qualifiers = self.resource_parameter_qualifiers(param)
+        if "storage" not in resource_qualifiers:
+            return None
+
+        raw_type = self.resource_node_type(param)
+        if not (
+            hasattr(raw_type, "element_type")
+            and str(type(raw_type)).find("ArrayType") != -1
+        ):
+            return None
+
+        element_type = self.convert_type_node_to_string(raw_type.element_type)
+        access = None
+        for qualifier in resource_qualifiers:
+            normalized = normalized_image_access(qualifier)
+            if normalized is not None:
+                access = normalized
+                break
+        buffer_type = "StructuredBuffer" if access == "read" else "RWStructuredBuffer"
+        return f"{buffer_type}<{element_type}>"
+
     def stage_entry_resource_parameter_type(self, param):
         constant_struct_type = self.stage_entry_constant_struct_parameter_type(param)
         if constant_struct_type is not None:
             return constant_struct_type
+        storage_array_type = self.stage_entry_storage_array_structured_buffer_type(param)
+        if storage_array_type is not None:
+            return storage_array_type
         return self.stage_entry_metal_pointer_structured_buffer_type(param)
 
     def stage_entry_parameter_expression_type(self, param, raw_type):
@@ -7105,6 +7161,8 @@ class GLSLCodeGen:
         if self.is_sampler_type(raw_type):
             return False
         if self.is_stage_entry_resource_parameter(param):
+            return False
+        if self.stage_entry_constant_value_parameter_type(param) is not None:
             return False
         type_name = self.type_node_name(raw_type)
         return type_name not in self.structs_by_name
@@ -7303,12 +7361,7 @@ class GLSLCodeGen:
                     declarations.append(declaration)
 
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if hasattr(func, "qualifiers") and func.qualifiers
-                else getattr(func, "qualifier", None)
-            )
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
             if qualifier_name not in graphics_stages:
                 continue
             if not should_emit_qualified_function(target_stage, qualifier_name):
@@ -7383,12 +7436,7 @@ class GLSLCodeGen:
                     declarations.append(declaration)
 
         for func in getattr(ast, "functions", []) or []:
-            qualifier = (
-                func.qualifiers[0]
-                if hasattr(func, "qualifiers") and func.qualifiers
-                else getattr(func, "qualifier", None)
-            )
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
             if qualifier_name not in graphics_stages:
                 continue
             if not should_emit_qualified_function(target_stage, qualifier_name):
@@ -9679,6 +9727,19 @@ class GLSLCodeGen:
             return constructor
         return None
 
+    def glsl_builtin_identifier_result_type(self, name):
+        if not name:
+            return None
+        target_name = self.glsl_target_builtin_identifier(name)
+        return {
+            "gl_GlobalInvocationID": "uvec3",
+            "gl_LocalInvocationID": "uvec3",
+            "gl_WorkGroupID": "uvec3",
+            "gl_NumWorkGroups": "uvec3",
+            "gl_WorkGroupSize": "uvec3",
+            "gl_LocalInvocationIndex": "uint",
+        }.get(target_name)
+
     def expression_result_type(self, expr):
         if expr is None:
             return None
@@ -9688,6 +9749,15 @@ class GLSLCodeGen:
                 self.local_variable_types.get(name)
                 or self.glsl_buffer_block_variable_types.get(name)
                 or self.global_variable_types.get(name)
+                or self.glsl_builtin_identifier_result_type(name)
+            )
+        if hasattr(expr, "__class__") and "IdentifierNode" in str(type(expr)):
+            name = getattr(expr, "name", None)
+            return (
+                self.local_variable_types.get(name)
+                or self.glsl_buffer_block_variable_types.get(name)
+                or self.global_variable_types.get(name)
+                or self.glsl_builtin_identifier_result_type(name)
             )
         if isinstance(expr, (int, float)):
             return "float" if isinstance(expr, float) else "int"
@@ -17713,6 +17783,12 @@ class GLSLCodeGen:
     def resource_access_metadata_choices(self, node):
         choices = []
         for qualifier in getattr(node, "qualifiers", []) or []:
+            source = str(qualifier).lower()
+            access = normalized_image_access(source)
+            if access is not None:
+                choices.append((source, access))
+
+        for qualifier in getattr(node, "resource_qualifiers", []) or []:
             source = str(qualifier).lower()
             access = normalized_image_access(source)
             if access is not None:

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -35418,6 +35418,100 @@ def test_translate_project_opencl_targets_do_not_leak_resource_parameter_syntax(
     assert "kernel void kernel_scale(" in outputs["metal"]
 
 
+def test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "vectorAdd.cu").write_text(
+        textwrap.dedent("""
+            extern "C" __global__ void vectorAdd(const float *A,
+                                                  const float *B,
+                                                  float *C,
+                                                  int numElements) {
+                int i = blockDim.x * blockIdx.x + threadIdx.x;
+                if (i < numElements) {
+                    C[i] = A[i] + B[i];
+                }
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["opengl"],
+        output_dir="out",
+    ).to_json()
+
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("opengl", "translated")}
+
+    output = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
+
+    assert "layout(std430, binding = 0) buffer ABuffer { float A[]; };" in output
+    assert "layout(std430, binding = 1) buffer BBuffer { float B[]; };" in output
+    assert "layout(std430, binding = 2) buffer CBuffer { float C[]; };" in output
+    assert "uniform vectorAdd_numElements_Args" in output
+    assert "void main()" in output
+    assert "void vectorAdd(float A[]" not in output
+    assert "float A[], float B[]" not in output
+
+    assert_compute_glsl_validates_if_available(output, tmp_path)
+
+
+def test_translate_project_hip_pointer_parameters_lower_to_opengl_buffers(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "add_kernel.hip").write_text(
+        textwrap.dedent("""
+            #include <hip/hip_runtime.h>
+
+            __global__ void addKernel(const float *A,
+                                      const float *B,
+                                      float *C,
+                                      int N) {
+                int i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+                if (i < N) {
+                    C[i] = A[i] + B[i];
+                }
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["opengl"],
+        output_dir="out",
+    ).to_json()
+
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("opengl", "translated")}
+
+    output = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
+
+    assert (
+        "layout(std430, binding = 0) readonly buffer ABuffer { float A[]; };"
+        in output
+    )
+    assert (
+        "layout(std430, binding = 1) readonly buffer BBuffer { float B[]; };"
+        in output
+    )
+    assert "layout(std430, binding = 2) buffer CBuffer { float C[]; };" in output
+    assert "layout(std140, binding = 3) uniform addKernel_N_Args" in output
+    assert "void main()" in output
+    assert "void addKernel(float A[]" not in output
+    assert "float A[], float B[]" not in output
+
+    assert_compute_glsl_validates_if_available(output, tmp_path)
+
+
 def test_translate_project_opencl_directx_allocates_generated_parameter_bindings(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Lower bound CUDA/HIP storage array kernel parameters to OpenGL SSBO declarations instead of function array parameters.
- Treat compute scalar kernel parameters as uniform block members when needed for valid GLSL entry points.
- Reuse attribute-based stage detection so generated `@compute` CrossGL emits a GLSL `main()` entry point.

## Validation
- `python3.11 -m pytest tests/test_translator/test_project_translation.py::test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers tests/test_translator/test_project_translation.py::test_translate_project_hip_pointer_parameters_lower_to_opengl_buffers tests/test_translator/test_project_translation.py::test_translate_project_opencl_targets_do_not_leak_resource_parameter_syntax tests/test_backend/test_metal/test_codegen.py::test_glsl_codegen_lowers_native_metal_entry_buffer_parameters_to_resources tests/test_translator/test_codegen/test_GLSL_codegen.py::test_structured_buffer_operations_lower_to_ssbo tests/test_translator/test_codegen/test_GLSL_codegen.py::test_compute_stage_validates_builtin_parameter_types tests/test_translator/test_codegen/test_GLSL_codegen.py::test_glsl_hlsl_compute_builtin_parameter_aliases_to_glsl_builtins tests/test_translator/test_codegen/test_GLSL_codegen.py::test_readonly_structured_buffer_uses_readonly_ssbo tests/test_translator/test_codegen/test_GLSL_codegen.py::test_glsl_structured_buffer_access_metadata_emits_ssbo_qualifiers tests/test_translator/test_codegen/test_GLSL_codegen.py::test_structured_buffer_arrays_lower_to_ssbo_instance_arrays`
- `python3.11 tools/support_matrix.py check`
- `python3.11 -m crosstl._crosstl translate-project <cuda-case> --output-dir issue-probe-out --report <cuda-case>/issue-probe-out/report.json --validate --no-format --target opengl`
- `python3.11 -m crosstl._crosstl translate-project <hip-case> --output-dir issue-probe-out --report <hip-case>/issue-probe-out/report.json --validate --no-format --target opengl`
- `glslangValidator -S comp <cuda-case>/issue-probe-out/opengl/vectorAdd.glsl`
- `glslangValidator -S comp <hip-case>/issue-probe-out/opengl/add_kernel.glsl`

closes #1070
