### PR TITLE
Update backend typed buffer write expectations

### DIFF
--- a/tests/test_backend/test_directx/test_codegen.py
+++ b/tests/test_backend/test_directx/test_codegen.py
@@ -5079,7 +5079,8 @@ def test_codegen_resource_array_receivers_use_canonical_calls():
 
     hlsl = TranslatorHLSLCodeGen().generate(shader_ast)
     assert "RWStructuredBuffer<int> buffers[2] : register(u2);" in hlsl
-    assert "buffers[index].Store(0, 7);" in hlsl
+    assert "buffers[index][0] = 7;" in hlsl
+    assert "buffers[index].Store(" not in hlsl
     assert "buffers[index].Load(0)" in hlsl
     assert "buffer_store(" not in hlsl
     assert "buffer_load(" not in hlsl
@@ -5131,7 +5132,8 @@ def test_codegen_resource_array_spaces_roundtrip_for_srv_uav_and_typed_buffers()
     assert "RWBuffer<uint> counters[2] : register(u8, space4);" in hlsl
     assert "textures[index].Sample(samplers[index], uv)" in hlsl
     assert "images[index][uint2(1, 2)] = c;" in hlsl
-    assert "buffers[index].Store(0, 7);" in hlsl
+    assert "buffers[index][0] = 7;" in hlsl
+    assert "buffers[index].Store(" not in hlsl
     assert "buffers[index].Load(0)" in hlsl
     assert "InterlockedAdd(counters[index][0], 1u, oldValue);" in hlsl
     assert "buffer_store(" not in hlsl

--- a/tests/test_backend/test_metal/test_codegen.py
+++ b/tests/test_backend/test_metal/test_codegen.py
@@ -1866,7 +1866,8 @@ def test_codegen_device_buffer_parameters_use_structured_buffer_contract():
     assert "RWStructuredBuffer<float> data" in hlsl
     assert "StructuredBuffer<float> input" in hlsl
     assert "float value = input.Load(tid.x);" in hlsl
-    assert "data.Store(tid.x, (value * 2.0));" in hlsl
+    assert "data[tid.x] = (value * 2.0);" in hlsl
+    assert "data.Store(" not in hlsl
 
     metal = MetalCodeGen().generate(ast)
     assert "kernel void compute_main(device float* data" in metal


### PR DESCRIPTION
## Summary
- Update backend roundtrip tests to expect indexed writes for typed writable HLSL buffers.
- Keep negative `.Store` assertions for typed buffer writes while preserving `.Load` checks.

## Tests
- python3.11 -m pytest -q tests/test_backend/test_directx tests/test_backend/test_metal
- python3.11 tools/support_matrix.py check
- git diff --check