### PR TITLE
Stabilize CUDA OpenGL uniform names

### DIFF
--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -4268,9 +4268,15 @@ class GLSLCodeGen:
         )
         for _entry_id, stage_name, func in stage_entry_records:
             for parameter in getattr(func, "parameters", getattr(func, "params", [])):
-                member_type = self.stage_entry_constant_value_parameter_member_type(
-                    parameter, stage_name
+                explicit_value_type = self.stage_entry_constant_value_parameter_type(
+                    parameter
                 )
+                compute_value_type = (
+                    self.stage_entry_compute_value_parameter_type(parameter)
+                    if explicit_value_type is None and stage_name == "compute"
+                    else None
+                )
+                member_type = explicit_value_type or compute_value_type
                 if member_type is None:
                     continue
                 binding = self.explicit_resource_binding_index(parameter)
@@ -4298,6 +4304,7 @@ class GLSLCodeGen:
                         parameter_name,
                         used_member_names,
                         parameter_member_name_counts,
+                        force_block_qualified=compute_value_type is not None,
                     )
                 )
                 used_member_names.add(member_name)
@@ -4414,11 +4421,17 @@ class GLSLCodeGen:
         )
 
     def stage_entry_constant_value_parameter_member_name(
-        self, block_name, parameter_name, used_names, parameter_member_name_counts=None
+        self,
+        block_name,
+        parameter_name,
+        used_names,
+        parameter_member_name_counts=None,
+        force_block_qualified=False,
     ):
         parameter_name = sanitize_type_name(parameter_name or "value")
         if (
-            parameter_name
+            not force_block_qualified
+            and parameter_name
             and parameter_name not in self.GLSL_RESERVED_IDENTIFIERS
             and parameter_name not in used_names
             and (parameter_member_name_counts or {}).get(parameter_name, 0) == 1

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -37980,6 +37980,8 @@ def test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers(
     assert {
         (artifact["target"], artifact["status"]) for artifact in payload["artifacts"]
     } == {("opengl", "translated")}
+    assert payload["summary"]["sourceRemapMappingCount"] == 6
+    assert payload["artifacts"][0]["sourceRemap"]["mappingCount"] == 6
 
     output = (repo / payload["artifacts"][0]["path"]).read_text(encoding="utf-8")
 
@@ -37987,6 +37989,9 @@ def test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers(
     assert "layout(std430, binding = 1) buffer BBuffer { float B[]; };" in output
     assert "layout(std430, binding = 2) buffer CBuffer { float C[]; };" in output
     assert "uniform vectorAdd_numElements_Args" in output
+    assert "int vectorAdd_numElements_Args_numElements;" in output
+    assert "if ((i < vectorAdd_numElements_Args_numElements))" in output
+    assert not re.search(r"(?<!_)\bnumElements\b(?!_)", output)
     assert "void main()" in output
     assert "void vectorAdd(float A[]" not in output
     assert "float A[], float B[]" not in output


### PR DESCRIPTION
## Summary

- Force block-qualified OpenGL uniform-block member names for bare compute scalar parameters lowered from CUDA-style kernels.
- Preserve the existing simple member-name path for explicit constant/uniform parameters when it is unambiguous.
- Add regression coverage for the CUDA vector-add OpenGL uniform member, condition expression, and source-remap mapping count.

## Validation

- `/opt/homebrew/bin/python3 tools/support_matrix.py check` -> `Support matrix catalogs and generated artifacts are current.`
- `/opt/homebrew/bin/pytest -q tests/test_translator/test_project_translation.py::test_translate_project_cuda_pointer_parameters_lower_to_opengl_buffers tests/test_translator/test_project_translation.py::test_translate_project_cuda_vector_add_lowers_compute_builtins_for_targets tests/test_translator/test_project_translation.py::test_translate_project_opengl_materializes_mlx_pointer_and_value_bindings` -> `3 passed`
- `/opt/homebrew/bin/pytest -q tests/test_translator/test_project_translation.py -k "opengl and (cuda or vector_add or pointer_parameters or materializes_mlx)"` -> `7 passed, 870 deselected`
- `/opt/homebrew/bin/pytest -q tests/test_translator/test_codegen/test_GLSL_codegen.py -k "cbuffer or uniform_block or uniform"` -> `16 passed, 804 deselected`
- `/opt/homebrew/bin/pytest -q tests/test_backend/test_CUDA/test_codegen.py -k "packedArgs or launch or vectorAdd"` -> `17 passed, 179 deselected`

Demo fixture note: this checkout does not contain a `demos/` directory, so the open-source porting demo command could not be run locally.

closes #1290
