### PR TITLE
Add DirectX regression for Metal pointer resources

### DIFF
--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1101", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1102", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1185", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "80", "69", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1101
+        "test_count": 1102
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -1842,6 +1842,61 @@ def test_hlsl_stage_entry_buffer_pointer_params_promote_to_resources():
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
 
 
+def test_hlsl_metal_matmul_pointer_params_lower_to_resources(tmp_path):
+    shader = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct MatMulParams {
+        uint row_dim_x;
+        uint col_dim_x;
+        uint inner_dim;
+    };
+
+    kernel void mat_mul_simple1(
+        device const float* A [[buffer(0)]],
+        device const float* B [[buffer(1)]],
+        device float* X [[buffer(2)]],
+        constant MatMulParams& params [[buffer(3)]],
+        uint3 id [[thread_position_in_grid]])
+    {
+        uint row = id.y;
+        uint col = id.x;
+        if (row >= params.row_dim_x || col >= params.col_dim_x) {
+            return;
+        }
+        float sum = 0.0;
+        for (uint k = 0; k < params.inner_dim; k++) {
+            sum += A[row * params.inner_dim + k] *
+                B[k * params.col_dim_x + col];
+        }
+        X[row * params.col_dim_x + col] = sum;
+    }
+    """
+    shader_path = tmp_path / "mat_mul_simple1.metal"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="metal",
+    )
+
+    assert "StructuredBuffer<float> A : register(t0);" in generated_code
+    assert "StructuredBuffer<float> B : register(t1);" in generated_code
+    assert "RWStructuredBuffer<float> X : register(u2);" in generated_code
+    assert "ConstantBuffer<MatMulParams> params : register(b3);" in generated_code
+    assert "void CSMain(uint3 id : SV_DispatchThreadID)" in generated_code
+    assert "float* A" not in generated_code
+    assert "float* B" not in generated_code
+    assert "float* X" not in generated_code
+    assert "A.Load(((row * params.inner_dim) + k))" in generated_code
+    assert "B.Load(((k * params.col_dim_x) + col))" in generated_code
+    assert "X.Store(((row * params.col_dim_x) + col), sum);" in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
 def test_hlsl_default_integer_storage_image_vector_load_store_from_compiler_fixture():
     # Reduced from CrossGL-Compiler
     # tests/frontend/fixtures/StorageImageHIRShader.cgl.


### PR DESCRIPTION
## Summary
- Add an end-to-end Metal matmul to DirectX regression for device pointer kernel parameters.
- Assert Metal buffer attributes lower to explicit HLSL StructuredBuffer, RWStructuredBuffer, and ConstantBuffer resources with preserved register bindings.
- Assert the generated compute entry signature remains pointer-free and parseable as HLSL.

## Tests
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_stage_entry_buffer_pointer_params_promote_to_resources tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_metal_matmul_pointer_params_lower_to_resources
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py
- glslangValidator -D -V -S comp -e CSMain generated mat_mul_simple1.hlsl
- git diff --check

closes #1168
