### PR TITLE
Fix DirectX vertex input semantics

### DIFF
--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -3627,6 +3627,11 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 promoted_entry_resource_parameter_ids,
                 func,
             )
+        default_vertex_parameter_semantics = {}
+        if effective_shader_type == "vertex":
+            default_vertex_parameter_semantics = (
+                self.hlsl_default_vertex_parameter_semantics(param_list, func)
+            )
         for p in param_list:
             if id(p) in promoted_entry_resource_parameter_ids:
                 continue
@@ -3671,6 +3676,8 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                     )
 
             semantic = self.semantic_from_node(p)
+            if semantic is None:
+                semantic = default_vertex_parameter_semantics.get(id(p))
             dispatch_thread_id_bridge = None
             if effective_shader_type == "compute":
                 dispatch_thread_id_bridge = (
@@ -13213,6 +13220,29 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             "translating stage input/output semantics to DirectX."
         )
 
+    def hlsl_parameter_semantic_slot_count(self, parameter, semantic):
+        size_expr = self.hlsl_parameter_array_size_expression(parameter)
+        if size_expr is None:
+            return 1
+
+        count = self.literal_int_value(size_expr, self.literal_int_constants)
+        if count is not None and count > 0:
+            return count
+
+        parameter_name = getattr(parameter, "name", "<anonymous>")
+        semantic_name = self.hlsl_semantic_name(semantic)
+        size_label = (
+            self.expression_to_string(size_expr) if size_expr is not None else ""
+        )
+        size_suffix = f" from '{size_label}'" if size_label else ""
+        raise DirectXSemanticArraySizeError(
+            f"DirectX entry parameter '{parameter_name}' uses array-valued "
+            f"semantic '{semantic_name}' but its array size{size_suffix} "
+            "cannot be resolved to a positive integer. Use a literal or "
+            "compile-time integer constant array size before translating "
+            "stage input/output semantics to DirectX."
+        )
+
     def hlsl_reserve_semantic_range(
         self, used_ranges, struct_name, member_name, semantic, count
     ):
@@ -13369,6 +13399,53 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
                 used_ranges,
                 struct_node.name,
                 member_name,
+                semantic,
+                count,
+            )
+            next_texcoord += count
+        return defaults
+
+    def hlsl_default_vertex_parameter_semantics(self, parameters, func):
+        used_ranges = {}
+        for parameter in parameters or []:
+            semantic = self.semantic_from_node(parameter)
+            if semantic is None:
+                continue
+            count = self.hlsl_parameter_semantic_slot_count(parameter, semantic)
+            self.hlsl_reserve_semantic_range(
+                used_ranges,
+                getattr(func, "name", "<entry>"),
+                getattr(parameter, "name", "<anonymous>"),
+                semantic,
+                count,
+            )
+
+        defaults = {}
+        next_texcoord = 0
+        for parameter in parameters or []:
+            if self.semantic_from_node(parameter) is not None:
+                continue
+            if self.hlsl_entry_resource_parameter_global_type(parameter, func):
+                continue
+            if self.hlsl_parameter_user_struct_type(parameter) is not None:
+                continue
+            if not self.hlsl_can_default_fragment_input_semantic(
+                self.hlsl_parameter_raw_type(parameter)
+            ):
+                continue
+
+            count = self.hlsl_parameter_semantic_slot_count(
+                parameter, f"TEXCOORD{next_texcoord}"
+            )
+            next_texcoord = self.hlsl_next_available_semantic_index(
+                used_ranges, "TEXCOORD", next_texcoord, count
+            )
+            semantic = f"TEXCOORD{next_texcoord}"
+            defaults[id(parameter)] = semantic
+            self.hlsl_reserve_semantic_range(
+                used_ranges,
+                getattr(func, "name", "<entry>"),
+                getattr(parameter, "name", "<anonymous>"),
                 semantic,
                 count,
             )

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -22,7 +22,7 @@ implicitly supported.
 .. csv-table:: Backend inventory
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
-   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1112", "292", "Microsoft Learn HLSL reference; HLSL specification project"
+   "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1114", "292", "Microsoft Learn HLSL reference; HLSL specification project"
    "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_backend/test_GLSL", "1189", "186", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "39", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "103", "70", "WGSL specification; WebGPU specification"

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -123,7 +123,7 @@
           "tests/test_translator/test_codegen/test_directx_codegen.py",
           "tests/test_backend/test_directx"
         ],
