### PR TITLE
Fix DirectX vector constructor truncation

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -16845,6 +16845,10 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 if not self.hlsl_expression_is_repeatable(args[0]):
                     return self.hlsl_scalar_splat_cast(mapped_type, rendered_arg)
                 rendered_args = [rendered_arg] * component_count
+            elif arg_component_count and arg_component_count > component_count:
+                rendered_args = [
+                    f"{rendered_args[0]}.{self.hlsl_vector_swizzle(component_count)}"
+                ]
         return f"{mapped_type}({', '.join(rendered_args)})"
 
     def hlsl_constructor_expression(self, constructor_type, args):

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1111", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1112", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1188", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1111
+        "test_count": 1112
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -33758,6 +33758,49 @@ def test_hlsl_matrix_resize_constructor_lowers_nested_inverse_transpose():
     )
 
 
+def test_hlsl_vector_constructor_truncates_matrix_vector_result():
+    shader = """
+    shader MatrixVectorTruncation {
+        vertex {
+            struct VertexInput {
+                vec3 position;
+                vec3 normal;
+            };
+
+            struct VertexOutput {
+                vec3 worldPosition;
+                vec3 worldNormal;
+            };
+
+            VertexOutput main(VertexInput input) {
+                VertexOutput output;
+                mat4 model = mat4(1.0);
+                mat4 normalMatrix = mat4(1.0);
+                output.worldPosition = vec3(model * vec4(input.position, 1.0));
+                output.worldNormal = normalize(vec3(normalMatrix * vec4(input.normal, 1.0)));
+                return output;
+            }
+        }
+    }
+    """
+
+    generated_code = generate_code(parse_code(tokenize_code(shader)))
+
+    assert (
+        "output.worldPosition = float3(mul(model, "
+        "float4(input.position, 1.0)).xyz);"
+    ) in generated_code
+    assert (
+        "output.worldNormal = normalize(float3(mul(normalMatrix, "
+        "float4(input.normal, 1.0)).xyz));"
+    ) in generated_code
+    assert "float3(mul(model, float4(input.position, 1.0)))" not in generated_code
+    assert (
+        "float3(mul(normalMatrix, float4(input.normal, 1.0)))"
+        not in generated_code
+    )
+
+
 def test_hlsl_local_helpers_capture_stage_input_parameters():
     shader = """
     shader LocalHelperStageCapture {


### PR DESCRIPTION
## Summary
- Narrow single wider vector arguments in HLSL vector constructors with the target-width swizzle.
- Preserve existing scalar splat behavior for vector constructors.
- Add a DirectX regression for `vec3(mat4 * vec4(...))` matrix-vector results.

## Validation
- `/opt/homebrew/bin/python3 tools/support_matrix.py check` -> `Support matrix catalogs and generated artifacts are current.`
- `.venv/bin/python -m pytest -q tests/test_translator/test_codegen/test_directx_codegen.py` -> `929 passed`
- `.venv/bin/python -m pytest -q tests/test_translator/test_codegen/test_directx_codegen.py::test_hlsl_vector_constructor_truncates_matrix_vector_result tests/test_backend/test_directx/test_codegen.py -q` -> passed

The raylib lighting fixture described in the issue is not present on current `main`. Local toolchain validation with DXC was not run because `dxc` is not installed in this environment.

closes #1271
