### PR TITLE
Lower OpenCL fma calls for DirectX

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -580,6 +580,8 @@ class HLSLCodeGen:
         # GLSL findLSB/findMSB lower to HLSL first-bit intrinsics.
         "firstbithigh",
         "firstbitlow",
+        # OpenCL/GLSL fma lowers to HLSL mad.
+        "mad",
     }
     HLSL_BITCAST_FUNCTION_TARGETS = {
         "floatBitsToInt": "int",
@@ -947,6 +949,7 @@ class HLSLCodeGen:
             "floatBitsToUint": "asuint",
             "findLSB": "firstbitlow",
             "findMSB": "firstbithigh",
+            "fma": "mad",
             "inverseSqrt": "rsqrt",
             "inversesqrt": "rsqrt",
             "intBitsToFloat": "asfloat",

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1107", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1111", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1188", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1107
+        "test_count": 1111
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_backend/test_OpenCL/test_codegen.py
+++ b/tests/test_backend/test_OpenCL/test_codegen.py
@@ -1,6 +1,8 @@
 import pytest
 
 import crosstl
+from crosstl.backend.DirectX.DirectxLexer import HLSLLexer
+from crosstl.backend.DirectX.DirectxParser import HLSLParser
 from crosstl.backend.OpenCL.OpenCLCrossGLCodeGen import OpenCLToCrossGLConverter
 from crosstl.backend.OpenCL.OpenCLLexer import OpenCLLexer
 from crosstl.backend.OpenCL.OpenCLParser import OpenCLParser
@@ -56,6 +58,23 @@ def test_opencl_saxpy_signed_global_id_lowers_to_wgsl_casted_local(tmp_path):
     assert "var gid: i32 = gl_GlobalInvocationID.x;" in crossgl
     assert "var gid: i32 = i32(global_invocation_id.x);" in wgsl
     assert "out[gid] = (_saxpy_Args.a * x[gid]);" in wgsl
+
+
+def test_opencl_saxpy_fma_lowers_to_directx_mad(tmp_path):
+    source = """
+        kernel void saxpy(global float *y, global const float *x, const float a) {
+            const uint gid = get_global_id(0);
+            y[gid] = fma(a, x[gid], y[gid]);
+        }
+        """
+    opencl_path = tmp_path / "saxpy.cl"
+    opencl_path.write_text(source, encoding="utf-8")
+
+    hlsl = crosstl.translate(str(opencl_path), backend="directx", format_output=False)
+
+    assert "y[gid] = mad(a, x[gid], y[gid]);" in hlsl
+    assert "fma(" not in hlsl
+    HLSLParser(HLSLLexer(hlsl).tokenize()).parse()
 
 
 def test_hashcat_kernel_specifier_macros_codegen_reparse():

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -7168,6 +7168,100 @@ def test_hlsl_user_defined_mod_is_not_lowered():
     assert "floor(" not in generated_code
 
 
+def test_hlsl_fma_lowers_to_mad_intrinsic():
+    shader = """
+    shader HlslFmaBuiltinLowering {
+        compute {
+            void main(uint3 tid @ gl_GlobalInvocationID) {
+                float value = float(tid.x);
+                float scale = 2.0;
+                float bias = 1.0;
+                float fused = fma(value, scale, bias);
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "float fused = mad(value, scale, bias);" in generated_code
+    assert "fma(" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_hlsl_fma_lowers_to_mad_with_shadowing_local_renamed():
+    shader = """
+    shader HlslFmaMadShadowing {
+        compute {
+            void main(uint3 tid @ gl_GlobalInvocationID) {
+                float value = float(tid.x);
+                float scale = 2.0;
+                float bias = 1.0;
+                float mad = bias;
+                float fused = fma(value, scale, mad);
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "float mad_ = bias;" in generated_code
+    assert "float fused = mad(value, scale, mad_);" in generated_code
+    assert "float mad = bias;" not in generated_code
+    assert "fma(" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_hlsl_user_defined_fma_function_is_preserved():
+    shader = """
+    shader HlslUserFma {
+        float fma(float value, float scale, float bias) {
+            return (value * scale) + bias;
+        }
+
+        compute {
+            void main(uint3 tid @ gl_GlobalInvocationID) {
+                float value = float(tid.x);
+                float fused = fma(value, 2.0, 1.0);
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "float fma(float value, float scale, float bias)" in generated_code
+    assert "float fused = fma(value, 2.0, 1.0);" in generated_code
+    assert "mad(" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
+def test_hlsl_user_defined_mad_function_is_renamed_consistently():
+    shader = """
+    shader HlslUserMad {
+        float mad(float value, float scale, float bias) {
+            return (value * scale) + bias;
+        }
+
+        compute {
+            void main(uint3 tid @ gl_GlobalInvocationID) {
+                float value = float(tid.x);
+                float fused = mad(value, 2.0, 1.0);
+            }
+        }
+    }
+    """
+
+    generated_code = HLSLCodeGen().generate(crosstl.translator.parse(shader))
+
+    assert "float mad_(float value, float scale, float bias)" in generated_code
+    assert "float fused = mad_(value, 2.0, 1.0);" in generated_code
+    assert "float mad(float value, float scale, float bias)" not in generated_code
+    assert "float fused = mad(value, 2.0, 1.0);" not in generated_code
+    HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
+
+
 def test_hlsl_two_argument_atan_lowers_to_atan2_intrinsic():
     shader = """
     shader HlslAtanBuiltinLowering {

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -14,6 +14,8 @@ import pytest
 import crosstl._crosstl as crosstl_cli
 import crosstl.project as project_api
 import crosstl.project.pipeline as project_pipeline
+from crosstl.backend.DirectX.DirectxLexer import HLSLLexer
+from crosstl.backend.DirectX.DirectxParser import HLSLParser
 from crosstl.backend.GLSL.OpenglLexer import GLSLLexer
 from crosstl.backend.GLSL.OpenglParser import GLSLParser
 from crosstl.backend.Metal.MetalLexer import MetalLexer
@@ -41518,6 +41520,41 @@ def test_translate_project_opencl_to_opengl_casts_signed_global_id_local(
     assert "int gid = int(gl_GlobalInvocationID.x);" in output
     assert "uint gid = gl_GlobalInvocationID.x;" not in output
     GLSLParser(GLSLLexer(output).tokenize(), "compute").parse()
+
+
+def test_translate_project_opencl_saxpy_fma_to_directx_lowers_to_mad(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "saxpy.cl").write_text(
+        textwrap.dedent("""
+            kernel void saxpy(global float *dst,
+                              global const float *x,
+                              const float a) {
+                const uint gid = get_global_id(0);
+                dst[gid] = fma(a, x[gid], dst[gid]);
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["directx"],
+        output_dir="out",
+    ).to_json()
+
+    assert payload["diagnosticCounts"]["error"] == 0
+    assert {
+        (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
+    } == {("directx", "translated")}
+
+    output = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
+
+    assert "dst[gid] = mad(a, x[gid], dst[gid]);" in output
+    assert "fma(" not in output
+    HLSLParser(HLSLLexer(output).tokenize()).parse()
 
 
 def test_translate_project_opencl_saxpy_to_mojo_lowers_compute_builtin_inputs(


### PR DESCRIPTION
## Summary
- Lower CrossGL/OpenCL `fma` calls to the HLSL `mad` intrinsic for DXC-compatible float code.
- Reserve `mad` so lowered calls cannot be captured by local symbols while preserving user-defined `fma`/`mad` helpers.
- Add direct, OpenCL, and project translation regressions for the SAXPY `fma` case.

## Validation
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_fma_lowers_to_mad_intrinsic tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_fma_lowers_to_mad_with_shadowing_local_renamed tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_user_defined_fma_function_is_preserved tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_user_defined_mad_function_is_renamed_consistently tests/test_translator/test_project_translation.py::test_translate_project_opencl_saxpy_fma_to_directx_lowers_to_mad -q
- python3.11 -m pytest tests/test_translator/test_codegen/test_directx_codegen.py
- python3.11 -m pytest tests/test_backend/test_OpenCL/test_codegen.py
- python3.11 tools/support_matrix.py check
- git diff --check
- pre-commit run --files crosstl/translator/codegen/directx_codegen.py tests/test_backend/test_OpenCL/test_codegen.py tests/test_translator/test_codegen/test_directx_codegen.py tests/test_translator/test_project_translation.py docs/source/support-matrix.rst support/generated/support-matrix.json

closes #1227