### PR TITLE
Make OpenCL reduce project output deterministic

### DIFF
--- a/crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py
+++ b/crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py
@@ -310,13 +310,15 @@ class OpenCLToCrossGLConverter(HipToCrossGLConverter):
     def visit_OpenCLProgramNode(self, node):
         """Render an OpenCL program AST as a CrossGL shader block."""
         self.opencl_sdk_reduce_materialize_op = self.is_opencl_sdk_reduce_shape(node)
-        if self.normalize_target_safe_cgl and self.opencl_sdk_reduce_materialize_op:
+        if self.opencl_sdk_reduce_materialize_op:
             self.opencl_event_tokens = self.collect_opencl_event_tokens(node)
+        else:
+            self.opencl_event_tokens = set()
+        if self.normalize_target_safe_cgl and self.opencl_sdk_reduce_materialize_op:
             self.opencl_workgroup_pointer_helper_params = (
                 self.collect_opencl_workgroup_pointer_helper_params(node)
             )
         else:
-            self.opencl_event_tokens = set()
             self.opencl_workgroup_pointer_helper_params = {}
         self.emit("// OpenCL to CrossGL conversion")
 

--- a/tests/test_backend/test_OpenCL/test_codegen.py
+++ b/tests/test_backend/test_OpenCL/test_codegen.py
@@ -1,6 +1,7 @@
 import pytest
 
 import crosstl
+from crosstl.backend.common_ast import UnaryOpNode
 from crosstl.backend.DirectX.DirectxLexer import HLSLLexer
 from crosstl.backend.DirectX.DirectxParser import HLSLParser
 from crosstl.backend.OpenCL.OpenCLCrossGLCodeGen import OpenCLToCrossGLConverter
@@ -25,6 +26,22 @@ def parse_crossgl_from_opencl(source):
 def generate_crossgl(source):
     _cgl_ast, crossgl = parse_crossgl_from_opencl(source)
     return crossgl
+
+
+def test_opencl_event_token_extraction_handles_identifier_spellings():
+    converter = OpenCLToCrossGLConverter()
+    assert converter.opencl_event_token_name("read") == "read"
+    assert converter.opencl_event_token_name(UnaryOpNode("&", "read")) == "read"
+
+    ast = OpenCLParser(OpenCLLexer("""
+            kernel void reduce(global int *front, local int *shared) {
+                event_t read;
+                async_work_group_copy(shared, front, 1, read);
+                wait_group_events(1, &read);
+            }
+            """).tokenize()).parse()
+
+    assert converter.collect_opencl_event_tokens(ast) == {"read"}
 
 
 def test_opencl_kernel_codegen_reparses_and_lowers_builtin_ids():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -39325,7 +39325,9 @@ def test_translate_project_metal_templated_functor_header_reports_before_transla
         "project.translate.template-materialization-unsupported": 1
     }
     diagnostic = payload["diagnostics"][0]
-    assert diagnostic["code"] == "project.translate.template-materialization-unsupported"
+    assert (
+        diagnostic["code"] == "project.translate.template-materialization-unsupported"
+    )
     assert diagnostic["target"] == "opengl"
     assert diagnostic["sourceBackend"] == "metal"
     assert diagnostic["location"]["file"] == "binary_two.metal"
