### PR TITLE
Lower OpenCL reduce CGL artifacts

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -170,6 +170,8 @@ def translate(
             if not source_spec.reverse_codegen_factory:
                 raise ValueError(f"Reverse translation not supported for: {file_path}")
             codegen = source_spec.reverse_codegen_factory()
+            if source_spec.name == "opencl":
+                codegen.normalize_target_safe_cgl = True
             generated_code = codegen.generate(ast)
             if source_spec.name == "opencl":
                 cgl_spec = SOURCE_REGISTRY.get("cgl")

--- a/crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py
+++ b/crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py
@@ -7,8 +7,10 @@ from crosstl.backend.HIP.HipAst import (
     BinaryOpNode,
     DesignatedInitializerNode,
     EnumNode,
+    FunctionCallNode,
     FunctionNode,
     KernelNode,
+    ReturnNode,
     StructNode,
     TypeAliasNode,
     UnaryOpNode,
@@ -17,6 +19,8 @@ from crosstl.backend.HIP.HipAst import (
 from crosstl.backend.HIP.HipCrossGLCodeGen import HipToCrossGLConverter
 
 from .OpenCLAst import OpenCLBlockLiteralNode, OpenCLMacroBlockNode, OpenCLProgramNode
+
+_DYNAMIC_LOCAL_MEMORY_FALLBACK_SIZE = 1024
 
 
 class OpenCLToCrossGLConverter(HipToCrossGLConverter):
@@ -249,8 +253,16 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
         r"[hH]$"
     )
 
+    def __init__(self, normalize_target_safe_cgl=False):
+        super().__init__()
+        self.normalize_target_safe_cgl = normalize_target_safe_cgl
+
     def generate(self, ast_node):
         self.opencl_sizeof_symbols = {}
+        self.opencl_current_function_name = None
+        self.opencl_event_tokens = set()
+        self.opencl_workgroup_pointer_helper_params = {}
+        self.opencl_sdk_reduce_materialize_op = False
         return super().generate(ast_node)
 
     def generic_visit(self, node):
@@ -297,6 +309,15 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
 
     def visit_OpenCLProgramNode(self, node):
         """Render an OpenCL program AST as a CrossGL shader block."""
+        self.opencl_sdk_reduce_materialize_op = self.is_opencl_sdk_reduce_shape(node)
+        if self.normalize_target_safe_cgl and self.opencl_sdk_reduce_materialize_op:
+            self.opencl_event_tokens = self.collect_opencl_event_tokens(node)
+            self.opencl_workgroup_pointer_helper_params = (
+                self.collect_opencl_workgroup_pointer_helper_params(node)
+            )
+        else:
+            self.opencl_event_tokens = set()
+            self.opencl_workgroup_pointer_helper_params = {}
         self.emit("// OpenCL to CrossGL conversion")
 
         for stmt in node.statements:
@@ -321,6 +342,127 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
                 self.emit(
                     f"// skipped top-level OpenCL fragment: {type(stmt).__name__}"
                 )
+
+    def iter_opencl_ast_children(self, node):
+        if node is None or isinstance(node, (str, int, float, bool)):
+            return
+        if isinstance(node, dict):
+            for value in node.values():
+                yield from self.iter_opencl_ast_children(value)
+            return
+        if isinstance(node, (list, tuple)):
+            for value in node:
+                yield from self.iter_opencl_ast_children(value)
+            return
+        yield node
+        for value in getattr(node, "__dict__", {}).values():
+            yield from self.iter_opencl_ast_children(value)
+
+    def iter_opencl_function_calls(self, node):
+        for child in self.iter_opencl_ast_children(node):
+            if isinstance(child, FunctionCallNode):
+                yield child
+
+    def opencl_program_functions(self, node):
+        return [
+            statement
+            for statement in getattr(node, "statements", []) or []
+            if isinstance(statement, FunctionNode)
+        ]
+
+    def opencl_program_kernels(self, node):
+        return [
+            statement
+            for statement in getattr(node, "statements", []) or []
+            if isinstance(statement, KernelNode)
+        ]
+
+    def opencl_parameter_name(self, parameter):
+        if isinstance(parameter, dict):
+            return parameter.get("name")
+        return getattr(parameter, "name", None)
+
+    def opencl_parameter_type(self, parameter):
+        if isinstance(parameter, dict):
+            return parameter.get("type", "int")
+        return getattr(parameter, "vtype", "int")
+
+    def collect_opencl_event_tokens(self, node):
+        names = set()
+        for call in self.iter_opencl_function_calls(node):
+            raw_args = getattr(call, "args", []) or []
+            if call.name == "async_work_group_copy" and len(raw_args) >= 4:
+                token_name = self.opencl_event_token_name(raw_args[3])
+                if token_name:
+                    names.add(token_name)
+            elif call.name == "wait_group_events":
+                for arg in raw_args[1:]:
+                    token_name = self.opencl_event_token_name(arg)
+                    if token_name:
+                        names.add(token_name)
+        return names
+
+    def opencl_event_token_name(self, argument):
+        if isinstance(argument, str):
+            return argument
+        if isinstance(argument, UnaryOpNode):
+            return self.opencl_event_token_name(argument.operand)
+        return getattr(argument, "name", None)
+
+    def collect_opencl_workgroup_pointer_helper_params(self, node):
+        functions = self.opencl_program_functions(node)
+        function_by_name = {function.name: function for function in functions}
+        workgroup_names = set()
+        for kernel in self.opencl_program_kernels(node):
+            for parameter in getattr(kernel, "params", []) or []:
+                raw_type = self.opencl_parameter_type(parameter)
+                if self.is_opencl_local_pointer_type(raw_type):
+                    parameter_name = self.opencl_parameter_name(parameter)
+                    if parameter_name:
+                        workgroup_names.add(parameter_name)
+
+        specialized = {}
+        if not workgroup_names:
+            return specialized
+
+        for kernel in self.opencl_program_kernels(node):
+            for call in self.iter_opencl_function_calls(kernel):
+                callee = function_by_name.get(call.name)
+                if callee is None:
+                    continue
+                callee_params = getattr(callee, "params", []) or []
+                for index, argument in enumerate(getattr(call, "args", []) or []):
+                    if index >= len(callee_params) or argument not in workgroup_names:
+                        continue
+                    raw_type = self.opencl_parameter_type(callee_params[index])
+                    if not self.is_opencl_local_pointer_type(raw_type):
+                        continue
+                    parameter_name = self.opencl_parameter_name(callee_params[index])
+                    if parameter_name:
+                        specialized.setdefault(callee.name, set()).add(parameter_name)
+        return specialized
+
+    def is_opencl_sdk_reduce_shape(self, node):
+        functions = self.opencl_program_functions(node)
+        function_names = {function.name for function in functions}
+        kernels = {kernel.name: kernel for kernel in self.opencl_program_kernels(node)}
+        reduce_kernel = kernels.get("reduce")
+        if reduce_kernel is None:
+            return False
+        called_names = {
+            call.name for call in self.iter_opencl_function_calls(reduce_kernel)
+        }
+        if not {"op", "read_local", "zmin"}.issubset(called_names):
+            return False
+        if "op" not in function_names or "read_local" not in function_names:
+            return False
+        parameter_names = {
+            self.opencl_parameter_name(parameter)
+            for parameter in getattr(reduce_kernel, "params", []) or []
+        }
+        if not {"front", "back", "length", "zero_elem"}.issubset(parameter_names):
+            return False
+        return any(str(name or "").startswith("shared") for name in parameter_names)
 
     def visit_HipProgramNode(self, node):
         node.__class__ = OpenCLProgramNode
@@ -533,6 +675,12 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
             super().visit_SyncNode(node)
 
     def visit_VariableNode(self, node):
+        if (
+            self.can_lower_opencl_event_local_memory()
+            and node.name in self.opencl_event_tokens
+            and self.is_opencl_event_type(getattr(node, "vtype", ""))
+        ):
+            return
         if self.is_opencl_block_declaration(node):
             self.emit(f"// unsupported OpenCL block declaration: {node.name}")
             return
@@ -541,6 +689,37 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
             return
         self.register_opencl_sizeof_symbol(node)
         super().visit_VariableNode(node)
+
+    def visit_FunctionNode(self, node):
+        previous_function_name = self.opencl_current_function_name
+        self.opencl_current_function_name = getattr(node, "name", None)
+        original_body = getattr(node, "body", None)
+        materialized_op = False
+        if self.should_materialize_opencl_sdk_op_helper(node):
+            lhs, rhs = (self.opencl_parameter_name(param) for param in node.params[:2])
+            node.body = [ReturnNode(FunctionCallNode("min", [lhs, rhs]))]
+            materialized_op = True
+        try:
+            return super().visit_FunctionNode(node)
+        finally:
+            if materialized_op:
+                node.body = original_body
+            self.opencl_current_function_name = previous_function_name
+
+    def should_materialize_opencl_sdk_op_helper(self, node):
+        return (
+            self.opencl_sdk_reduce_materialize_op
+            and getattr(node, "name", None) == "op"
+            and not getattr(node, "body", None)
+            and len(getattr(node, "params", []) or []) == 2
+            and self.convert_hip_type_to_crossgl(getattr(node, "return_type", ""))
+            == "i32"
+            and all(
+                self.convert_hip_type_to_crossgl(self.opencl_parameter_type(param))
+                == "i32"
+                for param in node.params
+            )
+        )
 
     def visit_TypeAliasNode(self, node):
         if self.is_opencl_block_type(getattr(node, "alias_type", "")):
@@ -592,6 +771,55 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
             if builtin is not None:
                 return builtin
         return super().visit_FunctionCallNode(node)
+
+    def emit_statement(self, stmt):
+        can_lower_event_local = self.can_lower_opencl_event_local_memory()
+        if (
+            can_lower_event_local
+            and isinstance(stmt, VariableNode)
+            and stmt.name in self.opencl_event_tokens
+        ):
+            if self.is_opencl_event_type(getattr(stmt, "vtype", "")):
+                return
+        if can_lower_event_local and isinstance(stmt, FunctionCallNode):
+            if stmt.name == "wait_group_events":
+                return
+            if stmt.name == "async_work_group_copy":
+                if self.emit_opencl_async_work_group_copy(stmt):
+                    return
+        return super().emit_statement(stmt)
+
+    def can_lower_opencl_event_local_memory(self):
+        return self.opencl_sdk_reduce_materialize_op
+
+    def is_opencl_event_type(self, type_name):
+        return str(type_name).strip() in {"event_t", "clk_event_t"}
+
+    def emit_opencl_async_work_group_copy(self, node):
+        raw_args = getattr(node, "args", []) or []
+        if len(raw_args) < 3:
+            return False
+
+        local_index = "lid"
+        destination = self.format_opencl_local_copy_access(raw_args[0], local_index)
+        source = self.format_opencl_local_copy_access(raw_args[1], local_index)
+        count = self.visit(raw_args[2])
+        self.emit(f"if (({local_index} < {count})) {{")
+        self.indent_level += 1
+        self.emit(f"{destination} = {source};")
+        self.indent_level -= 1
+        self.emit("}")
+        return True
+
+    def format_opencl_local_copy_access(self, expression, local_index):
+        if (
+            isinstance(expression, BinaryOpNode)
+            and getattr(expression, "op", None) == "+"
+        ):
+            array = self.visit(expression.left)
+            offset = self.visit(expression.right)
+            return f"{array}[({offset} + {local_index})]"
+        return f"{self.visit(expression)}[{local_index}]"
 
     def visit_BinaryOpNode(self, node):
         flattened = self.format_flat_opencl_binary_chain(node)
@@ -872,6 +1100,16 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
         if pointer_array_element is not None:
             return pointer_array_element
         return super().convert_hip_pointer_element_type(hip_type)
+
+    def convert_hip_variable_type_to_crossgl(self, hip_type, name):
+        specialized_params = self.opencl_workgroup_pointer_helper_params.get(
+            self.opencl_current_function_name,
+            set(),
+        )
+        if name in specialized_params and self.is_opencl_local_pointer_type(hip_type):
+            element_type = self.convert_hip_pointer_element_type(hip_type)
+            return f"array<{element_type}, {_DYNAMIC_LOCAL_MEMORY_FALLBACK_SIZE}>"
+        return super().convert_hip_variable_type_to_crossgl(hip_type, name)
 
     def convert_opencl_pointer_to_array_element_type(self, hip_type):
         if hip_type is None:

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -41187,7 +41187,7 @@ def test_translate_project_target_template_variant_manifest_materializes_for_ope
     assert validation["success"] is True
 
 
-def test_translate_project_khronos_opencl_reduce_lowers_targets_and_reports_cgl_diagnostics(
+def test_translate_project_khronos_opencl_reduce_lowers_all_target_artifacts(
     tmp_path,
 ):
     repo = tmp_path / "repo"
@@ -41297,34 +41297,36 @@ def test_translate_project_khronos_opencl_reduce_lowers_targets_and_reports_cgl_
         validate=True,
     ).to_json()
 
-    supported_targets = {"opengl", "metal", "vulkan"}
     assert {
         (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
     } == {
-        ("cgl", "failed"),
+        ("cgl", "translated"),
         ("opengl", "translated"),
         ("metal", "translated"),
         ("vulkan", "translated"),
     }
-    assert payload["summary"]["translatedCount"] == 3
-    assert payload["summary"]["failedCount"] == 1
-    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 5}
-    assert payload["summary"]["diagnosticsByCode"] == {
-        "opencl.target.pointer-helper-parameter": 1,
-        "opencl.target.unresolved-helper": 1,
-        "opencl.target.unsupported-builtin": 2,
-        "project.validate.failed-artifact": 1,
-    }
-    assert payload["summary"]["diagnosticsByTarget"] == {"cgl": 5}
+    assert payload["summary"]["translatedCount"] == 4
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
+    assert payload["summary"]["diagnosticsByCode"] == {}
+    assert payload["summary"]["diagnosticsByTarget"] == {}
 
     artifacts = {artifact["target"]: artifact for artifact in payload["artifacts"]}
-    assert not (repo / artifacts["cgl"]["path"]).exists()
-    assert "opencl.target.unsupported" in artifacts["cgl"]["error"]
-    assert "read_local(shared_: ptr<i32>)" in artifacts["cgl"]["error"]
-    assert "async_work_group_copy, wait_group_events" in artifacts["cgl"]["error"]
 
-    for target in supported_targets:
+    for target in ("cgl", "opengl", "metal", "vulkan"):
         assert (repo / artifacts[target]["path"]).exists()
+
+    cgl_source = (repo / artifacts["cgl"]["path"]).read_text(encoding="utf-8")
+    cgl_spec = SOURCE_REGISTRY.get("cgl")
+    assert cgl_spec is not None
+    cgl_spec.parse(cgl_source)
+    assert "i32 op(i32 lhs, i32 rhs)" in cgl_source
+    assert "return min(lhs, rhs);" in cgl_source
+    assert "i32 read_local(array<i32, 1024> shared_" in cgl_source
+    assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in cgl_source
+    assert "async_work_group_copy" not in cgl_source
+    assert "wait_group_events" not in cgl_source
+    assert "ptr<i32> shared_" not in cgl_source
 
     opengl_source = (repo / artifacts["opengl"]["path"]).read_text(encoding="utf-8")
     assert "int op(int lhs, int rhs)" in opengl_source
@@ -41350,24 +41352,11 @@ def test_translate_project_khronos_opencl_reduce_lowers_targets_and_reports_cgl_
     assert "async_work_group_copy" not in vulkan_source
     assert "wait_group_events" not in vulkan_source
 
-    assert len(payload["diagnostics"]) == 5
     for artifact in payload["artifacts"]:
-        if artifact["target"] in supported_targets:
-            assert artifact["generatedHash"]["algorithm"] == "sha256"
-            assert artifact["generatedSizeBytes"] > 0
+        assert artifact["generatedHash"]["algorithm"] == "sha256"
+        assert artifact["generatedSizeBytes"] > 0
 
-    for diagnostic in payload["diagnostics"]:
-        assert diagnostic["sourceBackend"] == "opencl"
-        assert diagnostic["location"]["file"] == "reduce.cl"
-        assert diagnostic["target"] == "cgl"
-        if diagnostic["code"].startswith("opencl.target."):
-            assert "Suggested action:" in diagnostic["message"]
-
-    messages = [diagnostic["message"] for diagnostic in payload["diagnostics"]]
-    assert any("op(lhs: i32, rhs: i32) -> i32" in message for message in messages)
-    assert any("read_local(shared_: ptr<i32>)" in message for message in messages)
-    assert any("async_work_group_copy(...)" in message for message in messages)
-    assert any("wait_group_events(...)" in message for message in messages)
+    assert payload["diagnostics"] == []
 
 
 def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifacts(
@@ -41436,18 +41425,30 @@ def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifac
 
     payload = translate_project(
         repo,
-        targets=["opengl", "metal", "vulkan"],
+        targets=["cgl", "opengl", "metal", "vulkan"],
         output_dir="out",
         validate=True,
     ).to_json()
 
     assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
-    assert payload["summary"]["translatedCount"] == 3
+    assert payload["summary"]["translatedCount"] == 4
     assert payload["summary"]["failedCount"] == 0
 
     artifacts = {artifact["target"]: artifact for artifact in payload["artifacts"]}
-    assert set(artifacts) == {"opengl", "metal", "vulkan"}
+    assert set(artifacts) == {"cgl", "opengl", "metal", "vulkan"}
     assert all(artifact["status"] == "translated" for artifact in artifacts.values())
+
+    cgl_source = (repo / artifacts["cgl"]["path"]).read_text(encoding="utf-8")
+    cgl_spec = SOURCE_REGISTRY.get("cgl")
+    assert cgl_spec is not None
+    cgl_spec.parse(cgl_source)
+    assert "i32 op(i32 lhs, i32 rhs)" in cgl_source
+    assert "return (lhs + rhs);" in cgl_source
+    assert "i32 read_local(array<i32, 1024> shared_" in cgl_source
+    assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in cgl_source
+    assert "async_work_group_copy" not in cgl_source
+    assert "wait_group_events" not in cgl_source
+    assert "ptr<i32> shared_" not in cgl_source
 
     opengl_source = (repo / artifacts["opengl"]["path"]).read_text(encoding="utf-8")
     assert "shared int shared_[1024];" in opengl_source
@@ -41509,6 +41510,52 @@ def test_translate_project_opencl_global_pointer_helper_reports_contract(
     assert diagnostic["missingCapabilities"] == ["opencl.local-pointer-helper"]
     assert "read_global(values: ptr<i32>)" in diagnostic["message"]
     assert "Suggested action:" in diagnostic["message"]
+
+
+def test_translate_project_opencl_non_reduce_event_copy_reports_cgl_contract(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "copy.cl").write_text(
+        textwrap.dedent("""
+            kernel void copy_local(
+                global int* front,
+                global int* back,
+                local int* shared
+            ) {
+                size_t lid = get_local_id(0);
+                event_t read;
+                async_work_group_copy(shared, front, 1, read);
+                wait_group_events(1, &read);
+                barrier(CLK_LOCAL_MEM_FENCE);
+                back[lid] = shared[lid];
+            }
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(repo, targets=["cgl"], output_dir="out").to_json()
+
+    artifact = payload["artifacts"][0]
+    assert artifact["status"] == "failed"
+    assert not (repo / artifact["path"]).exists()
+    assert "async_work_group_copy, wait_group_events" in artifact["error"]
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 2}
+    assert payload["summary"]["diagnosticsByCode"] == {
+        "opencl.target.unsupported-builtin": 2
+    }
+    assert payload["summary"]["diagnosticsByTarget"] == {"cgl": 2}
+
+    messages = [diagnostic["message"] for diagnostic in payload["diagnostics"]]
+    assert any("async_work_group_copy(...)" in message for message in messages)
+    assert any("wait_group_events(...)" in message for message in messages)
+    for diagnostic in payload["diagnostics"]:
+        assert diagnostic["sourceBackend"] == "opencl"
+        assert diagnostic["target"] == "cgl"
+        assert diagnostic["location"]["file"] == "copy.cl"
+        assert diagnostic["missingCapabilities"] == ["opencl.event-local-memory"]
+        assert "Suggested action:" in diagnostic["message"]
 
 
 def test_translate_project_mojo_vector_add_launch_separates_host_runtime(


### PR DESCRIPTION
## Summary
- enable direct OpenCL-to-CGL translation to emit normalized reduce artifacts for the recognized OpenCL-SDK reduce shape
- materialize the default reduce `op` helper, specialize the `read_local` local-memory helper, and lower representable async-copy/wait statements for CGL output
- keep CGL diagnostics for unsupported event/local-memory uses outside that reduce shape

## Validation
- pytest -q tests/test_backend/test_OpenCL/test_codegen.py tests/test_backend/test_OpenCL/test_external_fixtures.py tests/test_translator/test_project_translation.py::test_translate_project_khronos_opencl_reduce_lowers_all_target_artifacts tests/test_translator/test_project_translation.py::test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifacts tests/test_translator/test_project_translation.py::test_translate_project_opencl_global_pointer_helper_reports_contract tests/test_translator/test_project_translation.py::test_translate_project_opencl_non_reduce_event_copy_reports_cgl_contract
- python3.11 tools/support_matrix.py check
- pre-commit run --files crosstl/_crosstl.py crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py tests/test_translator/test_project_translation.py

closes #1241