### PR TITLE
Use VRS-capable DirectX smoke profiles

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -2277,6 +2277,11 @@ DIRECTX_DXC_ENTRY_PROFILES = (
     ("MSMain", "ms_6_5"),
 )
 DIRECTX_DXC_DEFAULT_ENTRY_PROFILE = ("VSMain", "vs_6_0")
+DIRECTX_DXC_VRS_MIN_PROFILE_BY_STAGE = {
+    "vs": "vs_6_4",
+    "ps": "ps_6_4",
+    "gs": "gs_6_4",
+}
 TOOLCHAIN_SMOKE_TIMEOUT_SECONDS = 30
 TOOLCHAIN_TIMEOUT_RETURNCODE = 124
 RUNTIME_ADAPTER_CATALOG = {
@@ -11611,9 +11616,7 @@ def _metal_template_type_declarations(
             continue
 
         parameters = tuple(
-            preprocessor._template_parameter_names(
-                source[angle_start + 1 : angle_end]
-            )
+            preprocessor._template_parameter_names(source[angle_start + 1 : angle_end])
         )
         declaration_start = angle_end + 1
         header = source[declaration_start : declaration_start + 512]
@@ -31825,11 +31828,39 @@ def _directx_dxc_entry_profiles(
     for entry, profile in DIRECTX_DXC_ENTRY_PROFILES:
         match = re.search(rf"\b{re.escape(entry)}\s*\(", source)
         if match:
-            matches.append((match.start(), entry, profile))
+            matches.append(
+                (
+                    match.start(),
+                    entry,
+                    _directx_dxc_profile_for_source(profile, source),
+                )
+            )
     if not matches:
         return (DIRECTX_DXC_DEFAULT_ENTRY_PROFILE,)
 
     return tuple((entry, profile) for _position, entry, profile in sorted(matches))
+
+
+def _directx_dxc_profile_for_source(profile: str, source: str) -> str:
+    if not re.search(r"\bSV_ShadingRate\b", source, re.IGNORECASE):
+        return profile
+
+    stage = profile.split("_", 1)[0]
+    min_profile = DIRECTX_DXC_VRS_MIN_PROFILE_BY_STAGE.get(stage)
+    if min_profile is None:
+        return profile
+    if _directx_dxc_profile_version(profile) >= _directx_dxc_profile_version(
+        min_profile
+    ):
+        return profile
+    return min_profile
+
+
+def _directx_dxc_profile_version(profile: str) -> tuple[int, int]:
+    match = re.match(r"^[a-z]+_(\d+)_(\d+)$", profile)
+    if match is None:
+        return (0, 0)
+    return int(match.group(1)), int(match.group(2))
 
 
 GLSLANG_STAGE_BY_SUFFIX = {

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -17716,6 +17716,39 @@ def test_directx_toolchain_smoke_commands_compile_all_detected_entries(tmp_path)
     ]
 
 
+def test_directx_toolchain_smoke_command_uses_vrs_capable_profile(tmp_path):
+    shader = tmp_path / "vrs_fragment.hlsl"
+    shader.write_text(
+        textwrap.dedent("""
+            struct FragmentInput {
+                float4 position : SV_Position;
+            };
+
+            float4 PSMain(
+                FragmentInput input,
+                uint shadingRate : SV_ShadingRate
+            ) : SV_Target0 {
+                return float4(shadingRate.xxx / 4.0, 1.0);
+            }
+        """).strip(),
+        encoding="utf-8",
+    )
+
+    assert project_pipeline._toolchain_smoke_command("directx", ["dxc"], shader) == (
+        [
+            "dxc",
+            "-T",
+            "ps_6_4",
+            "-E",
+            "PSMain",
+            str(shader),
+            "-Fo",
+            project_pipeline.os.devnull,
+        ],
+        "artifact",
+    )
+
+
 def test_directx_toolchain_smoke_command_compiles_library_targets(tmp_path):
     shader = tmp_path / "ray_library.hlsl"
     shader.write_text(


### PR DESCRIPTION
## Summary
- promote DirectX DXC smoke profiles to shader model 6.4 when HLSL uses SV_ShadingRate
- keep normal DirectX entry profile inference unchanged for non-VRS artifacts
- add a focused project-pipeline regression for VRS pixel shader validation

## Tests
- python3.11 -m pytest tests/test_translator/test_project_translation.py::test_directx_toolchain_smoke_command_compiles_detected_entry tests/test_translator/test_project_translation.py::test_directx_toolchain_smoke_commands_compile_all_detected_entries tests/test_translator/test_project_translation.py::test_directx_toolchain_smoke_command_uses_vrs_capable_profile tests/test_translator/test_project_translation.py::test_directx_toolchain_smoke_command_compiles_library_targets tests/test_translator/test_project_translation.py::test_validate_project_report_rejects_directx_artifact_toolchain_run_argv_mismatch tests/test_translator/test_project_translation.py::test_runtime_loader_manifest_reports_directx_dxc_entry_profile_metadata -q
- python3.11 tools/support_matrix.py check
- pre-commit run --files crosstl/project/pipeline.py tests/test_translator/test_project_translation.py

closes #1235