### PR TITLE
Fix CUDA vector-add DirectX lowering

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -193,7 +193,11 @@ def translate(
             if source_spec.name == "opencl" and normalized_backend != "webgl":
                 validate_opencl_intermediate_for_target(cgl_ast, normalized_backend)
                 cgl_ast = normalize_opencl_intermediate_for_target(cgl_ast)
-            if source_spec.name == "cuda" and normalized_backend in {"metal", "vulkan"}:
+            if source_spec.name == "cuda" and normalized_backend in {
+                "directx",
+                "metal",
+                "vulkan",
+            }:
                 cgl_ast = normalize_opencl_intermediate_for_target(cgl_ast)
             codegen = get_codegen(requested_backend)
             lower_default_arguments(cgl_ast)

--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -3535,11 +3535,21 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                     )
         elif effective_shader_type == "compute":
             for (
+                builtin_name,
                 name,
                 param_type,
                 semantic,
-            ) in self.required_hlsl_compute_builtin_parameters(func):
-                if not name or name in param_names:
+                alias,
+            ) in self.required_hlsl_compute_builtin_parameters(
+                func, execution_config
+            ):
+                if alias is not None:
+                    self.current_identifier_aliases[builtin_name] = alias
+                    continue
+                if not name:
+                    continue
+                self.current_identifier_aliases[builtin_name] = name
+                if name in param_names:
                     continue
                 declaration = f"{param_type} {name}"
                 if semantic:
@@ -13996,19 +14006,48 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 used_names.add(base_name)
         return used_names
 
-    def required_hlsl_compute_builtin_parameters(self, func):
+    def required_hlsl_compute_builtin_parameters(self, func, execution_config=None):
         used_names = self.used_hlsl_compute_builtin_names(getattr(func, "body", []))
         builtin_parameters = [
-            ("gl_GlobalInvocationID", "uint3", "SV_DispatchThreadID"),
-            ("gl_LocalInvocationID", "uint3", "SV_GroupThreadID"),
-            ("gl_WorkGroupID", "uint3", "SV_GroupID"),
-            ("gl_LocalInvocationIndex", "uint", "SV_GroupIndex"),
-            ("gl_WorkGroupSize", "uint3", None),
-            ("gl_NumWorkGroups", "uint3", None),
+            ("gl_GlobalInvocationID", "dispatchThreadID", "uint3", "SV_DispatchThreadID"),
+            ("gl_LocalInvocationID", "groupThreadID", "uint3", "SV_GroupThreadID"),
+            ("gl_WorkGroupID", "groupID", "uint3", "SV_GroupID"),
+            ("gl_LocalInvocationIndex", "groupIndex", "uint", "SV_GroupIndex"),
+            (
+                "gl_WorkGroupSize",
+                None,
+                None,
+                None,
+                self.hlsl_compute_workgroup_size_expression(execution_config),
+            ),
+            ("gl_NumWorkGroups", "numWorkGroups", "uint3", None),
         ]
