### PR TITLE
Fix GLSL vertex position DirectX semantic

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -12984,7 +12984,13 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         used_ranges = self.hlsl_declared_struct_semantic_ranges(struct_node)
 
         defaults = {}
-        position_names = {"position", "clipposition", "clip_position"}
+        position_names = {
+            "position",
+            "clipposition",
+            "clip_position",
+            "glposition",
+            "gl_position",
+        }
         if not self.hlsl_semantic_range_is_used(used_ranges, "SV_Position"):
             for member in getattr(struct_node, "members", []) or []:
                 member_name = getattr(member, "name", None)

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1102", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1103", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1186", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "89", "69", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1102
+        "test_count": 1103
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -321,6 +321,36 @@ def test_glsl_vertex_input_locations_lower_to_distinct_hlsl_semantics(tmp_path):
     assert ": location" not in generated_code
 
 
+def test_glsl_pervertex_position_output_lowers_to_hlsl_sv_position(tmp_path):
+    shader = """
+    #version 450
+    out gl_PerVertex {
+        vec4 gl_Position;
+    };
+    layout(location = 0) out vec3 outColor;
+
+    void main() {
+        outColor = vec3(1.0, 0.0, 0.0);
+        gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+    """
+    shader_path = tmp_path / "conservative.vert"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="opengl",
+    )
+
+    assert "float4 gl_Position: SV_Position;" in generated_code
+    assert "float4 gl_Position: TEXCOORD" not in generated_code
+    assert "float3 outColor: TEXCOORD0;" in generated_code
+    assert generated_code.count(": TEXCOORD0") == 1
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
 def test_directx_user_defined_synchronization_names_are_not_lowered():
     shader = """
     shader SynchronizationShadowing {


### PR DESCRIPTION
## Summary
- Map GLSL vertex output fields named `gl_Position` to the DirectX `SV_Position` semantic when defaulting vertex output struct semantics.
- Add a regression for GLSL `gl_PerVertex` output blocks so user varyings remain on `TEXCOORD` while position uses `SV_Position`.
- Refresh generated support matrix test counts.

## Tests
- `pytest -q tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_pervertex_position_output_lowers_to_hlsl_sv_position tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_vertex_output_locations_lower_to_distinct_hlsl_semantics tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_vertex_input_locations_lower_to_distinct_hlsl_semantics`
- `pytest -q tests/test_translator/test_codegen/test_directx_codegen.py`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`

closes #1196