### PR TITLE
Declare Rust-GPU storage buffers for OpenGL

### DIFF
--- a/crosstl/backend/Rust/RustCrossGLCodeGen.py
+++ b/crosstl/backend/Rust/RustCrossGLCodeGen.py
@@ -1098,7 +1098,11 @@ class RustToCrossGLConverter:
             qualifier = self.get_parameter_qualifier_from_attributes(
                 getattr(param, "attributes", [])
             )
-            param_type = self.normalize_parameter_type(param.vtype, struct_name)
+            param_type = self.normalize_parameter_type(
+                param.vtype,
+                struct_name,
+                attributes=getattr(param, "attributes", []),
+            )
             if self.is_graphics_mutable_output_parameter(
                 param, shader_type, qualifier, semantic
             ):
@@ -1473,7 +1477,7 @@ class RustToCrossGLConverter:
             return struct_name
         return type_name
 
-    def normalize_parameter_type(self, type_name, struct_name=None):
+    def normalize_parameter_type(self, type_name, struct_name=None, attributes=None):
         typed_buffer_type = self.map_typed_buffer_parameter_type(type_name)
         if typed_buffer_type is not None:
             return typed_buffer_type
@@ -1482,6 +1486,12 @@ class RustToCrossGLConverter:
         )
         if byte_addressable_type is not None:
             return byte_addressable_type
+        storage_buffer_type = self.map_rust_gpu_storage_buffer_parameter_type(
+            type_name,
+            attributes,
+        )
+        if storage_buffer_type is not None:
+            return storage_buffer_type
         tuple_type = self.map_tuple_type(type_name)
         if tuple_type is not None:
             return tuple_type
@@ -11114,6 +11124,60 @@ class RustToCrossGLConverter:
                 rust_type[1:].strip(),
                 writable=False,
             )
+        return None
+
+    def map_rust_gpu_storage_buffer_parameter_type(self, rust_type, attributes):
+        if not isinstance(rust_type, str):
+            return None
+        if not self.has_rust_gpu_storage_buffer_attribute(attributes):
+            return None
+
+        rust_type = self.strip_lifetime_type_syntax(rust_type.strip())
+        writable = False
+        if rust_type.startswith("&mut "):
+            writable = True
+            rust_type = rust_type[5:].strip()
+        elif rust_type.startswith("&"):
+            rust_type = rust_type[1:].strip()
+        else:
+            return None
+
+        element_type = self.rust_gpu_storage_buffer_element_type(rust_type)
+        if element_type is None:
+            return None
+
+        buffer_kind = "RWStructuredBuffer" if writable else "StructuredBuffer"
+        return self.format_typed_buffer_resource_type(element_type, buffer_kind)
+
+    def has_rust_gpu_storage_buffer_attribute(self, attributes):
+        for attr in self.effective_attributes(attributes):
+            if not isinstance(attr, AttributeNode) or attr.name != "spirv":
+                continue
+            if "storage_buffer" in getattr(attr, "args", []):
+                return True
+        return False
+
+    def rust_gpu_storage_buffer_element_type(self, rust_type):
+        stripped = rust_type.strip()
+        if stripped.endswith("[]"):
+            element_type = stripped[:-2].strip()
+            return element_type or None
+        if "[" in stripped and stripped.endswith("]"):
+            base_type, _array_size = stripped.rsplit("[", 1)
+            if _array_size[:-1].strip():
+                return base_type.strip() or None
+        if stripped.startswith("[") and stripped.endswith("]"):
+            body = stripped[1:-1].strip()
+            if ";" in body:
+                body = body.split(";", 1)[0].strip()
+            return body or None
+
+        generic = self.parse_generic_type(stripped)
+        if generic is not None:
+            base_name, args = generic
+            if base_name in {"RuntimeArray", "Slice"} and args:
+                return args[0]
+
         return None
 
     def map_byte_addressable_buffer_type(self, rust_type, writable=False):

