### PR TITLE
Align SPIR-V WGSL constant formatting tests

### DIFF
--- a/tests/test_translator/spirv_wgsl_contract.py
+++ b/tests/test_translator/spirv_wgsl_contract.py
@@ -1,0 +1,34 @@
+SPIRV_VERTEX_POSITION_OUTPUT_SOURCE = """
+; SPIR-V
+; Version: 1.0
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main" %pos
+OpName %main "main"
+OpName %pos "gl_Position"
+OpDecorate %pos BuiltIn Position
+%void = OpTypeVoid
+%fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%ptr_output_v4float = OpTypePointer Output %v4float
+%float_0 = OpConstant %float 0
+%float_1 = OpConstant %float 1
+%const_pos = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+%pos = OpVariable %ptr_output_v4float Output
+%main = OpFunction %void None %fn
+%entry = OpLabel
+OpStore %pos %const_pos
+OpReturn
+OpFunctionEnd
+"""
+
+
+def assert_spirv_position_output_wgsl_contract(wgsl):
+    assert "struct VertexOutput" in wgsl
+    assert "@builtin(position) position: vec4<f32>," in wgsl
+    assert "@vertex\nfn vertex_main() -> VertexOutput" in wgsl
+    assert "output.position = vec4<f32>(0, 0, 0, 1);" in wgsl
+    assert "vec4<f32>(f32(0), f32(0), f32(0), f32(1))" not in wgsl
+    assert "return output;" in wgsl
+    assert "gl_Position" not in wgsl

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -45,6 +45,10 @@ from crosstl.translator.source_registry import SOURCE_REGISTRY, register_default
 from tests.test_backend.test_SPIRV.test_codegen import (
     SPIRV_TOOLS_GLPERVERTEX_ACCESS_CHAIN_ASSEMBLY,
 )
+from tests.test_translator.spirv_wgsl_contract import (
+    SPIRV_VERTEX_POSITION_OUTPUT_SOURCE,
+    assert_spirv_position_output_wgsl_contract,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -7516,30 +7520,7 @@ def test_translate_project_spirv_assembly_vertex_position_lowers_to_wgsl(tmp_pat
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "position.spvasm").write_text(
-        textwrap.dedent("""
-            ; SPIR-V
-            ; Version: 1.0
-            OpCapability Shader
-            OpMemoryModel Logical GLSL450
-            OpEntryPoint Vertex %main "main" %pos
-            OpName %main "main"
-            OpName %pos "gl_Position"
-            OpDecorate %pos BuiltIn Position
-            %void = OpTypeVoid
-            %fn = OpTypeFunction %void
-            %float = OpTypeFloat 32
-            %v4float = OpTypeVector %float 4
-            %ptr_output_v4float = OpTypePointer Output %v4float
-            %float_0 = OpConstant %float 0
-            %float_1 = OpConstant %float 1
-            %const_pos = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
-            %pos = OpVariable %ptr_output_v4float Output
-            %main = OpFunction %void None %fn
-            %entry = OpLabel
-            OpStore %pos %const_pos
-            OpReturn
-            OpFunctionEnd
-            """).lstrip(),
+        SPIRV_VERTEX_POSITION_OUTPUT_SOURCE.lstrip(),
         encoding="utf-8",
     )
 
@@ -7560,12 +7541,7 @@ def test_translate_project_spirv_assembly_vertex_position_lowers_to_wgsl(tmp_pat
     } == {("wgsl", "translated")}
 
     wgsl = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
-    assert "struct VertexOutput" in wgsl
-    assert "@builtin(position) position: vec4<f32>," in wgsl
-    assert "@vertex\nfn vertex_main() -> VertexOutput" in wgsl
-    assert "output.position = vec4<f32>(0, 0, 0, 1);" in wgsl
-    assert "return output;" in wgsl
-    assert "gl_Position" not in wgsl
+    assert_spirv_position_output_wgsl_contract(wgsl)
 
     if shutil.which("naga"):
         assert payload["validation"]["artifacts"][0]["status"] == "ok"

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -12,6 +12,10 @@ import crosstl.translator.codegen as codegen
 from crosstl.project import translate_project
 from crosstl.translator.ast import ShaderStage
 from crosstl.translator.source_registry import SOURCE_REGISTRY, register_default_sources
+from tests.test_translator.spirv_wgsl_contract import (
+    SPIRV_VERTEX_POSITION_OUTPUT_SOURCE,
+    assert_spirv_position_output_wgsl_contract,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -152,32 +156,6 @@ void main() {
     fragColor = FragmentDensityToColor();
 }
 """
-
-SPIRV_VERTEX_POSITION_OUTPUT_SOURCE = """
-; SPIR-V
-; Version: 1.0
-OpCapability Shader
-OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %main "main" %pos
-OpName %main "main"
-OpName %pos "gl_Position"
-OpDecorate %pos BuiltIn Position
-%void = OpTypeVoid
-%fn = OpTypeFunction %void
-%float = OpTypeFloat 32
-%v4float = OpTypeVector %float 4
-%ptr_output_v4float = OpTypePointer Output %v4float
-%float_0 = OpConstant %float 0
-%float_1 = OpConstant %float 1
-%const_pos = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
-%pos = OpVariable %ptr_output_v4float Output
-%main = OpFunction %void None %fn
-%entry = OpLabel
-OpStore %pos %const_pos
-OpReturn
-OpFunctionEnd
-"""
-
 
 def _write_source(tmp_path, filename, source):
     path = tmp_path / filename
@@ -1084,12 +1062,7 @@ def test_spirv_assembly_vertex_position_output_lowers_to_wgsl(tmp_path):
     generated = crosstl.translate(str(source_path), backend="wgsl", format_output=False)
 
     _assert_generated_output_is_usable(generated)
-    assert "struct VertexOutput" in generated
-    assert "@builtin(position) position: vec4<f32>," in generated
-    assert "@vertex\nfn vertex_main() -> VertexOutput" in generated
-    assert "output.position = vec4<f32>(0, 0, 0, 1);" in generated
-    assert "return output;" in generated
-    assert "gl_Position" not in generated
+    assert_spirv_position_output_wgsl_contract(generated)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- share the SPIR-V vertex-position assembly fixture between single-file and project translation tests
- assert the WGSL constant formatting contract in one helper for both paths
- explicitly reject the stale f32(...) constructor form for this lowering

closes #1282

## Validation
- .venv/bin/python -m pytest -q tests/test_translator/test_translation_pipeline.py -k spirv_assembly_vertex_position_output_lowers_to_wgsl
- .venv/bin/python -m pytest -q tests/test_translator/test_project_translation.py -k translate_project_spirv_assembly_vertex_position_lowers_to_wgsl
- .venv/bin/python -m pytest -q tests/test_translator/test_project_translation.py -k "spirv_assembly or spvasm"
- .venv/bin/python -m pytest -q tests/test_translator/test_codegen/test_wgsl_codegen.py

Note: the full tests/test_translator/test_translation_pipeline.py file still has unrelated Metal/DirectX expectation failures on current main around RWStructuredBuffer Store syntax and Metal program-scope groupshared output.