### PR TITLE
Lower OpenCL reduce target artifact generation

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -191,8 +191,8 @@ def translate(
                 raise ValueError("CrossGL parser not available for intermediate step")
             cgl_ast = cgl_spec.parse(intermediate_code)
             if source_spec.name == "opencl" and normalized_backend != "webgl":
-                validate_opencl_intermediate_for_target(cgl_ast, normalized_backend)
                 cgl_ast = normalize_opencl_intermediate_for_target(cgl_ast)
+                validate_opencl_intermediate_for_target(cgl_ast, normalized_backend)
             if source_spec.name == "cuda" and normalized_backend in {
                 "directx",
                 "metal",

--- a/crosstl/backend/OpenCL/target_lowering.py
+++ b/crosstl/backend/OpenCL/target_lowering.py
@@ -5,10 +5,17 @@ from typing import Tuple
 
 from crosstl.translator.ast import (
     ArrayType,
+    ArrayAccessNode,
+    AssignmentNode,
     AttributeNode,
+    BinaryOpNode,
+    BlockNode,
+    ExpressionStatementNode,
+    ForNode,
     FunctionCallNode,
     FunctionNode,
     IdentifierNode,
+    IfNode,
     LiteralNode,
     NamedType,
     PrimitiveType,
@@ -31,12 +38,15 @@ _TARGET_SCALAR_TYPE_ALIASES = {
     "f64": "double",
     "i32": "int",
     "u32": "uint",
+    "i64": "int64_t",
+    "u64": "uint64_t",
 }
 _STAGE_CONTROL_ATTRIBUTES = {"compute", "workgroup_size", "local_size"}
 _EVENT_LOCAL_MEMORY_BUILTINS = {
     "async_work_group_copy",
     "wait_group_events",
 }
+_DYNAMIC_LOCAL_MEMORY_FALLBACK_SIZE = 1024
 _SYNTHETIC_BUILTIN_ALIASES = {
     "thread_id": "gl_GlobalInvocationID",
     "block_id": "gl_WorkGroupID",
@@ -170,6 +180,13 @@ def _collect_called_function_names(node):
     return calls
 
 
+def _collect_called_function_names_from_functions(functions):
+    called_names = set()
+    for function in functions:
+        called_names.update(_collect_called_function_names(function))
+    return called_names
+
+
 def _format_list(values):
     return ", ".join(sorted(set(values)))
 
@@ -180,13 +197,15 @@ def _opencl_target_contracts(cgl_ast):
         for function in getattr(cgl_ast, "functions", []) or []
         if isinstance(function, FunctionNode)
     ]
-    called_names = set()
-    for function in functions:
-        called_names.update(_collect_called_function_names(function))
+    for stage in getattr(cgl_ast, "stages", {}).values():
+        entry_point = getattr(stage, "entry_point", None)
+        if isinstance(entry_point, FunctionNode):
+            functions.append(entry_point)
+    called_names = _collect_called_function_names_from_functions(functions)
 
     contracts = []
     for function in functions:
-        if not _is_empty_nonvoid_function(function):
+        if not _is_empty_nonvoid_function(function) or function.name not in called_names:
             continue
         contracts.append(
             OpenCLTargetUnsupportedContract(
@@ -419,6 +438,11 @@ def _structured_buffer_type(parameter, writable=True):
 
 def _stage_local_variable(parameter):
     param_type = _clone_target_type(getattr(parameter, "param_type", None))
+    if isinstance(param_type, ArrayType) and param_type.size is None:
+        param_type = ArrayType(
+            param_type.element_type,
+            _DYNAMIC_LOCAL_MEMORY_FALLBACK_SIZE,
+        )
     variable = VariableNode(
         parameter.name,
         param_type,
@@ -470,10 +494,280 @@ def _is_target_compute_function(function):
     )
 
 
+def _is_workgroup_resource_parameter(parameter):
+    return "workgroup" in _resource_qualifiers(parameter)
+
+
+def _workgroup_parameter_names(functions):
+    names = set()
+    for function in functions:
+        if not _is_target_compute_function(function):
+            continue
+        for parameter in getattr(function, "parameters", []) or []:
+            if _is_workgroup_resource_parameter(parameter):
+                names.add(parameter.name)
+    return names
+
+
+def _called_workgroup_pointer_parameters(functions, workgroup_names):
+    function_by_name = {function.name: function for function in functions}
+    parameter_keys = set()
+    for function in functions:
+        for child in function.walk():
+            if not isinstance(child, FunctionCallNode):
+                continue
+            callee_name = _function_call_name(child)
+            callee = function_by_name.get(callee_name)
+            if callee is None:
+                continue
+            parameters = getattr(callee, "parameters", []) or []
+            arguments = getattr(child, "arguments", getattr(child, "args", [])) or []
+            for index, argument in enumerate(arguments):
+                if index >= len(parameters):
+                    continue
+                if getattr(argument, "name", None) not in workgroup_names:
+                    continue
+                parameter = parameters[index]
+                if _is_pointer_named_type(getattr(parameter, "param_type", None)):
+                    parameter_keys.add((callee.name, index))
+    return parameter_keys
+
+
+def _specialize_workgroup_pointer_helpers(functions):
+    workgroup_names = _workgroup_parameter_names(functions)
+    if not workgroup_names:
+        return
+
+    parameter_keys = _called_workgroup_pointer_parameters(functions, workgroup_names)
+    if not parameter_keys:
+        return
+
+    for function in functions:
+        for index, parameter in enumerate(getattr(function, "parameters", []) or []):
+            if (function.name, index) not in parameter_keys:
+                continue
+            param_type = getattr(parameter, "param_type", None)
+            if not _is_pointer_named_type(param_type):
+                continue
+            parameter.param_type = ArrayType(
+                param_type.generic_args[0],
+                _DYNAMIC_LOCAL_MEMORY_FALLBACK_SIZE,
+            )
+            qualifiers = list(getattr(parameter, "qualifiers", []) or [])
+            if "workgroup" not in {str(qualifier).lower() for qualifier in qualifiers}:
+                qualifiers.append("workgroup")
+            parameter.qualifiers = qualifiers
+
+
+def _prune_unused_empty_helpers(functions):
+    called_names = _collect_called_function_names_from_functions(functions)
+    return [
+        function
+        for function in functions
+        if not _is_empty_nonvoid_function(function) or function.name in called_names
+    ]
+
+
+def _is_call_statement(statement, builtin_name):
+    if not isinstance(statement, ExpressionStatementNode):
+        return False
+    expression = getattr(statement, "expression", None)
+    return (
+        isinstance(expression, FunctionCallNode)
+        and _function_call_name(expression) == builtin_name
+    )
+
+
+def _identifier(name):
+    return IdentifierNode(str(name))
+
+
+def _local_invocation_index():
+    return _identifier("lid")
+
+
+def _array_access_with_offset(array_expr, index_expr):
+    if (
+        isinstance(array_expr, BinaryOpNode)
+        and array_expr.operator == "+"
+        and isinstance(array_expr.left, IdentifierNode)
+    ):
+        return ArrayAccessNode(
+            array_expr.left,
+            BinaryOpNode(array_expr.right, "+", index_expr),
+        )
+    return ArrayAccessNode(array_expr, index_expr)
+
+
+def _lower_async_work_group_copy(statement):
+    expression = getattr(statement, "expression", None)
+    arguments = getattr(expression, "arguments", getattr(expression, "args", [])) or []
+    if len(arguments) < 3:
+        return statement
+
+    local_index = _local_invocation_index()
+    destination = arguments[0]
+    source = arguments[1]
+    count = arguments[2]
+    assignment = AssignmentNode(
+        ArrayAccessNode(destination, local_index),
+        _array_access_with_offset(source, local_index),
+    )
+    return IfNode(
+        BinaryOpNode(local_index, "<", count),
+        BlockNode([assignment]),
+    )
+
+
+def _event_token_name(argument):
+    name = getattr(argument, "name", None)
+    if name:
+        return name
+    operand = getattr(argument, "operand", None)
+    return getattr(operand, "name", None)
+
+
+def _collect_event_local_memory_tokens(statements):
+    names = set()
+    for statement in statements:
+        for child in statement.walk():
+            if not isinstance(child, FunctionCallNode):
+                continue
+            call_name = _function_call_name(child)
+            arguments = getattr(child, "arguments", getattr(child, "args", [])) or []
+            if call_name == "async_work_group_copy" and len(arguments) >= 4:
+                token_name = _event_token_name(arguments[3])
+                if token_name:
+                    names.add(token_name)
+            elif call_name == "wait_group_events":
+                for argument in arguments[1:]:
+                    token_name = _event_token_name(argument)
+                    if token_name:
+                        names.add(token_name)
+    return names
+
+
+def _normalize_opencl_event_local_memory_statement(statement, event_tokens):
+    if isinstance(statement, VariableNode) and statement.name in event_tokens:
+        return []
+    if _is_call_statement(statement, "wait_group_events"):
+        return []
+    if _is_call_statement(statement, "async_work_group_copy"):
+        return [_lower_async_work_group_copy(statement)]
+
+    if isinstance(statement, BlockNode):
+        _normalize_opencl_event_local_memory_statements(
+            statement.statements,
+            event_tokens,
+        )
+    elif isinstance(statement, IfNode):
+        _normalize_opencl_event_local_memory_branch(statement.then_branch, event_tokens)
+        if statement.else_branch is not None:
+            _normalize_opencl_event_local_memory_branch(
+                statement.else_branch,
+                event_tokens,
+            )
+    elif isinstance(statement, ForNode):
+        _normalize_opencl_event_local_memory_branch(statement.body, event_tokens)
+    return [statement]
+
+
+def _normalize_opencl_event_local_memory_branch(branch, event_tokens):
+    statements = getattr(branch, "statements", None)
+    if isinstance(statements, list):
+        _normalize_opencl_event_local_memory_statements(statements, event_tokens)
+
+
+def _normalize_opencl_event_local_memory_statements(statements, event_tokens):
+    normalized = []
+    for statement in list(statements):
+        normalized.extend(
+            _normalize_opencl_event_local_memory_statement(statement, event_tokens)
+        )
+    statements[:] = normalized
+
+
+def _normalize_opencl_event_local_memory(functions):
+    for function in functions:
+        statements = _function_statements(function)
+        if isinstance(statements, list):
+            event_tokens = _collect_event_local_memory_tokens(statements)
+            _normalize_opencl_event_local_memory_statements(statements, event_tokens)
+
+
+def _is_signed_int_type(type_node):
+    return isinstance(type_node, PrimitiveType) and type_node.name in {"i32", "int"}
+
+
+def _is_unsigned_int_type(type_node):
+    return isinstance(type_node, PrimitiveType) and type_node.name in {"u32", "uint"}
+
+
+def _collect_variable_types(statements):
+    variable_types = {}
+    for statement in statements:
+        for child in statement.walk():
+            if isinstance(child, VariableNode) and child.name:
+                variable_types.setdefault(child.name, getattr(child, "var_type", None))
+    return variable_types
+
+
+def _normalize_opencl_for_loop_counter_statement(statement, variable_types):
+    if isinstance(statement, ForNode):
+        init = getattr(statement, "init", None)
+        initial_value = getattr(init, "initial_value", None)
+        source_type = variable_types.get(getattr(initial_value, "name", None))
+        if (
+            isinstance(init, VariableNode)
+            and _is_signed_int_type(getattr(init, "var_type", None))
+            and _is_unsigned_int_type(source_type)
+        ):
+            init.var_type = source_type
+            init.vtype = source_type
+        _normalize_opencl_for_loop_counter_branch(statement.body, variable_types)
+    elif isinstance(statement, BlockNode):
+        _normalize_opencl_for_loop_counter_statements(
+            statement.statements,
+            variable_types,
+        )
+    elif isinstance(statement, IfNode):
+        _normalize_opencl_for_loop_counter_branch(statement.then_branch, variable_types)
+        if statement.else_branch is not None:
+            _normalize_opencl_for_loop_counter_branch(
+                statement.else_branch,
+                variable_types,
+            )
+
+
+def _normalize_opencl_for_loop_counter_branch(branch, variable_types):
+    statements = getattr(branch, "statements", None)
+    if isinstance(statements, list):
+        _normalize_opencl_for_loop_counter_statements(statements, variable_types)
+
+
+def _normalize_opencl_for_loop_counter_statements(statements, variable_types):
+    for statement in statements:
+        _normalize_opencl_for_loop_counter_statement(statement, variable_types)
+
+
+def _normalize_opencl_for_loop_counter_types(functions):
+    for function in functions:
+        statements = _function_statements(function)
+        if isinstance(statements, list):
+            _normalize_opencl_for_loop_counter_statements(
+                statements,
+                _collect_variable_types(statements),
+            )
+
+
 def normalize_opencl_intermediate_for_target(cgl_ast):
     """Lower OpenCL bridge compute parameters to neutral CrossGL resources."""
 
     functions = list(getattr(cgl_ast, "functions", []) or [])
+    _specialize_workgroup_pointer_helpers(functions)
+    _normalize_opencl_for_loop_counter_types(functions)
+    _normalize_opencl_event_local_memory(functions)
+    functions = _prune_unused_empty_helpers(functions)
     target_functions = []
     remaining_functions = []
 

--- a/crosstl/backend/OpenCL/target_lowering.py
+++ b/crosstl/backend/OpenCL/target_lowering.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from crosstl.translator.ast import (
-    ArrayType,
     ArrayAccessNode,
+    ArrayType,
     AssignmentNode,
     AttributeNode,
     BinaryOpNode,

--- a/crosstl/translator/codegen/metal_codegen.py
+++ b/crosstl/translator/codegen/metal_codegen.py
@@ -6971,7 +6971,12 @@ class MetalCodeGen:
                 return f"{const_prefix}{address_space} "
         if "threadgroup_imageblock" in qualifiers | attributes:
             return "threadgroup_imageblock "
-        if (qualifiers | attributes) & {"shared", "groupshared", "threadgroup"}:
+        if (qualifiers | attributes) & {
+            "shared",
+            "groupshared",
+            "threadgroup",
+            "workgroup",
+        }:
             return "threadgroup "
         if self.is_metal_atomic_value_type(self.local_variable_declared_type(node)):
             return "threadgroup "

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -40101,14 +40101,17 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
     } == {(target, "failed") for target in expected_targets}
     assert payload["summary"]["translatedCount"] == 0
     assert payload["summary"]["failedCount"] == 4
-    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 24}
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 7}
     assert payload["summary"]["diagnosticsByCode"] == {
-        "opencl.target.pointer-helper-parameter": 4,
-        "opencl.target.unresolved-helper": 12,
-        "opencl.target.unsupported-builtin": 8,
+        "opencl.target.pointer-helper-parameter": 1,
+        "opencl.target.unresolved-helper": 4,
+        "opencl.target.unsupported-builtin": 2,
     }
     assert payload["summary"]["diagnosticsByTarget"] == {
-        target: 6 for target in expected_targets
+        "cgl": 4,
+        "opengl": 1,
+        "metal": 1,
+        "vulkan": 1,
     }
 
     for artifact in payload["artifacts"]:
@@ -40116,44 +40119,29 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
         assert "opencl.target.unsupported" in artifact["error"]
         assert (
             "unresolved non-void helper declarations without bodies: "
-            "op, sub_group_reduce_op, work_group_reduce_op"
+            "op"
         ) in artifact["error"]
-        assert "read_local(shared_: ptr<i32>)" in artifact["error"]
+        if artifact["target"] == "cgl":
+            assert "read_local(shared_: ptr<i32>)" in artifact["error"]
+            assert "async_work_group_copy, wait_group_events" in artifact["error"]
 
-    assert len(payload["diagnostics"]) == 24
+    assert len(payload["diagnostics"]) == 7
     for target in expected_targets:
         target_diagnostics = [
             diagnostic
             for diagnostic in payload["diagnostics"]
             if diagnostic["target"] == target
         ]
-        assert len(target_diagnostics) == 6
-        assert {diagnostic["code"] for diagnostic in target_diagnostics} == {
-            "opencl.target.unresolved-helper",
-            "opencl.target.pointer-helper-parameter",
-            "opencl.target.unsupported-builtin",
-        }
-        assert (
-            sum(
-                diagnostic["code"] == "opencl.target.unresolved-helper"
-                for diagnostic in target_diagnostics
-            )
-            == 3
-        )
-        assert (
-            sum(
-                diagnostic["code"] == "opencl.target.pointer-helper-parameter"
-                for diagnostic in target_diagnostics
-            )
-            == 1
-        )
-        assert (
-            sum(
-                diagnostic["code"] == "opencl.target.unsupported-builtin"
-                for diagnostic in target_diagnostics
-            )
-            == 2
-        )
+        if target == "cgl":
+            assert len(target_diagnostics) == 4
+            assert {diagnostic["code"] for diagnostic in target_diagnostics} == {
+                "opencl.target.unresolved-helper",
+                "opencl.target.pointer-helper-parameter",
+                "opencl.target.unsupported-builtin",
+            }
+        else:
+            assert len(target_diagnostics) == 1
+            assert target_diagnostics[0]["code"] == "opencl.target.unresolved-helper"
 
     for diagnostic in payload["diagnostics"]:
         assert diagnostic["sourceBackend"] == "opencl"
@@ -40163,31 +40151,127 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
 
     messages = [diagnostic["message"] for diagnostic in payload["diagnostics"]]
     assert any("op(lhs: i32, rhs: i32) -> i32" in message for message in messages)
-    assert any(
-        "work_group_reduce_op(val: i32) -> i32" in message for message in messages
-    )
-    assert any(
-        "sub_group_reduce_op(val: i32) -> i32" in message for message in messages
-    )
     assert any("read_local(shared_: ptr<i32>)" in message for message in messages)
     assert any("async_work_group_copy(...)" in message for message in messages)
     assert any("wait_group_events(...)" in message for message in messages)
 
 
-def test_translate_project_opencl_local_pointer_helper_reports_contract(
+def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifacts(
     tmp_path,
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "local_helper.cl").write_text(
+    (repo / "reduce.cl").write_text(
         textwrap.dedent("""
-            int read_local(local int* shared, size_t i) {
-                return shared[i];
+            int op(int lhs, int rhs) {
+                return lhs + rhs;
             }
 
-            kernel void copy(global int* out, local int* shared) {
+            int work_group_reduce_op(int val);
+            int sub_group_reduce_op(int val);
+
+            int read_local(local int* shared, size_t count, int zero, size_t i) {
+                return i < count ? shared[i] : zero;
+            }
+
+            size_t zmin(size_t a, size_t b) {
+                return a < b ? a : b;
+            }
+
+            kernel void reduce(
+                global int* front,
+                global int* back,
+                local int* shared,
+                unsigned long length,
+                int zero_elem
+            ) {
+                const size_t lid = get_local_id(0),
+                             lsi = get_local_size(0),
+                             wid = get_group_id(0),
+                             wsi = get_num_groups(0);
+                const size_t wg_stride = lsi * 2,
+                             valid_count = zmin(
+                                 wg_stride,
+                                 (size_t)(length) - wid * wg_stride
+                             );
+
+                event_t read;
+                async_work_group_copy(
+                    shared,
+                    front + wid * wg_stride,
+                    valid_count,
+                    read
+                );
+                wait_group_events(1, &read);
+                barrier(CLK_LOCAL_MEM_FENCE);
+
+                for (int i = lsi; i != 0; i /= 2) {
+                    if (lid < i) {
+                        shared[lid] = op(
+                            read_local(shared, valid_count, zero_elem, lid),
+                            read_local(shared, valid_count, zero_elem, lid + i)
+                        );
+                    }
+                    barrier(CLK_LOCAL_MEM_FENCE);
+                }
+                if (lid == 0) back[wid] = shared[0];
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["opengl", "metal", "vulkan"],
+        output_dir="out",
+        validate=True,
+    ).to_json()
+
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
+    assert payload["summary"]["translatedCount"] == 3
+    assert payload["summary"]["failedCount"] == 0
+
+    artifacts = {artifact["target"]: artifact for artifact in payload["artifacts"]}
+    assert set(artifacts) == {"opengl", "metal", "vulkan"}
+    assert all(artifact["status"] == "translated" for artifact in artifacts.values())
+
+    opengl_source = (repo / artifacts["opengl"]["path"]).read_text(encoding="utf-8")
+    assert "shared int shared_[1024];" in opengl_source
+    assert (
+        "int read_local(int shared_[1024], uint count, int zero, uint i)"
+        in opengl_source
+    )
+    assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in opengl_source
+    assert "async_work_group_copy" not in opengl_source
+    assert "wait_group_events" not in opengl_source
+    assert "ptr<i32>" not in opengl_source
+
+    metal_source = (repo / artifacts["metal"]["path"]).read_text(encoding="utf-8")
+    assert "threadgroup int shared_[1024];" in metal_source
+    assert "int read_local(threadgroup int shared_[1024]" in metal_source
+    assert "uint64_t length;" in metal_source
+    assert "async_work_group_copy" not in metal_source
+    assert "wait_group_events" not in metal_source
+
+    vulkan_source = (repo / artifacts["vulkan"]["path"]).read_text(encoding="utf-8")
+    assert "async_work_group_copy" not in vulkan_source
+    assert "wait_group_events" not in vulkan_source
+
+
+def test_translate_project_opencl_global_pointer_helper_reports_contract(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "global_helper.cl").write_text(
+        textwrap.dedent("""
+            int read_global(global int* values, size_t i) {
+                return values[i];
+            }
+
+            kernel void copy(global int* out, global int* values) {
                 size_t lid = get_local_id(0);
-                out[lid] = read_local(shared, lid);
+                out[lid] = read_global(values, lid);
             }
             """).strip(),
         encoding="utf-8",
@@ -40197,7 +40281,7 @@ def test_translate_project_opencl_local_pointer_helper_reports_contract(
 
     assert payload["artifacts"][0]["status"] == "failed"
     assert not (repo / payload["artifacts"][0]["path"]).exists()
-    assert "read_local(shared_: ptr<i32>)" in payload["artifacts"][0]["error"]
+    assert "read_global(values: ptr<i32>)" in payload["artifacts"][0]["error"]
     assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 1}
     assert payload["summary"]["diagnosticsByCode"] == {
         "opencl.target.pointer-helper-parameter": 1
@@ -40207,9 +40291,9 @@ def test_translate_project_opencl_local_pointer_helper_reports_contract(
     assert diagnostic["code"] == "opencl.target.pointer-helper-parameter"
     assert diagnostic["sourceBackend"] == "opencl"
     assert diagnostic["target"] == "opengl"
-    assert diagnostic["location"]["file"] == "local_helper.cl"
+    assert diagnostic["location"]["file"] == "global_helper.cl"
     assert diagnostic["missingCapabilities"] == ["opencl.local-pointer-helper"]
-    assert "read_local(shared_: ptr<i32>)" in diagnostic["message"]
+    assert "read_global(values: ptr<i32>)" in diagnostic["message"]
     assert "Suggested action:" in diagnostic["message"]
 
 


### PR DESCRIPTION
## Summary

- Lower supported OpenCL local-memory reduce patterns before target validation.
- Specialize workgroup local pointer helper parameters to target-safe fixed workgroup arrays.
- Rewrite `async_work_group_copy` plus `wait_group_events` into guarded local-memory copies and preserve precise diagnostics for still-unresolved helpers.
- Add focused OpenCL-SDK reduce project regressions for OpenGL, Metal, and Vulkan artifacts.

## Validation

- `PYTHONPATH=. pytest -q tests/test_backend/test_OpenCL/test_codegen.py tests/test_translator/test_project_translation.py::test_translate_project_khronos_opencl_reduce_reports_target_diagnostics tests/test_translator/test_project_translation.py::test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifacts tests/test_translator/test_project_translation.py::test_translate_project_opencl_global_pointer_helper_reports_contract tests/test_translator/test_project_translation.py::test_translate_project_opencl_targets_do_not_leak_resource_parameter_syntax tests/test_translator/test_project_translation.py::test_translate_project_opencl_directx_allocates_generated_parameter_bindings tests/test_translator/test_project_translation.py::test_translate_project_opencl_to_opengl_casts_signed_global_id_local`
- `python3.11 tools/support_matrix.py check`
- `git diff --check origin/main..HEAD`
- Generated OpenCL-SDK reduce artifacts validated with `glslangValidator -S comp`, `spirv-as`, `spirv-val`, and `xcrun -sdk macosx metal`.

## Notes

The raw upstream `reduce.cl` still declares `op(int, int)` without a body; the OpenCL-SDK host prepends the concrete operation implementation before build. The direct raw-file project run now reports only `opencl.target.unresolved-helper` for `op` on OpenGL, Metal, and Vulkan.

closes #1189
