### PR TITLE
Fix SPIR-V gl_PerVertex DirectX lowering

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -8,6 +8,7 @@ from ..ast import (
     ArrayLiteralNode,
     ArrayNode,
     AssignmentNode,
+    AttributeNode,
     BinaryOpNode,
     BlockNode,
     BreakNode,
@@ -32,6 +33,7 @@ from ..ast import (
     RayTracingOpNode,
     ReferenceType,
     ReturnNode,
+    StructMemberNode,
     StructNode,
     SwitchNode,
     SwizzleNode,
@@ -1197,6 +1199,7 @@ class HLSLCodeGen:
         self.current_function_name = None
         self.current_function_return_type = None
         self.current_expression_expected_type = None
+        self.current_hlsl_stage_output_lowering = None
         self.allow_hlsl_byteaddress_interlocked_member_expression = False
         self.local_variable_types = {}
         self.global_variable_types = {}
@@ -1236,6 +1239,27 @@ class HLSLCodeGen:
         structs = deduplicate_named_declarations(
             list(getattr(ast, "structs", []) or [])
             + collect_stage_local_structs(ast, target_stage),
+            "struct",
+        )
+        self.hlsl_stage_output_lowerings = self.collect_hlsl_stage_output_lowerings(
+            ast, target_stage, structs
+        )
+        if any(
+            lowering.get("struct_name") is not None
+            for lowering in self.hlsl_stage_output_lowerings.values()
+        ):
+            structs = [
+                struct
+                for struct in structs
+                if not self.hlsl_should_omit_lowered_spirv_pervertex_struct(struct)
+            ]
+        structs = deduplicate_named_declarations(
+            structs
+            + [
+                struct
+                for lowering in self.hlsl_stage_output_lowerings.values()
+                for struct in lowering["structs"]
+            ],
             "struct",
         )
         self.structs_by_name = {
@@ -1302,8 +1326,24 @@ class HLSLCodeGen:
         self.vertex_entry_output_struct_names = (
             self.collect_hlsl_vertex_entry_output_struct_names(ast, target_stage)
         )
+        self.vertex_entry_output_struct_names.update(
+            {
+                lowering["struct_name"]
+                for lowering in self.hlsl_stage_output_lowerings.values()
+                if lowering["stage_name"] == "vertex"
+                and lowering.get("struct_name") is not None
+            }
+        )
         self.vertex_entry_input_struct_names = (
             self.collect_hlsl_vertex_entry_input_struct_names(ast, target_stage)
+        )
+        self.vertex_entry_input_struct_names.update(
+            {
+                lowering["input_struct_name"]
+                for lowering in self.hlsl_stage_output_lowerings.values()
+                if lowering["stage_name"] == "vertex"
+                and lowering.get("input_struct_name") is not None
+            }
         )
         self.fragment_entry_input_struct_names = (
             self.collect_hlsl_fragment_entry_input_struct_names(ast, target_stage)
@@ -2250,6 +2290,9 @@ class HLSLCodeGen:
                             shader_type=stage_name,
                             execution_config=getattr(stage, "execution_config", None),
                             entry_name=stage_entry_names.get(id(stage.entry_point)),
+                            stage_output_lowering=self.hlsl_stage_output_lowerings.get(
+                                id(stage)
+                            ),
                         )
                     finally:
                         self.current_hlsl_available_functions = (
@@ -3473,6 +3516,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         shader_type=None,
         execution_config=None,
         entry_name=None,
+        stage_output_lowering=None,
     ):
         """Render a function or stage entry point with HLSL semantics."""
         code = ""
@@ -3502,6 +3546,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         previous_local_variable_types = self.local_variable_types
         previous_identifier_aliases = self.current_identifier_aliases
         previous_identifier_reserved_names = self.current_identifier_reserved_names
+        previous_stage_output_lowering = self.current_hlsl_stage_output_lowering
         previous_function_name = self.current_function_name
         previous_generic_function_substitutions = (
             self.current_generic_function_substitutions
@@ -3536,9 +3581,16 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         self.current_function_name = getattr(func, "name", None) or entry_name
         self.local_variable_types = {}
         self.current_identifier_aliases = {}
+        self.current_hlsl_stage_output_lowering = stage_output_lowering
         self.current_identifier_reserved_names = (
             self.collect_hlsl_function_identifier_names(func)
         )
+        if stage_output_lowering is not None:
+            self.current_identifier_aliases.update(stage_output_lowering["aliases"])
+            for local_name_key in ("local_name", "input_local_name"):
+                local_name = stage_output_lowering.get(local_name_key)
+                if local_name is not None:
+                    self.current_identifier_reserved_names.add(local_name)
         if hasattr(func, "qualifiers") and func.qualifiers:
             qualifier = func.qualifiers[0] if func.qualifiers else None
         else:
@@ -3795,6 +3847,13 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         else:
             raw_return_type = "void"
             return_type = "void"
+        if (
+            stage_output_lowering is not None
+            and stage_output_lowering.get("struct_name") is not None
+            and self.map_type(return_type) == "void"
+        ):
+            raw_return_type = stage_output_lowering["struct_name"]
+            return_type = stage_output_lowering["struct_name"]
         self.current_function_return_type = raw_return_type
         declaration_return_type = (
             f"{self.hlsl_precise_modifier_prefix(func)}{return_type}"
@@ -3819,6 +3878,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             self.local_variable_types = previous_local_variable_types
             self.current_identifier_aliases = previous_identifier_aliases
             self.current_identifier_reserved_names = previous_identifier_reserved_names
+            self.current_hlsl_stage_output_lowering = previous_stage_output_lowering
             self.current_generic_function_substitutions = (
                 previous_generic_function_substitutions
             )
@@ -3845,6 +3905,11 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 effective_shader_type,
                 return_type,
             )
+        if (
+            stage_output_lowering is not None
+            and stage_output_lowering.get("struct_name") is not None
+        ):
+            return_semantic = None
         body = getattr(func, "body", None)
         if effective_shader_type is None and body is None:
             function_name = self.hlsl_function_declaration_name(func, entry_name)
@@ -3858,6 +3923,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             self.local_variable_types = previous_local_variable_types
             self.current_identifier_aliases = previous_identifier_aliases
             self.current_identifier_reserved_names = previous_identifier_reserved_names
+            self.current_hlsl_stage_output_lowering = previous_stage_output_lowering
             self.current_generic_function_substitutions = (
                 previous_generic_function_substitutions
             )
@@ -3906,6 +3972,20 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             self.validate_hlsl_stage_parameter_requirements(func, effective_shader_type)
             if effective_shader_type == "compute":
                 code += self.generate_compute_numthreads(execution_config)
+            if (
+                stage_output_lowering is not None
+                and stage_output_lowering.get("input_struct_name") is not None
+            ):
+                input_name = stage_output_lowering["input_local_name"]
+                input_declaration = (
+                    f"{stage_output_lowering['input_struct_name']} {input_name}"
+                )
+                params_str = self.append_hlsl_parameter_declaration(
+                    params_str, input_declaration
+                )
+                self.local_variable_types[input_name] = stage_output_lowering[
+                    "input_struct_name"
+                ]
             code += wave_size_attribute
             code += waveops_helper_lanes_attribute
             function_name = entry_name or shader_map[effective_shader_type]
@@ -3963,6 +4043,12 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             return_type != "void" and not self.statement_body_terminates(body)
         )
         try:
+            if stage_output_lowering is not None:
+                output_name = stage_output_lowering.get("local_name")
+                output_type = stage_output_lowering.get("struct_name")
+                if output_name is not None and output_type is not None:
+                    code += f"{'    ' * (indent + 1)}{output_type} {output_name};\n"
+                    self.local_variable_types[output_name] = output_type
             for statement in parameter_prologue_statements:
                 code += f"{'    ' * (indent + 1)}{statement}\n"
             code += self.generate_statement_body(body, indent + 1)
@@ -3971,7 +4057,13 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 previous_hlsl_visible_int_constants
             )
         if needs_fallthrough_return:
-            fallback = self.hlsl_default_value_expression(raw_return_type)
+            if (
+                stage_output_lowering is not None
+                and stage_output_lowering.get("local_name") is not None
+            ):
+                fallback = stage_output_lowering["local_name"]
+            else:
+                fallback = self.hlsl_default_value_expression(raw_return_type)
             code += f"{'    ' * (indent + 1)}return {fallback};\n"
         self.current_sampler_parameters = previous_sampler_parameters
         self.current_texture_parameters = previous_texture_parameters
@@ -3989,6 +4081,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         self.local_variable_types = previous_local_variable_types
         self.current_identifier_aliases = previous_identifier_aliases
         self.current_identifier_reserved_names = previous_identifier_reserved_names
+        self.current_hlsl_stage_output_lowering = previous_stage_output_lowering
         self.current_generic_function_substitutions = (
             previous_generic_function_substitutions
         )
@@ -4215,6 +4308,14 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                         f"{self.generate_expression_with_expected(stmt.value, self.current_function_return_type)};\n"
                     )
             else:
+                stage_output_lowering = self.current_hlsl_stage_output_lowering
+                if (
+                    stage_output_lowering is not None
+                    and stage_output_lowering.get("local_name") is not None
+                ):
+                    return (
+                        f"{indent_str}return {stage_output_lowering['local_name']};\n"
+                    )
                 return f"{indent_str}return;\n"
 
         elif hasattr(stmt, "__class__") and "ExpressionStatement" in str(
@@ -13785,6 +13886,262 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             if entry_point is not None:
                 functions.append(entry_point)
         return functions
+
+    def collect_hlsl_stage_output_lowerings(self, ast, target_stage, existing_structs):
+        if not stage_matches(target_stage, "vertex"):
+            return {}
+
+        used_struct_names = {
+            getattr(struct, "name", "")
+            for struct in existing_structs
+            if getattr(struct, "name", "")
+        }
+        lowerings = {}
+        for stage_type, stage in getattr(ast, "stages", {}).items():
+            stage_name = normalize_stage_name(stage_type)
+            if stage_name != "vertex" or not stage_matches(target_stage, stage_name):
+                continue
+
+            entry_point = getattr(stage, "entry_point", None)
+            if entry_point is None:
+                continue
+
+            referenced_names = self.hlsl_referenced_identifier_names(entry_point)
+            stage_inputs = []
+            stage_outputs = []
+            for variable in getattr(stage, "local_variables", []) or []:
+                name = getattr(variable, "name", None)
+                if not name or name not in referenced_names:
+                    continue
+                if self.hlsl_stage_local_variable_direction(variable) == "input":
+                    stage_inputs.append(variable)
+                elif self.hlsl_stage_local_variable_direction(variable) == "output":
+                    stage_outputs.append(variable)
+
+            if not stage_inputs and not stage_outputs:
+                continue
+
+            raw_return_type = self.type_name_string(
+                getattr(entry_point, "return_type", getattr(entry_point, "vtype", None))
+            )
+            can_lower_outputs = (
+                not raw_return_type or self.map_type(raw_return_type) == "void"
+            )
+            if not can_lower_outputs:
+                stage_outputs = []
+
+            input_struct = None
+            input_struct_name = None
+            input_local_name = None
+            input_aliases = {}
+            if stage_inputs:
+                input_struct_name = self.hlsl_unique_stage_io_struct_name(
+                    "VertexInput", "SPIRVVertexInput", used_struct_names
+                )
+                used_struct_names.add(input_struct_name)
+                input_local_name = self.hlsl_unique_stage_io_local_name(
+                    entry_point, "input", "spirvInput"
+                )
+                input_members, input_aliases = self.hlsl_stage_io_struct_members(
+                    stage_inputs, input_local_name
+                )
+                input_struct = StructNode(input_struct_name, input_members)
+
+            output_struct = None
+            output_struct_name = None
+            output_local_name = None
+            output_aliases = {}
+            if stage_outputs:
+                output_struct_name = self.hlsl_unique_stage_io_struct_name(
+                    "VertexOutput", "SPIRVVertexOutput", used_struct_names
+                )
+                used_struct_names.add(output_struct_name)
+                output_local_name = self.hlsl_unique_stage_io_local_name(
+                    entry_point, "output", "spirvOutput"
+                )
+                output_members, output_aliases = self.hlsl_stage_io_struct_members(
+                    stage_outputs, output_local_name
+                )
+                output_struct = StructNode(output_struct_name, output_members)
+
+            if input_struct is None and output_struct is None:
+                continue
+
+            lowerings[id(stage)] = {
+                "stage_name": stage_name,
+                "input_struct_name": input_struct_name,
+                "input_local_name": input_local_name,
+                "struct_name": output_struct_name,
+                "local_name": output_local_name,
+                "structs": [
+                    struct
+                    for struct in (input_struct, output_struct)
+                    if struct is not None
+                ],
+                "aliases": {**input_aliases, **output_aliases},
+            }
+
+        return lowerings
+
+    def hlsl_should_omit_lowered_spirv_pervertex_struct(self, struct_node):
+        if getattr(struct_node, "name", None) != "gl_PerVertex":
+            return False
+
+        builtin_members = {
+            "gl_Position",
+            "gl_PointSize",
+            "gl_ClipDistance",
+            "gl_CullDistance",
+        }
+        member_names = {
+            getattr(member, "name", None)
+            for member in getattr(struct_node, "members", []) or []
+            if getattr(member, "name", None)
+        }
+        return bool(member_names) and member_names <= builtin_members
+
+    def hlsl_referenced_identifier_names(self, func):
+        names = set()
+        for node in self.walk_ast(getattr(func, "body", None)):
+            if isinstance(node, IdentifierNode):
+                name = getattr(node, "name", None)
+            elif isinstance(node, VariableNode):
+                name = getattr(node, "name", None)
+            else:
+                continue
+            if name:
+                names.add(name)
+        return names
+
+    def hlsl_stage_local_variable_direction(self, variable):
+        for attr in getattr(variable, "attributes", []) or []:
+            name = str(getattr(attr, "name", "")).lower()
+            if name == "input":
+                return "input"
+            if name == "output":
+                return "output"
+        qualifiers = {
+            str(qualifier).lower() for qualifier in getattr(variable, "qualifiers", [])
+        }
+        if "in" in qualifiers:
+            return "input"
+        if "out" in qualifiers:
+            return "output"
+        return None
+
+    def hlsl_unique_stage_io_struct_name(self, preferred, fallback, used_names):
+        if preferred not in used_names:
+            return preferred
+        if fallback not in used_names:
+            return fallback
+        index = 2
+        while f"{fallback}{index}" in used_names:
+            index += 1
+        return f"{fallback}{index}"
+
+    def hlsl_unique_stage_io_local_name(self, entry_point, preferred, fallback):
+        used_names = self.collect_hlsl_function_identifier_names(entry_point)
+        used_names.update(self.HLSL_RESERVED_LOCAL_IDENTIFIER_NAMES)
+        if preferred not in used_names:
+            return preferred
+        if fallback not in used_names:
+            return fallback
+        index = 2
+        while f"{fallback}{index}" in used_names:
+            index += 1
+        return f"{fallback}{index}"
+
+    def hlsl_stage_io_struct_members(self, variables, local_name):
+        members = []
+        aliases = {}
+        used_member_names = set()
+        for variable in variables:
+            field_name = self.hlsl_stage_io_field_name(variable, used_member_names)
+            used_member_names.add(field_name)
+            member = StructMemberNode(
+                field_name,
+                getattr(variable, "var_type", getattr(variable, "vtype", None)),
+                attributes=self.hlsl_stage_io_member_attributes(variable),
+            )
+            members.append(member)
+            aliases[variable.name] = f"{local_name}.{field_name}"
+        return members, aliases
+
+    def hlsl_stage_io_field_name(self, variable, used_names):
+        semantic = self.hlsl_stage_io_variable_semantic(variable)
+        builtin_names = {
+            "gl_Position": "position",
+            "gl_PointSize": "pointSize",
+            "gl_ClipDistance": "clipDistance",
+            "gl_CullDistance": "cullDistance",
+        }
+        base_name = builtin_names.get(semantic)
+        if base_name is None:
+            base_name = str(getattr(variable, "name", "value") or "value")
+            base_name = base_name.lstrip("_") or "value"
+        candidate = self.hlsl_sanitized_identifier(base_name)
+        while (
+            candidate in used_names
+            or candidate in self.HLSL_RESERVED_LOCAL_IDENTIFIER_NAMES
+        ):
+            candidate += "_"
+        return candidate
+
+    def hlsl_sanitized_identifier(self, name):
+        text = "".join(
+            char if (char.isalnum() or char == "_") else "_"
+            for char in str(name or "value")
+        )
+        text = text or "value"
+        if text[0].isdigit():
+            text = f"value_{text}"
+        return text
+
+    def hlsl_stage_io_variable_semantic(self, variable):
+        for attr in getattr(variable, "attributes", []) or []:
+            attr_name = getattr(attr, "name", None)
+            normalized = str(attr_name).lower()
+            if normalized in {
+                "input",
+                "output",
+                "in",
+                "out",
+                "highp",
+                "mediump",
+                "lowp",
+            }:
+                continue
+            if attr_name in self.semantic_map or normalized == "location":
+                return self.semantic_attribute_name(attr)
+        return None
+
+    def hlsl_stage_io_member_attributes(self, variable):
+        retained = []
+        for attr in getattr(variable, "attributes", []) or []:
+            attr_name = getattr(attr, "name", None)
+            normalized = str(attr_name).lower()
+            if normalized in {
+                "input",
+                "output",
+                "in",
+                "out",
+                "highp",
+                "mediump",
+                "lowp",
+            }:
+                continue
+            if attr_name in self.semantic_map or normalized in {
+                "location",
+                "centroid",
+                "flat",
+                "noperspective",
+                "sample",
+                "smooth",
+            }:
+                retained.append(
+                    AttributeNode(attr_name, list(getattr(attr, "arguments", []) or []))
+                )
+        return retained
 
     def collect_hlsl_vertex_entry_output_struct_names(self, ast, target_stage=None):
         if not stage_matches(target_stage, "vertex"):

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1104", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1105", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1188", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1104
+        "test_count": 1105
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -31,6 +31,9 @@ from crosstl.translator.codegen.directx_codegen import (
 )
 from crosstl.translator.lexer import Lexer
 from crosstl.translator.parser import Parser
+from tests.test_backend.test_SPIRV.test_codegen import (
+    SPIRV_TOOLS_GLPERVERTEX_ACCESS_CHAIN_ASSEMBLY,
+)
 
 
 def tokenize_code(code: str) -> List:
@@ -348,6 +351,31 @@ def test_glsl_pervertex_position_output_lowers_to_hlsl_sv_position(tmp_path):
     assert "float4 gl_Position: TEXCOORD" not in generated_code
     assert "float3 outColor: TEXCOORD0;" in generated_code
     assert generated_code.count(": TEXCOORD0") == 1
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_spirv_pervertex_position_output_lowers_to_hlsl_vertex_contract(tmp_path):
+    shader_path = tmp_path / "glpervertex.vert.spvasm"
+    shader_path.write_text(
+        SPIRV_TOOLS_GLPERVERTEX_ACCESS_CHAIN_ASSEMBLY,
+        encoding="utf-8",
+    )
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+    )
+
+    assert "struct VertexInput" in generated_code
+    assert "float4 ua_position: TEXCOORD0;" in generated_code
+    assert "struct VertexOutput" in generated_code
+    assert "float4 position: SV_POSITION;" in generated_code
+    assert "VertexOutput VSMain(VertexInput input)" in generated_code
+    assert "output.position = input.ua_position;" in generated_code
+    assert "return output;" in generated_code
+    assert "gl_Position" not in generated_code
+    assert "_ua_position" not in generated_code
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
 
 

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -40,6 +40,9 @@ from crosstl.project import (
     validate_project_report,
 )
 from crosstl.translator.source_registry import SOURCE_REGISTRY, register_default_sources
+from tests.test_backend.test_SPIRV.test_codegen import (
+    SPIRV_TOOLS_GLPERVERTEX_ACCESS_CHAIN_ASSEMBLY,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -7565,6 +7568,42 @@ def test_translate_project_spirv_assembly_vertex_position_lowers_to_wgsl(tmp_pat
     if shutil.which("naga"):
         assert payload["validation"]["artifacts"][0]["status"] == "ok"
         assert payload["validation"]["toolchainRuns"][0]["status"] == "ok"
+
+
+def test_translate_project_spirv_pervertex_position_lowers_to_directx(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "basic_src.spvasm").write_text(
+        SPIRV_TOOLS_GLPERVERTEX_ACCESS_CHAIN_ASSEMBLY,
+        encoding="utf-8",
+    )
+
+    report = translate_project(
+        repo,
+        targets=["directx"],
+        output_dir="out",
+        format_output=False,
+    )
+    payload = report.to_json()
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("directx", "translated")}
+
+    hlsl = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
+    assert "struct VertexInput" in hlsl
+    assert "float4 ua_position: TEXCOORD0;" in hlsl
+    assert "struct VertexOutput" in hlsl
+    assert "float4 position: SV_POSITION;" in hlsl
+    assert "VertexOutput VSMain(VertexInput input)" in hlsl
+    assert "output.position = input.ua_position;" in hlsl
+    assert "return output;" in hlsl
+    assert "gl_Position" not in hlsl
+    assert "_ua_position" not in hlsl
+    assert_directx_vertex_validates_if_available(hlsl, tmp_path)
 
 
 def test_translate_project_glsl_usampler_texel_fetch_lowers_to_cuda_hip_slang(


### PR DESCRIPTION
## Summary
- lower SPIR-V vertex stage-local inputs and outputs into declared DirectX entry structs
- map `gl_PerVertex` position writes through an `SV_Position` vertex output instead of emitting `gl_Position`
- cover direct and project translation paths and update the generated support matrix count

## Validation
- `python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_glsl_pervertex_position_output_lowers_to_hlsl_sv_position tests/test_translator/test_codegen/test_directx_codegen.py::test_spirv_pervertex_position_output_lowers_to_hlsl_vertex_contract -q`
- `python3.11 -m pytest tests/test_translator/test_project_translation.py::test_translate_project_spirv_pervertex_position_lowers_to_directx tests/test_translator/test_project_translation.py::test_translate_project_glslang_spec_constant_vertex_to_directx tests/test_translator/test_project_translation.py::test_translate_project_glslang_push_constant_vertex_avoids_unwritten_sv_position -q`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- `pre-commit run --files crosstl/translator/codegen/directx_codegen.py tests/test_translator/test_codegen/test_directx_codegen.py tests/test_translator/test_project_translation.py support/generated/support-matrix.json docs/source/support-matrix.rst`

closes #1215