-        return [
-            parameter for parameter in builtin_parameters if parameter[0] in used_names
-        ]
+        reserved_names = set(self.local_variable_types)
+        reserved_names.update(self.global_variable_types)
+        reserved_names.update(self.current_identifier_reserved_names)
+        reserved_names.update(self.current_identifier_aliases.values())
+
+        required_parameters = []
+        for parameter in builtin_parameters:
+            builtin_name, base_name, param_type, semantic, *alias = parameter
+            if builtin_name not in used_names:
+                continue
+            alias_expression = alias[0] if alias else None
+            if alias_expression is not None:
+                required_parameters.append(
+                    (builtin_name, None, None, None, alias_expression)
+                )
+                continue
+            name = self.hlsl_unique_local_identifier(base_name, reserved_names)
+            reserved_names.add(name)
+            required_parameters.append(
+                (builtin_name, name, param_type, semantic, None)
+            )
+        return required_parameters
+
+    def hlsl_compute_workgroup_size_expression(self, execution_config=None):
+        x, y, z = compute_local_size(execution_config)
+        return f"uint3({x}, {y}, {z})"
 
     def collect_resource_array_size_hints(self, ast):
         return collect_resource_array_size_hints(

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -33594,11 +33594,16 @@ def test_hlsl_compute_builtins_are_auto_parameters_when_referenced_by_name():
 
     generated_code = generate_code(parse_code(tokenize_code(shader)))
 
-    assert "uint3 gl_GlobalInvocationID : SV_DispatchThreadID" in generated_code
-    assert "uint3 gl_LocalInvocationID : SV_GroupThreadID" in generated_code
-    assert "uint3 gl_WorkGroupID : SV_GroupID" in generated_code
-    assert "uint gl_LocalInvocationIndex : SV_GroupIndex" in generated_code
-    assert "uint3 gl_NumWorkGroups" in generated_code
+    assert "uint3 dispatchThreadID : SV_DispatchThreadID" in generated_code
+    assert "uint3 groupThreadID : SV_GroupThreadID" in generated_code
+    assert "uint3 groupID : SV_GroupID" in generated_code
+    assert "uint groupIndex : SV_GroupIndex" in generated_code
+    assert "uint3 numWorkGroups" in generated_code
+    assert "gl_GlobalInvocationID" not in generated_code
+    assert "gl_LocalInvocationID" not in generated_code
+    assert "gl_WorkGroupID" not in generated_code
+    assert "gl_LocalInvocationIndex" not in generated_code
+    assert "gl_NumWorkGroups" not in generated_code
 
 
 def test_hlsl_arrayed_resource_struct_members_lower_to_globals():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -40161,7 +40161,7 @@ def test_translate_project_cuda_vector_add_lowers_compute_builtins_for_targets(
 
     payload = translate_project(
         repo,
-        targets=["cgl", "metal", "vulkan", "wgsl"],
+        targets=["cgl", "directx", "metal", "vulkan", "wgsl"],
         output_dir="out",
     ).to_json()
 
@@ -40169,6 +40169,7 @@ def test_translate_project_cuda_vector_add_lowers_compute_builtins_for_targets(
         (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
     } == {
         ("cgl", "translated"),
+        ("directx", "translated"),
         ("metal", "translated"),
         ("vulkan", "translated"),
         ("wgsl", "translated"),
@@ -40206,6 +40207,27 @@ def test_translate_project_cuda_vector_add_lowers_compute_builtins_for_targets(
         "gl_WorkGroupSize",
     ]:
         assert gl_builtin not in metal_output
+
+    directx_output = outputs["directx"]
+    assert "RWStructuredBuffer<float> C : register(u0);" in directx_output
+    assert "RWStructuredBuffer<float> A : register(u1);" in directx_output
+    assert "RWStructuredBuffer<float> B : register(u2);" in directx_output
+    assert "cbuffer vectorAdd_Args : register(b3)" in directx_output
+    assert "uint3 groupID : SV_GroupID" in directx_output
+    assert "uint3 groupThreadID : SV_GroupThreadID" in directx_output
+    assert "SV_DispatchThreadID" not in directx_output
+    assert "float A[]" not in directx_output
+    assert "float B[]" not in directx_output
+    assert "float C[]" not in directx_output
+    assert ": group" not in directx_output
+    for gl_builtin in [
+        "gl_GlobalInvocationID",
+        "gl_WorkGroupID",
+        "gl_LocalInvocationID",
+        "gl_WorkGroupSize",
+    ]:
+        assert gl_builtin not in directx_output
+    assert_directx_compute_validates_if_available(directx_output, tmp_path)
 
     spirv_output = outputs["vulkan"]
     assert "OpEntryPoint GLCompute" in spirv_output


### PR DESCRIPTION
## Summary
- lower CUDA storage-array kernel parameters through the existing target resource normalization for DirectX
- map implicit compute builtins to HLSL system-value inputs and workgroup-size constants
- add CUDA vector-add DirectX regression coverage with validator checks

closes #1173

## Tests
- python3.11 -m pytest tests/test_translator/test_project_translation.py::test_translate_project_cuda_vector_add_lowers_compute_builtins_for_targets tests/test_translator/test_project_translation.py::test_translate_project_opencl_targets_do_not_leak_resource_parameter_syntax tests/test_translator/test_project_translation.py::test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers tests/test_translator/test_project_translation.py::test_translate_project_opencl_directx_allocates_generated_parameter_bindings tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_compute_builtins_are_auto_parameters_when_referenced_by_name tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_stage_entry_buffer_pointer_params_promote_to_resources tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_metal_matmul_pointer_params_lower_to_resources -q
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py -q
- python3.11 -m crosstl._crosstl translate-project "$repo" --target directx --output-dir "$repo/out" --report "$repo/report.json" --validate --no-format
- python3.11 tools/support_matrix.py check
- git diff --check
