### PR TITLE
Keep report artifact capabilities field consistent

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -13365,9 +13365,8 @@ def translate_project(
                             else None
                         ),
                     },
+                    "requiredCapabilities": list(required_capabilities),
                 }
-                if required_capabilities:
-                    artifact["requiredCapabilities"] = list(required_capabilities)
                 if variant is not None:
                     artifact["variant"] = variant
                 if output_dir_blocked:

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -15382,6 +15382,7 @@ def test_translate_project_emits_closed_portability_report_schema(tmp_path):
         "stage",
         "templateMaterialization",
     }
+    assert artifact["requiredCapabilities"] == []
     assert set(artifact["sourceHash"]) == project_pipeline.REPORT_HASH_FIELDS
     assert isinstance(artifact["sourceSizeBytes"], int)
     assert artifact["sourceSizeBytes"] == unit["sourceSizeBytes"]


### PR DESCRIPTION
## Summary

Project portability reports declare `requiredCapabilities` as part of the closed artifact schema, but artifacts without special capability needs omitted the field. This made the schema-field test fail even though capability-bearing artifacts already populated the field.

This updates project artifact construction to always emit `requiredCapabilities`, using an empty list when no capabilities are required, and tightens the closed-schema test to assert that default shape.

## Validation

- `.venv/bin/python -m pytest -q tests/test_translator/test_project_translation.py -k emits_closed_portability_report_schema` -> `1 passed, 876 deselected`
- `.venv/bin/python -m pytest -q tests/test_translator/test_project_translation.py::test_translate_project_emits_closed_portability_report_schema tests/test_translator/test_project_translation.py::test_translate_project_models_glsl_fragment_invocation_density_by_target` -> `2 passed`

closes #1268