@@ -39569,8 +39571,7 @@ def test_translate_project_metal_implicit_type_environment_cache_bounds_repeated
         encoding="utf-8",
     )
     repeated_declarations = "\n".join(
-        f"    float v{index} = v{index - 1};"
-        for index in range(1, 40)
+        f"    float v{index} = v{index - 1};" for index in range(1, 40)
     )
     (repo / "cached_implicit.metal").write_text(
         textwrap.dedent(f"""
@@ -39652,10 +39653,7 @@ def test_translate_project_metal_implicit_type_environment_budget_diagnostic(
     artifact = payload["artifacts"][0]
     assert artifact["status"] == "failed"
     assert "template materialization work budget exceeded" in artifact["error"].lower()
-    assert (
-        "implicit-template-materialization/type-environment"
-        in artifact["error"]
-    )
+    assert "implicit-template-materialization/type-environment" in artifact["error"]
     assert (
         "limit 3 from "
         "project.source_options.metal.max_template_materialization_work"
@@ -39673,10 +39671,7 @@ def test_translate_project_metal_implicit_type_environment_budget_diagnostic(
     assert diagnostic["location"]["file"] == "budgeted_implicit.metal"
     assert diagnostic["location"]["line"] == 10
     assert diagnostic["missingCapabilities"] == ["template.specialization"]
-    assert (
-        "implicit-template-materialization/type-environment"
-        in diagnostic["message"]
-    )
+    assert "implicit-template-materialization/type-environment" in diagnostic["message"]
     assert "templates=1" in diagnostic["message"]
 
 
@@ -41548,6 +41543,7 @@ def test_translate_project_khronos_opencl_reduce_lowers_all_target_artifacts(
     assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in cgl_source
     assert "async_work_group_copy" not in cgl_source
     assert "wait_group_events" not in cgl_source
+    assert "var read:" not in cgl_source
     assert "ptr<i32> shared_" not in cgl_source
 
     opengl_source = (repo / artifacts["opengl"]["path"]).read_text(encoding="utf-8")
@@ -41560,6 +41556,7 @@ def test_translate_project_khronos_opencl_reduce_lowers_all_target_artifacts(
     )
     assert "async_work_group_copy" not in opengl_source
     assert "wait_group_events" not in opengl_source
+    assert "uint read;" not in opengl_source
     assert "ptr<i32>" not in opengl_source
 
     metal_source = (repo / artifacts["metal"]["path"]).read_text(encoding="utf-8")
@@ -41569,10 +41566,12 @@ def test_translate_project_khronos_opencl_reduce_lowers_all_target_artifacts(
     assert "int read_local(threadgroup int shared_[1024]" in metal_source
     assert "async_work_group_copy" not in metal_source
     assert "wait_group_events" not in metal_source
+    assert "u64 read;" not in metal_source
 
     vulkan_source = (repo / artifacts["vulkan"]["path"]).read_text(encoding="utf-8")
     assert "async_work_group_copy" not in vulkan_source
     assert "wait_group_events" not in vulkan_source
+    assert '"read"' not in vulkan_source
 
     for artifact in payload["artifacts"]:
         assert artifact["generatedHash"]["algorithm"] == "sha256"
@@ -41670,6 +41669,7 @@ def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifac
     assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in cgl_source
     assert "async_work_group_copy" not in cgl_source
     assert "wait_group_events" not in cgl_source
+    assert "var read:" not in cgl_source
     assert "ptr<i32> shared_" not in cgl_source
 
     opengl_source = (repo / artifacts["opengl"]["path"]).read_text(encoding="utf-8")
@@ -41681,6 +41681,7 @@ def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifac
     assert "shared_[lid] = front[((wid * wg_stride) + lid)];" in opengl_source
     assert "async_work_group_copy" not in opengl_source
     assert "wait_group_events" not in opengl_source
+    assert "uint read;" not in opengl_source
     assert "ptr<i32>" not in opengl_source
 
     metal_source = (repo / artifacts["metal"]["path"]).read_text(encoding="utf-8")
@@ -41689,10 +41690,12 @@ def test_translate_project_khronos_opencl_reduce_lowers_supported_target_artifac
     assert "uint64_t length;" in metal_source
     assert "async_work_group_copy" not in metal_source
     assert "wait_group_events" not in metal_source
+    assert "u64 read;" not in metal_source
 
     vulkan_source = (repo / artifacts["vulkan"]["path"]).read_text(encoding="utf-8")
     assert "async_work_group_copy" not in vulkan_source
     assert "wait_group_events" not in vulkan_source
+    assert '"read"' not in vulkan_source
 
 
 def test_translate_project_opencl_reduce_get_num_groups_directx_uses_cbuffer_input(


### PR DESCRIPTION
## Summary
- collect OpenCL SDK reduce event tokens whenever reduce event lowering is active, including direct OpenCL-to-target project translation
- prevent the lowered async copy from leaving a standalone event token declaration that shifts generated text, SPIR-V ids, and source-remap spans
- add focused OpenCL reduce regression coverage for CGL, OpenGL, Metal, Vulkan, and event-token extraction forms

## Validation
- python3.11 -m pytest tests/test_translator/test_project_translation.py -k "opencl_reduce or khronos_opencl_reduce"
- python3.11 -m pytest tests/test_backend/test_OpenCL/test_codegen.py::test_opencl_event_token_extraction_handles_identifier_spellings tests/test_backend/test_OpenCL/test_codegen.py::test_opencl_reduce_helpers_report_structured_target_contracts tests/test_backend/test_OpenCL/test_external_fixtures.py::test_external_khronos_opencl_sdk_shared_parameter_name_codegen_reparse
- python3.11 tools/support_matrix.py check
- pre-commit run --files crosstl/backend/OpenCL/OpenCLCrossGLCodeGen.py tests/test_backend/test_OpenCL/test_codegen.py tests/test_translator/test_project_translation.py

closes #1251