### PR TITLE
Lower Rust Option values before DirectX emission

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -1,5 +1,6 @@
 """CrossGL-to-HLSL code generator."""
 
+from copy import deepcopy
 from hashlib import sha1
 
 from ..ast import (
@@ -1030,9 +1031,131 @@ class HLSLCodeGen:
         """Generate HLSL source for a single requested shader stage."""
         return self.generate_program(ast, target_stage=shader_type)
 
+    def with_hlsl_builtin_option_prelude(self, ast):
+        if not self.hlsl_ast_needs_builtin_option(ast):
+            return ast
+        if self.hlsl_ast_declares_type(ast, "Option"):
+            return ast
+
+        self.hlsl_builtin_option_available = True
+        ast = deepcopy(ast)
+        prelude_ast = self.parse_hlsl_builtin_option_prelude()
+        ast.structs = list(getattr(prelude_ast, "structs", []) or []) + list(
+            getattr(ast, "structs", []) or []
+        )
+        ast.functions = list(getattr(prelude_ast, "functions", []) or []) + list(
+            getattr(ast, "functions", []) or []
+        )
+        return ast
+
+    def parse_hlsl_builtin_option_prelude(self):
+        from ..lexer import Lexer
+        from ..parser import Parser
+
+        source = """
+        shader DirectXBuiltinOption {
+            generic<T> struct Option {
+                enum OptionType { Some(T), Absent }
+                OptionType variant;
+            }
+
+            generic<T> bool is_Some(Option<T> item) {
+                return item.variant == Option::Some;
+            }
+
+            generic<T> bool is_None(Option<T> item) {
+                return item.variant == Option::Absent;
+            }
+
+            generic<T> T unwrap_Some(Option<T> item) {
+                return item.Some_0;
+            }
+        }
+        """
+        return Parser(Lexer(source).tokens).parse()
+
+    def hlsl_ast_declares_type(self, ast, type_name):
+        return any(
+            getattr(struct, "name", None) == type_name
+            for struct in getattr(ast, "structs", []) or []
+        )
+
+    def hlsl_ast_needs_builtin_option(self, ast):
+        option_helpers = {"is_Some", "is_None", "unwrap_Some"}
+        for node in self.walk_ast(ast):
+            if self.hlsl_node_type_uses_builtin_option(node):
+                return True
+            if self.function_call_name(node) in option_helpers:
+                return True
+        return False
+
+    def hlsl_node_type_uses_builtin_option(self, node):
+        for attr in (
+            "return_type",
+            "param_type",
+            "var_type",
+            "vtype",
+            "member_type",
+            "const_type",
+            "constructor_type",
+        ):
+            if self.hlsl_type_uses_builtin_option(getattr(node, attr, None)):
+                return True
+        return False
+
+    def hlsl_type_uses_builtin_option(self, type_value):
+        type_name = self.type_name_string(type_value)
+        if not isinstance(type_name, str):
+            return False
+        base_name, generic_args = generic_type_parts(type_name)
+        return base_name.rsplit("::", 1)[-1] == "Option" and bool(generic_args)
+
+    def hlsl_builtin_option_payload_type(self, type_value):
+        type_name = self.type_name_string(type_value)
+        if not isinstance(type_name, str):
+            return None
+
+        base_name, generic_args = generic_type_parts(type_name)
+        if base_name.rsplit("::", 1)[-1] == "Option" and len(generic_args) == 1:
+            return generic_args[0]
+
+        for specialization in getattr(
+            self, "generic_enum_specializations", {}
+        ).values():
+            if (
+                specialization.get("struct_name") == type_name
+                and str(specialization.get("base_name")).rsplit("::", 1)[-1] == "Option"
+            ):
+                generic_params = specialization.get("definition", {}).get(
+                    "generic_params", []
+                )
+                if not generic_params:
+                    return None
+                return specialization.get("substitutions", {}).get(generic_params[0])
+        return None
+
+    def hlsl_builtin_option_call_type(self, node, func_name):
+        if not getattr(self, "hlsl_builtin_option_available", False):
+            return None
+
+        base_name = str(func_name).rsplit("::", 1)[-1]
+        if base_name == "Some":
+            return self.current_expression_expected_type
+        if base_name in {"is_Some", "is_None"}:
+            return "bool"
+        if base_name == "unwrap_Some":
+            args = list(getattr(node, "arguments", getattr(node, "args", [])) or [])
+            if len(args) != 1:
+                return None
+            option_type = self.expression_result_type(args[0])
+            return self.hlsl_builtin_option_payload_type(option_type)
+        return None
+
     def generate_program(self, ast, target_stage=None):
         """Render an AST to HLSL, optionally filtering stage entry points."""
         target_stage = normalize_stage_name(target_stage)
+        self.hlsl_builtin_option_available = False
+        ast = self.with_hlsl_builtin_option_prelude(ast)
 
         self.texture_variables = set()
         self.sampler_variables = set()
@@ -4184,6 +4307,16 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         vtype = getattr(stmt, "var_type", None)
         if vtype is None:
             vtype = getattr(stmt, "vtype", None)
+        vtype_name = self.type_name_string(vtype)
+        if isinstance(vtype_name, str) and vtype_name.strip().lower() in {
+            "auto",
+            "let",
+        }:
+            inferred_type = self.expression_result_type(
+                getattr(stmt, "initial_value", None)
+            )
+            if inferred_type is not None:
+                return inferred_type
         if vtype is None:
             vtype = self.expression_result_type(getattr(stmt, "initial_value", None))
         return vtype or "float"
@@ -4625,6 +4758,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             func_expr = getattr(expr, "function", None) or getattr(expr, "name", None)
             func_name = getattr(func_expr, "name", func_expr)
             args = getattr(expr, "arguments", getattr(expr, "args", []))
+            option_call_type = self.hlsl_builtin_option_call_type(expr, func_name)
+            if option_call_type is not None:
+                return option_call_type
             if func_name in self.HLSL_WAVE_INTRINSIC_ARITIES:
                 return self.hlsl_wave_intrinsic_return_type(func_name, args)
             if func_name in self.HLSL_NONUNIFORM_RESOURCE_INDEX_NAMES:
@@ -5292,11 +5428,51 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             declaration = f"{declaration} = {value}"
         return declaration
 
+    def is_hlsl_builtin_option_none_expression(self, expr):
+        if not getattr(self, "hlsl_builtin_option_available", False):
+            return False
+        if isinstance(expr, str):
+            return expr.rsplit("::", 1)[-1] == "None"
+        name = getattr(expr, "name", None)
+        return isinstance(name, str) and name.rsplit("::", 1)[-1] == "None"
+
+    def hlsl_builtin_option_constructor_name(self, func_name):
+        if not getattr(self, "hlsl_builtin_option_available", False):
+            return func_name
+        base_name = str(func_name).rsplit("::", 1)[-1]
+        if base_name == "Some":
+            return "Option::Some"
+        if base_name == "None":
+            return "Option::Absent"
+        return func_name
+
+    def generate_hlsl_builtin_option_none_value(self):
+        if not getattr(self, "hlsl_builtin_option_available", False):
+            return None
+        return generate_enum_constructor_call(self, "Option::Absent", [])
+
+    def generate_hlsl_builtin_option_none_comparison(self, left, op, right):
+        if op not in {"==", "!="}:
+            return None
+        left_is_none = self.is_hlsl_builtin_option_none_expression(left)
+        right_is_none = self.is_hlsl_builtin_option_none_expression(right)
+        if left_is_none == right_is_none:
+            return None
+
+        subject = right if left_is_none else left
+        subject_expr = self.generate_expression(subject)
+        operator = "==" if op == "==" else "!="
+        return f"({subject_expr}.variant {operator} Option_Absent)"
+
     def generate_expression(self, expr):
         """Render a CrossGL AST expression into HLSL expression syntax."""
         if expr is None:
             return ""
         elif isinstance(expr, str):
+            if self.is_hlsl_builtin_option_none_expression(expr):
+                none_value = self.generate_hlsl_builtin_option_none_value()
+                if none_value is not None:
+                    return none_value
             return expr
         elif isinstance(expr, bool):
             return "true" if expr else "false"
@@ -5325,6 +5501,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 return str(value)
             return str(expr)
         elif hasattr(expr, "__class__") and "Identifier" in str(expr.__class__):
+            if self.is_hlsl_builtin_option_none_expression(expr):
+                none_value = self.generate_hlsl_builtin_option_none_value()
+                if none_value is not None:
+                    return none_value
             unsupported_value = self.unsupported_glsl_buffer_block_access_value(expr)
             if unsupported_value is not None:
                 return unsupported_value
@@ -5334,6 +5514,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 return enum_value
             return self.hlsl_identifier_name(name)
         elif isinstance(expr, VariableNode):
+            if self.is_hlsl_builtin_option_none_expression(expr):
+                none_value = self.generate_hlsl_builtin_option_none_value()
+                if none_value is not None:
+                    return none_value
             unsupported_value = self.unsupported_glsl_buffer_block_access_value(expr)
             if unsupported_value is not None:
                 return unsupported_value
@@ -5345,6 +5529,13 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             left = self.generate_expression(getattr(expr, "left", ""))
             right = self.generate_expression(getattr(expr, "right", ""))
             op = getattr(expr, "operator", getattr(expr, "op", "+"))
+            option_none_comparison = self.generate_hlsl_builtin_option_none_comparison(
+                getattr(expr, "left", ""),
+                self.map_operator(op),
+                getattr(expr, "right", ""),
+            )
+            if option_none_comparison is not None:
+                return option_none_comparison
             if self.hlsl_binary_multiply_uses_mul(expr):
                 return f"mul({left}, {right})"
             return f"({left} {self.map_operator(op)} {right})"
@@ -5412,6 +5603,11 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 callee = self.hlsl_function_call_name(func_expr)
             else:
                 callee = self.generate_expression(func_expr)
+
+            original_func_name = self.hlsl_builtin_option_constructor_name(func_name)
+            if original_func_name != func_name:
+                func_name = original_func_name
+                callee = original_func_name
 
             byteaddress_interlocked_call = (
                 self.generate_hlsl_byteaddress_interlocked_member_call(

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1103", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1104", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1188", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1103
+        "test_count": 1104
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -1863,8 +1863,7 @@ def test_hlsl_stage_entry_buffer_pointer_params_promote_to_resources():
     assert "RWStructuredBuffer<float> B : register(u2);" in generated_code
     assert "RWStructuredBuffer<float> X : register(u3);" in generated_code
     assert (
-        "void CSMain(uint3 id_dispatchThreadID : SV_DispatchThreadID)"
-        in generated_code
+        "void CSMain(uint3 id_dispatchThreadID : SV_DispatchThreadID)" in generated_code
     )
     assert "float* A" not in generated_code
     assert "float* B" not in generated_code
@@ -6409,6 +6408,46 @@ def test_tuple_enum_constructor_wrong_arity_raises():
         ValueError, match="Enum constructor MaybeInt::Value expects 1 arguments, got 0"
     ):
         HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+
+def test_builtin_option_helpers_lower_to_hlsl_structs():
+    shader = """
+    shader BuiltinOptionDirectX {
+        Option<uint> collatz(uint n) {
+            if (n == 0) {
+                return None;
+            }
+            return Some(n);
+        }
+
+        uint read_option(Option<uint> item) {
+            match item {
+                Option::Some(value) => { return value; },
+                Option::Absent => { return 0; }
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "static const int Option_Some = 0;" in generated_code
+    assert "static const int Option_Absent = 1;" in generated_code
+    assert "struct Option_uint {" in generated_code
+    assert "Option_uint Option_uint_Some_make(uint payload0)" in generated_code
+    assert "Option_uint Option_uint_Absent_make()" in generated_code
+    assert "Option_uint collatz(uint n)" in generated_code
+    assert "uint read_option(Option_uint item)" in generated_code
+    assert "return Option_uint_Absent_make();" in generated_code
+    assert "return Option_uint_Some_make(n);" in generated_code
+    assert "uint value = item.Some_0;" in generated_code
+    assert "if ((item.variant == Option_Some))" in generated_code
+    assert "else if ((item.variant == Option_Absent))" in generated_code
+    assert "Option<" not in generated_code
+    assert "Option::" not in generated_code
+    assert re.search(r"\bSome\s*\(", generated_code) is None
+    assert "None" not in generated_code
+    assert "auto value" not in generated_code
 
 
 def test_generic_enum_struct_concrete_match_and_constructors():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -13777,6 +13777,70 @@ def test_translate_project_rust_option_helpers_lower_to_opengl_compute(tmp_path)
     assert_compute_glsl_validates_if_available(opengl_output, tmp_path)
 
 
+def test_translate_project_rust_option_helpers_lower_to_directx_compute(tmp_path):
+    repo = tmp_path / "repo"
+    source_dir = repo / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "collatz.rs").write_text(
+        textwrap.dedent("""
+            fn collatz(n: u32) -> Option<u32> {
+                if n == 0u32 {
+                    return None;
+                }
+                return Some(n);
+            }
+
+            fn read_option(item: Option<u32>) -> u32 {
+                match item {
+                    Some(value) => { return value; },
+                    None => { return 0u32; }
+                }
+            }
+
+            #[spirv(compute(threads(1, 1, 1)))]
+            pub fn main() {
+                let value = read_option(collatz(7u32));
+            }
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["src"]
+            targets = ["directx"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    directx_output = (
+        repo / "translated" / "directx" / "src" / "collatz.hlsl"
+    ).read_text(encoding="utf-8")
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["diagnostics"] == []
+    assert "struct Option_u32" in directx_output
+    assert "Option_u32 Option_u32_Some_make(uint payload0)" in directx_output
+    assert "Option_u32 Option_u32_Absent_make()" in directx_output
+    assert "bool is_Some_u32(Option_u32 item)" in directx_output
+    assert "uint unwrap_Some_u32(Option_u32 item)" in directx_output
+    assert "Option_u32 collatz(uint n)" in directx_output
+    assert "uint read_option(Option_u32 item)" in directx_output
+    assert "return Option_u32_Absent_make();" in directx_output
+    assert "return Option_u32_Some_make(n);" in directx_output
+    assert "uint value = unwrap_Some_u32(item);" in directx_output
+    assert "(item.variant == Option_Absent)" in directx_output
+    assert "Option<" not in directx_output
+    assert "Option::" not in directx_output
+    assert re.search(r"\bSome\s*\(", directx_output) is None
+    assert "None" not in directx_output
+    assert "auto value" not in directx_output
+    assert_directx_compute_validates_if_available(directx_output, tmp_path)
+
+
 def test_translate_project_rust_option_helpers_lower_to_wgsl_compute(tmp_path):
     repo = tmp_path / "repo"
     source_dir = repo / "src"


### PR DESCRIPTION
## Summary
- Lower built-in Rust Option values before DirectX HLSL emission with a small generic prelude that specializes to target-valid structs.
- Rewrite Rust-style Some/None values, helper calls, and None comparisons to HLSL constructors/tags.
- Infer concrete local types for lowered match bindings and add direct/project translation coverage.

## Validation
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_builtin_option_helpers_lower_to_hlsl_structs tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_directx_compute tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_opengl_compute tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_wgsl_compute tests/test_translator/test_codegen/test_directx_codegen.py::test_generic_enum_struct_concrete_match_and_constructors
- python3.11 tools/support_matrix.py check
- git diff --check HEAD~1..HEAD
- pre-commit run --files crosstl/translator/codegen/directx_codegen.py tests/test_translator/test_codegen/test_directx_codegen.py tests/test_translator/test_project_translation.py docs/source/support-matrix.rst support/generated/support-matrix.json

closes #1214
