### PR TITLE
Lower HIP storage array parameters for DirectX

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -312,6 +312,7 @@ from .stage_utils import (
     compute_local_size,
     declaration_signature,
     deduplicate_named_declarations,
+    function_stage_name,
     normalize_stage_name,
     order_functions_by_dependencies,
     should_emit_qualified_function,
@@ -2208,11 +2209,7 @@ class HLSLCodeGen:
         self.current_hlsl_available_functions = global_functions_by_name
         functions_code = ""
         for func in functions:
-            if hasattr(func, "qualifiers") and func.qualifiers:
-                qualifier = func.qualifiers[0] if func.qualifiers else None
-            else:
-                qualifier = getattr(func, "qualifier", None)
-            qualifier_name = normalize_stage_name(qualifier)
+            qualifier_name = function_stage_name(func)
 
             if not should_emit_qualified_function(target_stage, qualifier_name):
                 continue
@@ -7666,6 +7663,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         return f"stage-entry parameter {function_name}.{parameter_name}"
 
     def hlsl_entry_resource_parameter_global_type(self, parameter, func=None):
+        storage_array_type = self.hlsl_storage_array_parameter_resource_type(parameter)
+        if storage_array_type is not None:
+            return storage_array_type
+
         raw_type = self.hlsl_parameter_raw_type(parameter)
         mapped_type = self.map_resource_parameter_type_with_hint(
             raw_type,
@@ -7676,6 +7677,43 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         if self.is_hlsl_global_resource_type(mapped_type):
             return mapped_type
         return None
+
+    def hlsl_storage_array_parameter_resource_type(self, parameter):
+        qualifiers = {
+            str(qualifier).lower()
+            for qualifier in getattr(parameter, "resource_qualifiers", []) or []
+        }
+        if "storage" not in qualifiers:
+            return None
+
+        raw_type = self.hlsl_parameter_raw_type(parameter)
+        element_type = None
+        if (
+            hasattr(raw_type, "element_type")
+            and str(type(raw_type)).find("ArrayType") != -1
+        ):
+            element_type = raw_type.element_type
+        else:
+            type_name = self.type_name_string(raw_type)
+            if not type_name:
+                return None
+            base_type, array_suffix = split_array_type_suffix(type_name)
+            if array_suffix:
+                element_type = base_type
+            else:
+                base_name, generic_args = generic_type_parts(type_name)
+                if base_name == "array" and generic_args:
+                    element_type = generic_args[0]
+
+        if element_type is None:
+            return None
+
+        resource_name = (
+            "StructuredBuffer"
+            if qualifiers.intersection({"const", "read", "readonly", "read_only"})
+            else "RWStructuredBuffer"
+        )
+        return f"{resource_name}<{self.map_type(element_type)}>"
 
     def is_hlsl_global_resource_type(self, mapped_type):
         mapped_type = str(mapped_type)
@@ -14913,7 +14951,9 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 continue
             for param in getattr(func, "parameters", getattr(func, "params", [])):
                 vtype = getattr(param, "param_type", getattr(param, "vtype", None))
-                if self.is_unsized_resource_array_type(vtype):
+                if self.is_unsized_resource_array_type(
+                    vtype
+                ) or self.is_unsized_storage_array_parameter(param):
                     function_arrays.setdefault(func_name, {})[param.name] = vtype
         return function_arrays
 
@@ -14967,6 +15007,25 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             return False
         base_type, size = parse_array_type(type_string)
         return size is None and self.is_resource_array_hint_type(base_type)
+
+    def is_unsized_storage_array_parameter(self, parameter):
+        qualifiers = {
+            str(qualifier).lower()
+            for qualifier in getattr(parameter, "resource_qualifiers", []) or []
+        }
+        if "storage" not in qualifiers:
+            return False
+
+        vtype = getattr(parameter, "param_type", getattr(parameter, "vtype", None))
+        if hasattr(vtype, "element_type") and str(type(vtype)).find("ArrayType") != -1:
+            return vtype.size is None
+        if hasattr(vtype, "name") or hasattr(vtype, "element_type"):
+            return False
+        type_string = str(vtype)
+        if "[" not in type_string or "]" not in type_string:
+            return False
+        _, size = parse_array_type(type_string)
+        return size is None
 
     def is_resource_array_hint_type(self, vtype):
         return (
@@ -19219,6 +19278,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         return str(attr_name).lower() in {
             "binding",
             "buffer",
+            "group",
             "packoffset",
             "register",
             "sampler",

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1105", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1107", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1188", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1105
+        "test_count": 1107
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -1900,6 +1900,60 @@ def test_hlsl_stage_entry_buffer_pointer_params_promote_to_resources():
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
 
 
+def test_hlsl_stage_entry_storage_arrays_promote_to_resources():
+    shader = """
+    // HIP to CrossGL conversion
+    // Kernel: AddKernel
+    @compute
+    @stage_entry
+    @workgroup_size(1, 1, 1)
+    fn AddKernel(
+        @group(0) @binding(0) var<storage, read_write> a: array<f32>,
+        @group(0) @binding(1) var<storage, read> b: array<f32>
+    ) {
+        var global_idx: i32 = (
+            gl_LocalInvocationID.x + (gl_WorkGroupID.x * gl_WorkGroupSize.x)
+        );
+        a[global_idx] += b[global_idx];
+    }
+    """
+
+    generated_code = generate_code(parse_code(tokenize_code(shader)))
+
+    assert "RWStructuredBuffer<float> a : register(u0);" in generated_code
+    assert "StructuredBuffer<float> b : register(t1);" in generated_code
+    assert (
+        "void CSMain(uint3 groupThreadID : SV_GroupThreadID, "
+        "uint3 groupID : SV_GroupID)"
+    ) in generated_code
+    assert "a[global_idx] += b[global_idx];" in generated_code
+    assert ": group" not in generated_code
+    assert "float a[]" not in generated_code
+    assert "float b[]" not in generated_code
+    assert re.search(r"void CSMain\([^)]*StructuredBuffer", generated_code) is None
+    assert re.search(r"void CSMain\([^)]*float\s+[ab]\[\]", generated_code) is None
+    assert "gl_LocalInvocationID" not in generated_code
+    assert "gl_WorkGroupID" not in generated_code
+    assert "gl_WorkGroupSize" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_directx_group_binding_metadata_is_not_parameter_semantic():
+    shader = """
+    shader GroupBindingMetadata {
+        float passthrough(@group(0) @binding(0) float value) {
+            return value;
+        }
+    }
+    """
+
+    generated_code = generate_code(parse_code(tokenize_code(shader)))
+
+    assert "float passthrough(float value)" in generated_code
+    assert ": group" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
 def test_hlsl_metal_matmul_pointer_params_lower_to_resources(tmp_path):
     shader = """
     #include <metal_stdlib>

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -37826,6 +37826,65 @@ def test_translate_project_hip_pointer_parameters_lower_to_directx_resources(
     assert_directx_compute_validates_if_available(output, tmp_path)
 
 
+def test_translate_project_hip_bridge_cgl_storage_arrays_lower_to_directx_resources(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.cgl").write_text(
+        textwrap.dedent("""
+            // HIP to CrossGL conversion
+            // Kernel: AddKernel
+            @compute
+            @stage_entry
+            @workgroup_size(1, 1, 1)
+            fn AddKernel(
+                @group(0) @binding(0) var<storage, read_write> a: array<f32>,
+                @group(0) @binding(1) var<storage, read> b: array<f32>
+            ) {
+                var global_idx: i32 = (
+                    gl_LocalInvocationID.x + (gl_WorkGroupID.x * gl_WorkGroupSize.x)
+                );
+                a[global_idx] += b[global_idx];
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["directx"],
+        output_dir="out",
+        validate=True,
+    ).to_json()
+
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("directx", "translated")}
+    assert payload["diagnosticCounts"]["error"] == 0
+
+    artifact = payload["artifacts"][0]
+    output = (repo / artifact["path"]).read_text(encoding="utf-8")
+
+    assert "RWStructuredBuffer<float> a : register(u0);" in output
+    assert "StructuredBuffer<float> b : register(t1);" in output
+    assert (
+        "void CSMain(uint3 groupThreadID : SV_GroupThreadID, "
+        "uint3 groupID : SV_GroupID)"
+    ) in output
+    assert "a[global_idx] += b[global_idx];" in output
+    assert ": group" not in output
+    assert "float a[]" not in output
+    assert "float b[]" not in output
+    assert re.search(r"void CSMain\([^)]*StructuredBuffer", output) is None
+    assert re.search(r"void CSMain\([^)]*float\s+[ab]\[\]", output) is None
+    assert "gl_LocalInvocationID" not in output
+    assert "gl_WorkGroupID" not in output
+    assert "gl_WorkGroupSize" not in output
+
+    assert_directx_compute_validates_if_available(output, tmp_path)
+
+
 def test_translate_project_opencl_directx_allocates_generated_parameter_bindings(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Promote storage-qualified unsized array entry parameters to DirectX structured-buffer resources.
- Filter group metadata so it cannot leak as an HLSL parameter semantic.
- Add direct and project regressions for the HIP bridge intermediate shape.

## Validation
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_stage_entry_storage_arrays_promote_to_resources tests/test_translator/test_codegen/test_directx_codegen.py::test_directx_group_binding_metadata_is_not_parameter_semantic tests/test_backend/test_HIP/test_codegen.py::TestHipCodeGen::test_hip_pointer_kernel_lowers_to_directx_resources tests/test_translator/test_project_translation.py::test_translate_project_hip_pointer_parameters_lower_to_directx_resources tests/test_translator/test_project_translation.py::test_translate_project_hip_bridge_cgl_storage_arrays_lower_to_directx_resources -q
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py
- python3.11 tools/support_matrix.py check
- git diff --check
- pre-commit run --files crosstl/translator/codegen/directx_codegen.py tests/test_translator/test_codegen/test_directx_codegen.py tests/test_translator/test_project_translation.py docs/source/support-matrix.rst support/generated/support-matrix.json

closes #1220