--- a/tests/test_backend/test_rust/test_codegen.py
+++ b/tests/test_backend/test_rust/test_codegen.py
@@ -1003,13 +1003,20 @@ def test_rust_gpu_compute_option_unwrap_or_lowers_for_metal_and_spirv(tmp_path):
     rust_file.write_text(code)
 
     crossgl = crosstl.translate(str(rust_file), backend="cgl", format_output=False)
+    opengl = crosstl.translate(str(rust_file), backend="opengl", format_output=False)
     metal = crosstl.translate(str(rust_file), backend="metal", format_output=False)
     spirv = crosstl.translate(str(rust_file), backend="vulkan", format_output=False)
 
     assert ".unwrap_or" not in crossgl
+    assert ".unwrap_or" not in opengl
     assert ".unwrap_or" not in metal
-    assert "collatz_unwrap_or(prime_indices[index], 4294967295u)" in crossgl
-    assert "collatz_unwrap_or(prime_indices[index], 4294967295u)" in metal
+    assert "RWStructuredBuffer<uint> prime_indices @ set(0) @ binding(0)" in crossgl
+    assert (
+        "layout(std430, binding = 0) buffer prime_indicesBuffer "
+        "{ uint prime_indices[]; };" in opengl
+    )
+    for output in (crossgl, opengl, metal):
+        assert "collatz_unwrap_or(prime_indices[index], 4294967295u)" in output
     assert "uint collatz_unwrap_or(uint n, uint _rust_option_fallback)" in metal
     assert "return _rust_option_fallback;" in crossgl
     assert "return i;" in crossgl
@@ -1164,7 +1171,7 @@ def test_rust_gpu_spirv_attributes_drive_stage_and_parameter_semantics():
     assert "out vec4 out_pos @ gl_Position @ invariant" in result
     assert "compute main_cs {" in result
     assert "uvec3 id @ gl_GlobalInvocationID" in result
-    assert "uint values[] @ set(0) @ binding(0)" in result
+    assert "RWStructuredBuffer<uint> values @ set(0) @ binding(0)" in result
 
 
 def test_rust_gpu_uniform_descriptor_parameter_keeps_storage_class_from_dev_guide():
@@ -1246,7 +1253,7 @@ def test_rust_gpu_cfg_attr_spirv_metadata_codegen():
 
     assert "compute wrapped_main {" in result
     assert "void main(uvec3 id @ gl_GlobalInvocationID" in result
-    assert "uint values[] @ set(0) @ binding(1)" in result
+    assert "RWStructuredBuffer<uint> values @ set(0) @ binding(1)" in result
     assert "@numthreads(64, 1, 1)" in result
     assert "void shader_body(" not in result
 
@@ -2189,8 +2196,8 @@ def test_rust_gpu_reduce_subgroup_builtins_codegen_from_upstream_example():
     assert "uvec3 workgroup_id @ gl_WorkGroupID" in result
     assert "uint subgroup_id @ gl_SubgroupID" in result
     assert "uint num_subgroups @ gl_NumSubgroups" in result
-    assert "uint input[] @ set(0) @ binding(0)" in result
-    assert "uint output[] @ set(0) @ binding(1)" in result
+    assert "StructuredBuffer<uint> input @ set(0) @ binding(0)" in result
+    assert "RWStructuredBuffer<uint> output @ set(0) @ binding(1)" in result
     assert "uint shared_[256] @ groupshared" in result
     assert "@numthreads(256, 1, 1)" in result
     assert "sum = subgroup_add(sum);" in result
@@ -2570,7 +2577,7 @@ def test_rust_gpu_compute_collatz_option_chain_codegen_from_upstream_example():
     assert "return Some(i);" in result
     assert "compute main_cs {" in result
     assert "void main(uvec3 id @ gl_GlobalInvocationID" in result
