### PR TITLE
Lower fragment-density helpers for DirectX

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -627,6 +627,8 @@ class HLSLCodeGen:
         self.function_parameter_types = {}
         self.hlsl_function_name_aliases = {}
         self.function_stage_parameter_dependencies = {}
+        self.function_hlsl_fragment_builtin_dependencies = {}
+        self.function_hlsl_fragment_builtin_parameter_names = {}
         self.function_return_types = {}
         self.function_image_access_requirements = {}
         self.hlsl_pixel_only_feedback_function_names = {}
@@ -1316,6 +1318,15 @@ class HLSLCodeGen:
             )
         self.function_stage_parameter_dependencies = (
             self.collect_hlsl_function_stage_parameter_dependencies(ast, target_stage)
+        )
+        self.function_hlsl_fragment_builtin_dependencies = (
+            self.collect_hlsl_function_fragment_builtin_dependencies(ast, target_stage)
+        )
+        self.function_hlsl_fragment_builtin_parameter_names = (
+            self.collect_hlsl_fragment_builtin_parameter_names(
+                ast,
+                self.function_hlsl_fragment_builtin_dependencies,
+            )
         )
         self.function_image_access_requirements = (
             collect_function_image_access_requirements(
@@ -3071,8 +3082,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
 
     def referenced_hlsl_glsl_builtin_int_constants(self, ast):
         declared_names = {
-            getattr(node, "name", None)
-            for node in getattr(ast, "constants", []) or []
+            getattr(node, "name", None) for node in getattr(ast, "constants", []) or []
         }
         declared_names.update(
             getattr(node, "name", getattr(node, "variable_name", None))
@@ -3539,6 +3549,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             params_str = self.append_required_hlsl_stage_parameter_parameters(
                 params_str, getattr(func, "name", None), param_names
             )
+            params_str = self.append_required_hlsl_fragment_builtin_parameters(
+                params_str, getattr(func, "name", None), param_names
+            )
             for parameter in self.required_hlsl_stage_parameters(
                 getattr(func, "name", None)
             ):
@@ -3547,6 +3560,17 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                     self.local_variable_types[name] = self.type_name_string(
                         self.hlsl_parameter_raw_type(parameter)
                     )
+            for builtin_name in self.required_hlsl_fragment_builtin_names(
+                getattr(func, "name", None)
+            ):
+                name = self.hlsl_fragment_builtin_parameter_name(
+                    getattr(func, "name", None),
+                    builtin_name,
+                )
+                param_type = self.hlsl_fragment_builtin_parameter_type(builtin_name)
+                if name and param_type:
+                    self.current_identifier_aliases[builtin_name] = name
+                    self.local_variable_types[name] = param_type
         elif effective_shader_type == "compute":
             for (
                 builtin_name,
@@ -3554,9 +3578,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 param_type,
                 semantic,
                 alias,
-            ) in self.required_hlsl_compute_builtin_parameters(
-                func, execution_config
-            ):
+            ) in self.required_hlsl_compute_builtin_parameters(func, execution_config):
                 if alias is not None:
                     self.current_identifier_aliases[builtin_name] = alias
                     continue
@@ -13138,9 +13160,8 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             mapped_type = self.map_type(self.hlsl_struct_member_type_name(member))
             normalized_name = str(member_name).replace("_", "").lower()
             if normalized_name in {"depth", "fragdepth", "glfragdepth"}:
-                if (
-                    mapped_type == "float"
-                    and not self.hlsl_semantic_range_is_used(used_ranges, "SV_DEPTH")
+                if mapped_type == "float" and not self.hlsl_semantic_range_is_used(
+                    used_ranges, "SV_DEPTH"
                 ):
                     defaults[member_name] = "SV_DEPTH"
                     self.hlsl_reserve_semantic_range(
@@ -14002,10 +14023,138 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 used_names.add(base_name)
         return used_names
 
+    def hlsl_fragment_builtin_parameter_specs(self):
+        return {
+            "gl_FragCoord": ("_crossglFragCoord", "float4"),
+            "gl_FragSizeEXT": ("_crossglFragSize", "uint2"),
+        }
+
+    def hlsl_fragment_builtin_parameter_type(self, builtin_name):
+        spec = self.hlsl_fragment_builtin_parameter_specs().get(builtin_name)
+        return spec[1] if spec is not None else None
+
+    def direct_hlsl_fragment_builtin_dependencies(self, func):
+        return set(
+            self.used_hlsl_fragment_builtin_names(getattr(func, "body", []))
+        ) & set(self.hlsl_fragment_builtin_parameter_specs())
+
+    def collect_hlsl_function_fragment_builtin_dependencies(
+        self, ast, target_stage=None
+    ):
+        direct_dependencies = {}
+        function_calls = {}
+
+        for func in self.collect_functions(ast):
+            func_name = getattr(func, "name", None)
+            if not func_name:
+                continue
+            direct_dependencies.setdefault(
+                func_name,
+                self.direct_hlsl_fragment_builtin_dependencies(func),
+            )
+            function_calls.setdefault(func_name, self.hlsl_called_function_names(func))
+
+        for stage_type, stage in getattr(ast, "stages", {}).items():
+            stage_name = normalize_stage_name(stage_type)
+            if stage_name != "fragment" or not stage_matches(target_stage, stage_name):
+                continue
+            stage_functions = list(getattr(stage, "local_functions", []) or [])
+            entry_point = getattr(stage, "entry_point", None)
+            if entry_point is not None:
+                stage_functions.append(entry_point)
+            for func in stage_functions:
+                func_name = getattr(func, "name", None)
+                if not func_name:
+                    continue
+                direct_dependencies[func_name] = (
+                    self.direct_hlsl_fragment_builtin_dependencies(func)
+                )
+                function_calls[func_name] = self.hlsl_called_function_names(func)
+
+        dependencies = {name: set(deps) for name, deps in direct_dependencies.items()}
+        changed = True
+        while changed:
+            changed = False
+            for func_name, calls in function_calls.items():
+                before = set(dependencies.get(func_name, set()))
+                for called_name in calls:
+                    dependencies.setdefault(func_name, set()).update(
+                        dependencies.get(called_name, set())
+                    )
+                if dependencies.get(func_name, set()) != before:
+                    changed = True
+
+        return {
+            func_name: sorted(dependency_names)
+            for func_name, dependency_names in dependencies.items()
+            if dependency_names
+        }
+
+    def collect_hlsl_fragment_builtin_parameter_names(self, ast, dependencies):
+        functions_by_name = {
+            getattr(func, "name", None): func
+            for func in self.collect_functions(ast)
+            if getattr(func, "name", None)
+        }
+        parameter_names = {}
+        specs = self.hlsl_fragment_builtin_parameter_specs()
+        for func_name, builtin_names in (dependencies or {}).items():
+            func = functions_by_name.get(func_name)
+            if func is None:
+                continue
+            reserved_names = self.collect_hlsl_function_identifier_names(func)
+            reserved_names.update(self.HLSL_RESERVED_LOCAL_IDENTIFIER_NAMES)
+            names = {}
+            for builtin_name in builtin_names:
+                spec = specs.get(builtin_name)
+                if spec is None:
+                    continue
+                base_name, _param_type = spec
+                name = self.hlsl_unique_local_identifier(base_name, reserved_names)
+                reserved_names.add(name)
+                names[builtin_name] = name
+            if names:
+                parameter_names[func_name] = names
+        return parameter_names
+
+    def required_hlsl_fragment_builtin_names(self, func_name):
+        return list(
+            (self.function_hlsl_fragment_builtin_dependencies or {}).get(
+                func_name,
+                [],
+            )
+        )
+
+    def hlsl_fragment_builtin_parameter_name(self, func_name, builtin_name):
+        return (
+            (self.function_hlsl_fragment_builtin_parameter_names or {})
+            .get(func_name, {})
+            .get(builtin_name)
+        )
+
+    def append_required_hlsl_fragment_builtin_parameters(
+        self, params_str, func_name, existing_param_names=None
+    ):
+        existing_param_names = set(existing_param_names or set())
+        for builtin_name in self.required_hlsl_fragment_builtin_names(func_name):
+            name = self.hlsl_fragment_builtin_parameter_name(func_name, builtin_name)
+            param_type = self.hlsl_fragment_builtin_parameter_type(builtin_name)
+            if not name or not param_type or name in existing_param_names:
+                continue
+            params_str = self.append_hlsl_parameter_declaration(
+                params_str,
+                f"{param_type} {name}",
+            )
+            existing_param_names.add(name)
+        return params_str
+
     def required_hlsl_fragment_builtin_parameters(
         self, func, reserved_names=None, explicit_stage_builtins=None
     ):
         used_names = self.used_hlsl_fragment_builtin_names(getattr(func, "body", []))
+        used_names.update(
+            self.required_hlsl_fragment_builtin_names(getattr(func, "name", None))
+        )
         reserved_names = set(reserved_names or ())
         explicit_stage_builtins = explicit_stage_builtins or {}
         builtin_parameters = [
@@ -14066,7 +14215,12 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
     def required_hlsl_compute_builtin_parameters(self, func, execution_config=None):
         used_names = self.used_hlsl_compute_builtin_names(getattr(func, "body", []))
         builtin_parameters = [
-            ("gl_GlobalInvocationID", "dispatchThreadID", "uint3", "SV_DispatchThreadID"),
+            (
+                "gl_GlobalInvocationID",
+                "dispatchThreadID",
+                "uint3",
+                "SV_DispatchThreadID",
+            ),
             ("gl_LocalInvocationID", "groupThreadID", "uint3", "SV_GroupThreadID"),
             ("gl_WorkGroupID", "groupID", "uint3", "SV_GroupID"),
             ("gl_LocalInvocationIndex", "groupIndex", "uint", "SV_GroupIndex"),
@@ -14097,9 +14251,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 continue
             name = self.hlsl_unique_local_identifier(base_name, reserved_names)
             reserved_names.add(name)
-            required_parameters.append(
-                (builtin_name, name, param_type, semantic, None)
-            )
+            required_parameters.append((builtin_name, name, param_type, semantic, None))
         return required_parameters
 
     def hlsl_compute_workgroup_size_expression(self, execution_config=None):
@@ -15016,6 +15168,11 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             if not name or name in param_names:
                 continue
             generated_args.append(name)
+
+        for builtin_name in self.required_hlsl_fragment_builtin_names(func_name):
+            generated_args.append(
+                self.current_identifier_aliases.get(builtin_name, builtin_name)
+            )
 
         return generated_args
 

--- a/crosstl/translator/codegen/metal_codegen.py
+++ b/crosstl/translator/codegen/metal_codegen.py
@@ -684,6 +684,7 @@ class MetalCodeGen:
         self.function_parameter_names = {}
         self.function_parameter_infos = {}
         self.function_parameter_nodes = {}
+        self.functions_by_name = {}
         self.metal_skipped_function_parameter_indices = {}
         self.function_return_types = {}
         self.function_image_access_requirements = {}
@@ -1288,6 +1289,9 @@ class MetalCodeGen:
         self.validate_metal_mesh_payload_parameter_placement(ast, all_functions)
         self.user_function_names = {
             func.name for func in all_functions if getattr(func, "name", None)
+        }
+        self.functions_by_name = {
+            func.name: func for func in all_functions if getattr(func, "name", None)
         }
         self.function_parameter_infos = self.collect_function_parameter_infos(
             all_functions
@@ -5047,24 +5051,45 @@ class MetalCodeGen:
     def validate_metal_fragment_invocation_density(self, func, shader_type):
         if shader_type != "fragment":
             return
+        for reachable_func in self.metal_reachable_functions(func):
+            if self.function_uses_metal_fragment_invocation_density(reachable_func):
+                raise UnsupportedMetalFeatureError(
+                    "gl_FragSizeEXT",
+                    (
+                        "Metal target does not expose a fragment invocation density "
+                        "or fragment-size input equivalent for "
+                        "GL_EXT_fragment_invocation_density / gl_FragSizeEXT; keep "
+                        "this shader on a target with fragment density builtins or "
+                        "specialize the density path before Metal generation."
+                    ),
+                    missing_capabilities=FRAGMENT_INVOCATION_DENSITY_CAPABILITIES,
+                )
+
+    def metal_reachable_functions(self, root_func):
+        reachable = []
+        pending = [root_func]
+        visited = set()
+        while pending:
+            func = pending.pop(0)
+            if func is None or id(func) in visited:
+                continue
+            visited.add(id(func))
+            reachable.append(func)
+            for called_name in sorted(self.called_user_function_names(func)):
+                called_func = (self.functions_by_name or {}).get(called_name)
+                if called_func is not None and id(called_func) not in visited:
+                    pending.append(called_func)
+        return reachable
+
+    def function_uses_metal_fragment_invocation_density(self, func):
         for node in self.iter_ast_nodes(getattr(func, "body", []) or []):
             class_name = node.__class__.__name__
             if "Identifier" not in class_name and class_name != "VariableNode":
                 continue
             name = getattr(node, "name", "")
-            if name.split(".", 1)[0] != "gl_FragSizeEXT":
-                continue
-            raise UnsupportedMetalFeatureError(
-                "gl_FragSizeEXT",
-                (
-                    "Metal target does not expose a fragment invocation density "
-                    "or fragment-size input equivalent for "
-                    "GL_EXT_fragment_invocation_density / gl_FragSizeEXT; keep "
-                    "this shader on a target with fragment density builtins or "
-                    "specialize the density path before Metal generation."
-                ),
-                missing_capabilities=FRAGMENT_INVOCATION_DENSITY_CAPABILITIES,
-            )
+            if name.split(".", 1)[0] == "gl_FragSizeEXT":
+                return True
+        return False
 
     def validate_graphics_builtin_parameter_types(self, parameters, stage_name):
         expected_types = {
@@ -6817,9 +6842,7 @@ class MetalCodeGen:
         if not groupshared_globals:
             return {}
 
-        entries = self.metal_program_scope_groupshared_stage_entries(
-            ast, target_stage
-        )
+        entries = self.metal_program_scope_groupshared_stage_entries(ast, target_stage)
         entry_ids = {id(func) for _stage_name, func, _stage_locals in entries}
         lowered_by_function = {}
 

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -327,6 +327,26 @@ GLSL_FRAGMENT_INVOCATION_DENSITY_SOURCE = textwrap.dedent("""
     }
     """).strip()
 
+GLSL_FRAGMENT_INVOCATION_DENSITY_HELPER_SOURCE = textwrap.dedent("""
+    #version 450 core
+    #extension GL_EXT_fragment_invocation_density : require
+    layout(location = 0) out vec4 fragColor;
+
+    vec4 FragmentDensityToColor() {
+        float invocationArea = float(
+            gl_FragSizeEXT.x * gl_FragSizeEXT.y
+        );
+        float h = (
+            clamp(1.0 - 1.0 / invocationArea, 0.0, 1.0)
+        ) / 1.35;
+        return vec4(h, h, h, 1.0);
+    }
+
+    void main() {
+        fragColor = FragmentDensityToColor();
+    }
+    """).strip()
+
 GLSLANG_SPEC_CONSTANT_VERTEX_SOURCE = textwrap.dedent("""
     #version 400
     layout(constant_id = 16) const int arraySize = 5;
@@ -27007,6 +27027,56 @@ def test_translate_project_models_glsl_fragment_invocation_density_by_target(
     assert "gl_FragSizeEXT" in opengl_code
 
 
+def test_translate_project_lowers_fragment_invocation_density_helpers_by_target(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "CubeFDM_fs.glsl").write_text(
+        GLSL_FRAGMENT_INVOCATION_DENSITY_HELPER_SOURCE, encoding="utf-8"
+    )
+
+    report = translate_project(
+        repo,
+        targets=["directx", "metal"],
+        output_dir="out",
+    )
+    payload = report.to_json()
+
+    assert payload["summary"]["artifactCount"] == 2
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 1
+    assert payload["summary"]["diagnosticsByCode"] == {
+        "project.translate.unsupported-feature": 1
+    }
+    assert payload["summary"]["missingCapabilityCounts"] == {
+        "glsl.builtin.gl_FragSizeEXT": 1,
+        "glsl.extension.GL_EXT_fragment_invocation_density": 1,
+    }
+
+    artifacts_by_target = {
+        artifact["target"]: artifact for artifact in payload["artifacts"]
+    }
+    directx_artifact = artifacts_by_target["directx"]
+    metal_artifact = artifacts_by_target["metal"]
+
+    assert directx_artifact["status"] == "translated"
+    directx_code = (repo / directx_artifact["path"]).read_text(encoding="utf-8")
+    assert "SV_ShadingRate" in directx_code
+    assert "CrossGLFragmentSizeFromShadingRate" in directx_code
+    assert "float4 FragmentDensityToColor(uint2 _crossglFragSize)" in directx_code
+    assert "FragmentDensityToColor(_crossglFragSize)" in directx_code
+    assert "gl_FragSizeEXT" not in directx_code
+    assert_directx_fragment_validates_if_available(directx_code, tmp_path)
+
+    assert metal_artifact["status"] == "failed"
+    assert "GL_EXT_fragment_invocation_density" in metal_artifact["error"]
+    assert "gl_FragSizeEXT" in metal_artifact["error"]
+    assert "generatedHash" not in metal_artifact
+    assert "generatedSizeBytes" not in metal_artifact
+    assert not (repo / metal_artifact["path"]).exists()
+
+
 def test_translate_project_lowers_mlx_bfloat16_asuint_for_opengl(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -37682,8 +37752,7 @@ def test_translate_project_metal_matmul_device_buffers_do_not_emit_directx_param
     assert "uint2 id = id_dispatchThreadID.xy;" in output
     assert (
         "X[((row * col_dim_x) + col)] = "
-        "(A.Load(((row * inner_dim) + col)) + B.Load(col));"
-        in output
+        "(A.Load(((row * inner_dim) + col)) + B.Load(col));" in output
     )
     assert "X.Store(" not in output
     assert "A.Load(((row * inner_dim) + col))" in output
@@ -40508,8 +40577,7 @@ def test_translate_project_khronos_opencl_reduce_reports_target_diagnostics(
         assert not (repo / artifact["path"]).exists()
         assert "opencl.target.unsupported" in artifact["error"]
         assert (
-            "unresolved non-void helper declarations without bodies: "
-            "op"
+            "unresolved non-void helper declarations without bodies: " "op"
         ) in artifact["error"]
         if artifact["target"] == "cgl":
             assert "read_local(shared_: ptr<i32>)" in artifact["error"]

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -132,6 +132,27 @@ void main() {
 }
 """
 
+GLSL_FRAGMENT_INVOCATION_DENSITY_HELPER_SOURCE = """
+#version 450 core
+#extension GL_EXT_fragment_invocation_density : require
+layout(location = 0) out vec4 fragColor;
+
+vec4 FragmentDensityToColor() {
+    float h = (
+        clamp(
+            1.0 - 1.0 / float(gl_FragSizeEXT.x * gl_FragSizeEXT.y),
+            0.0,
+            1.0
+        )
+    ) / 1.35;
+    return vec4(h, h, h, 1.0);
+}
+
+void main() {
+    fragColor = FragmentDensityToColor();
+}
+"""
+
 SPIRV_VERTEX_POSITION_OUTPUT_SOURCE = """
 ; SPIR-V
 ; Version: 1.0
@@ -455,8 +476,8 @@ def test_hip_bit_extract_kernel_body_survives_metal_and_spirv_targets(tmp_path):
     assert "d_output[i] = d_input[i] >> 8 & 15u;" in metal
 
     _assert_generated_output_is_usable(spirv)
-    assert 'OpEntryPoint GLCompute' in spirv
-    assert 'OpName %' in spirv and '"d_outputBuffer"' in spirv
+    assert "OpEntryPoint GLCompute" in spirv
+    assert "OpName %" in spirv and '"d_outputBuffer"' in spirv
     assert '"d_inputBuffer"' in spirv
     assert "OpLoopMerge" in spirv
     assert "OpShiftRightLogical" in spirv
@@ -1416,6 +1437,48 @@ def test_glsl_fragment_invocation_density_reports_metal_target_diagnostic(tmp_pa
         tmp_path, "CubeFDM_fs.glsl", GLSL_FRAGMENT_INVOCATION_DENSITY_SOURCE
     )
     output_path = tmp_path / "CubeFDM_fs.metal.out"
+
+    with pytest.raises(ValueError, match="GL_EXT_fragment_invocation_density"):
+        crosstl.translate(
+            str(source_path),
+            backend="metal",
+            save_shader=str(output_path),
+            format_output=False,
+        )
+
+    assert not output_path.exists()
+
+
+def test_glsl_fragment_invocation_density_helper_lowers_to_directx(tmp_path):
+    source_path = _write_source(
+        tmp_path,
+        "CubeFDM_fs.glsl",
+        GLSL_FRAGMENT_INVOCATION_DENSITY_HELPER_SOURCE,
+    )
+    output_path = tmp_path / "CubeFDM_fs.hlsl"
+
+    generated = crosstl.translate(
+        str(source_path),
+        backend="directx",
+        save_shader=str(output_path),
+        format_output=False,
+    )
+
+    assert output_path.exists()
+    assert "SV_ShadingRate" in generated
+    assert "CrossGLFragmentSizeFromShadingRate" in generated
+    assert "float4 FragmentDensityToColor(uint2 _crossglFragSize)" in generated
+    assert "FragmentDensityToColor(_crossglFragSize)" in generated
+    assert "gl_FragSizeEXT" not in generated
+
+
+def test_glsl_fragment_invocation_density_helper_reports_metal_diagnostic(tmp_path):
+    source_path = _write_source(
+        tmp_path,
+        "CubeFDM_fs.glsl",
+        GLSL_FRAGMENT_INVOCATION_DENSITY_HELPER_SOURCE,
+    )
+    output_path = tmp_path / "CubeFDM_fs.metal"
 
     with pytest.raises(ValueError, match="GL_EXT_fragment_invocation_density"):
         crosstl.translate(


### PR DESCRIPTION
## Summary
- thread GLSL fragment-density builtins through DirectX helper calls so helper functions receive lowered fragment size values
- make Metal reject fragment-reachable `gl_FragSizeEXT` helper usage with the existing unsupported-feature diagnostic before artifact emission
- add direct translation and project translation regressions for helper-shaped fragment-density shaders

## Validation
- `python3.11 -m pytest -q tests/test_backend/test_GLSL/test_parser.py::test_parse_accepts_fragment_invocation_density_extension tests/test_backend/test_GLSL/test_parser.py::test_parse_accepts_fragment_invocation_density_builtin_without_extension tests/test_translator/test_translation_pipeline.py::test_glsl_fragment_invocation_density_lowers_supported_targets tests/test_translator/test_translation_pipeline.py::test_glsl_fragment_invocation_density_reports_metal_target_diagnostic tests/test_translator/test_translation_pipeline.py::test_glsl_fragment_invocation_density_helper_lowers_to_directx tests/test_translator/test_translation_pipeline.py::test_glsl_fragment_invocation_density_helper_reports_metal_diagnostic tests/test_translator/test_project_translation.py::test_translate_project_models_glsl_fragment_invocation_density_by_target tests/test_translator/test_project_translation.py::test_translate_project_lowers_fragment_invocation_density_helpers_by_target`
- `python3.11 -m pytest -q tests/test_translator/test_codegen/test_directx_codegen.py`
- `python3.11 -m pytest -q tests/test_translator/test_codegen/test_metal_codegen.py`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- `git diff --name-only origin/main...HEAD | xargs pre-commit run --files`

closes #1208