-        "test_count": 1112
+        "test_count": 1114
       },
       "translator_codegen": {
         "exists": true,

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -1,4 +1,7 @@
+import os
 import re
+import shutil
+import subprocess
 from typing import List
 
 import pytest
@@ -259,6 +262,73 @@ def test_glsl_fragment_input_locations_lower_to_distinct_hlsl_semantics(tmp_path
     assert "float3 nearPoint: TEXCOORD0;" in generated_code
     assert "float3 farPoint: TEXCOORD1;" in generated_code
     assert ": location" not in generated_code
+    assert generated_code.count(": TEXCOORD0") == 1
+    assert generated_code.count(": TEXCOORD1") == 1
+
+
+def test_rust_gpu_vertex_plain_input_lowers_to_hlsl_semantic(tmp_path):
+    shader = """
+    use spirv_std::glam::{Vec2, Vec4};
+    use spirv_std::spirv;
+
+    #[spirv(vertex)]
+    pub fn main_vs(pos: Vec2, #[spirv(position)] builtin_pos: &mut Vec4) {
+        *builtin_pos = pos.extend(0.0).extend(1.0);
+    }
+    """
+    shader_path = tmp_path / "rust_gpu_stage_inputs.rs"
+    shader_path.write_text(shader)
+
+    generated_code = crosstl.translate(
+        str(shader_path),
+        backend="directx",
+        format_output=False,
+        source_backend="rust",
+    )
+
+    assert (
+        "void VSMain(float2 pos : TEXCOORD0, "
+        "out float4 builtin_pos : SV_POSITION)" in generated_code
+    )
+    assert "void VSMain(float2 pos, out float4 builtin_pos : SV_POSITION)" not in (
+        generated_code
+    )
+
+    dxc = shutil.which("dxc")
+    if dxc is None:
+        return
+
+    hlsl_path = tmp_path / "rust_gpu_stage_inputs.hlsl"
+    hlsl_path.write_text(generated_code)
+    result = subprocess.run(
+        [dxc, "-T", "vs_6_0", "-E", "VSMain", str(hlsl_path), "-Fo", os.devnull],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_directx_vertex_default_parameter_semantics_skip_declared_ranges():
+    shader = """
+    shader VertexPlainInputs {
+        vertex {
+            void main(
+                vec2 uv @ TEXCOORD0,
+                vec3 normal,
+                out vec4 position @ gl_Position
+            ) {
+                position = vec4(normal, 1.0);
+            }
+        }
+    }
+    """
+
+    generated_code = generate_code(parse_code(tokenize_code(shader)))
+
+    assert "float2 uv : TEXCOORD0" in generated_code
+    assert "float3 normal : TEXCOORD1" in generated_code
+    assert "out float4 position : SV_POSITION" in generated_code
     assert generated_code.count(": TEXCOORD0") == 1
     assert generated_code.count(": TEXCOORD1") == 1
 


### PR DESCRIPTION
## Summary
- Add deterministic `TEXCOORDN` semantics for unannotated DirectX vertex entry value parameters.
- Keep explicit vertex parameter semantics reserved so generated defaults do not collide.
- Add Rust-GPU to DirectX regression coverage, including optional DXC validation when `dxc` is installed.
- Refresh support matrix generated test counts.

## Validation
- `/opt/homebrew/bin/python3 tools/support_matrix.py check` -> `Support matrix catalogs and generated artifacts are current.`
- `/opt/homebrew/bin/pytest -q tests/test_translator/test_codegen/test_directx_codegen.py tests/test_backend/test_rust/test_codegen.py tests/test_backend/test_directx/test_codegen.py tests/test_translator/test_codegen/test_hlsl_stage_inout_lowering.py` -> `1543 passed`
- `/opt/homebrew/bin/pytest -q tests/test_support_matrix.py` -> `64 passed`

`dxc` was not installed locally, so the regression asserts the legal HLSL signature and will run DXC when available.

closes #1278
