### PR TITLE
Isolate support issue sync mutation failure test

### DIFF
--- a/tests/test_support_issue_sync.py
+++ b/tests/test_support_issue_sync.py
@@ -2497,6 +2497,7 @@ def test_main_writes_sync_failure_summary_on_mutation_failure(
 ):
     module = load_sync_module()
     matrix_path = tmp_path / "support-matrix.json"
+    signals_path = tmp_path / "missing-signals.json"
     summary_path = tmp_path / "support-issue-sync-summary.json"
     matrix_path.write_text(json.dumps(sample_matrix()), encoding="utf-8")
     monkeypatch.setenv("GITHUB_TOKEN", "token")
@@ -2516,6 +2517,8 @@ def test_main_writes_sync_failure_summary_on_mutation_failure(
         [
             "--matrix",
             str(matrix_path),
+            "--signals",
+            str(signals_path),
             "--repo",
             "owner/repo",
             "--inspect-existing",


### PR DESCRIPTION
## Summary
- Isolate the mutation-failure `main()` test from workflow-generated `support/generated/support-signals.json`.
- Pass an explicit missing signals path so the test keeps exercising the matrix-only partial summary path.

## Tests
- `/private/tmp/crosstl-support-issue-sync-venv/bin/python -m pytest -q tests/test_support_issue_sync.py::test_main_writes_sync_failure_summary_on_mutation_failure`
- `/private/tmp/crosstl-support-issue-sync-venv/bin/python -m pytest -q tests/test_support_issue_sync.py`
- `/private/tmp/crosstl-support-issue-sync-venv/bin/python -m pytest -q tests/test_support_matrix.py tests/test_support_signals.py tests/test_support_ci_summary.py tests/test_support_issue_sync.py tests/test_pr_issue_links.py tests/test_pytest_failure_summary.py tests/test_ci_workflows.py tests/test_tool_cli.py tests/test_examples_test_script.py`