-    assert "uint prime_indices[] @ set(0) @ binding(0)" in result
+    assert "RWStructuredBuffer<uint> prime_indices @ set(0) @ binding(0)" in result
     assert "@numthreads(64, 1, 1)" in result
     assert "let index = uint(id.x);" in result
     assert (

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -13816,6 +13816,79 @@ def test_translate_project_rust_option_helpers_lower_to_opengl_compute(tmp_path)
     assert_compute_glsl_validates_if_available(opengl_output, tmp_path)
 
 
+def test_translate_project_rust_gpu_storage_buffer_declares_opengl_ssbo(tmp_path):
+    repo = tmp_path / "repo"
+    source_dir = repo / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "lib.rs").write_text(
+        textwrap.dedent("""
+            use glam::UVec3;
+            use spirv_std::{glam, spirv};
+
+            pub fn collatz(mut n: u32) -> Option<u32> {
+                let mut i = 0;
+                if n == 0 {
+                    return None;
+                }
+                while n != 1 {
+                    n = if n.is_multiple_of(2) {
+                        n / 2
+                    } else {
+                        if n >= 0x5555_5555 {
+                            return None;
+                        }
+                        3 * n + 1
+                    };
+                    i += 1;
+                }
+                Some(i)
+            }
+
+            #[spirv(compute(threads(64)))]
+            pub fn main_cs(
+                #[spirv(global_invocation_id)] id: UVec3,
+                #[spirv(storage_buffer, descriptor_set = 0, binding = 0)]
+                prime_indices: &mut [u32],
+            ) {
+                let index = id.x as usize;
+                prime_indices[index] =
+                    collatz(prime_indices[index]).unwrap_or(u32::MAX);
+            }
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            source_roots = ["src"]
+            targets = ["opengl"]
+            output_dir = "translated"
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
+    opengl_output = (repo / "translated" / "opengl" / "src" / "lib.glsl").read_text(
+        encoding="utf-8"
+    )
+
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 0
+    assert (
+        "layout(std430, binding = 0) buffer prime_indicesBuffer "
+        "{ uint prime_indices[]; };" in opengl_output
+    )
+    assert "void main()" in opengl_output
+    assert (
+        "prime_indices[index] = "
+        "collatz_unwrap_or(prime_indices[index], 4294967295u);"
+    ) in opengl_output
+    assert "prime_indices[" in opengl_output
+    assert "uint prime_indices[]" not in opengl_output.split("void main()", 1)[1]
+    assert_compute_glsl_validates_if_available(opengl_output, tmp_path)
+
+
 def test_translate_project_rust_option_helpers_lower_to_directx_compute(tmp_path):
     repo = tmp_path / "repo"
     source_dir = repo / "src"


### PR DESCRIPTION
## Summary
- Lower Rust-GPU `#[spirv(storage_buffer)]` slice parameters to CrossGL structured-buffer resource types.
- Add a project translation regression for the Collatz OpenGL artifact so `prime_indices` is declared as an SSBO before use.

## Validation
- `python3.11 -m pytest tests/test_backend/test_rust/test_codegen.py tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_opengl_compute tests/test_translator/test_project_translation.py::test_translate_project_rust_gpu_storage_buffer_declares_opengl_ssbo tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_directx_compute tests/test_translator/test_project_translation.py::test_translate_project_rust_option_helpers_lower_to_wgsl_compute tests/test_translator/test_codegen/test_GLSL_codegen.py::test_glsl_stage_resource_descriptor_set_flattens_to_opengl_binding tests/test_translator/test_codegen/test_GLSL_codegen.py::test_glsl_cbuffer_and_storage_buffer_bindings_are_independent -q`
- `python3.11 tools/support_matrix.py check`
- `git diff --check`
- `pre-commit run --files crosstl/backend/Rust/RustCrossGLCodeGen.py tests/test_backend/test_rust/test_codegen.py tests/test_translator/test_project_translation.py`
- Reduced Rust-GPU Collatz `translate-project --target opengl --validate --no-format` smoke plus `glslangValidator --stdin -S comp`

closes #1221