### PR TITLE
Propagate runtime command adapter availability

### DIFF
--- a/crosstl/project/test_runner.py
+++ b/crosstl/project/test_runner.py
@@ -377,13 +377,18 @@ def _commands_from_runtime_tests(
             metadata = {}
         upstream_name = metadata.get("upstreamTestName", fixture)
         command = metadata.get("testCommand")
+        adapter_id = _adapter_reference_id(test_case.get("adapter"))
+        platform_requirements = test_case.get("platformRequirements")
+        if not isinstance(platform_requirements, Mapping):
+            platform_requirements = {}
         commands.append(
             {
                 "name": str(upstream_name),
                 "command": command if isinstance(command, Sequence) else [],
-                "adapter": test_case.get("adapter"),
+                "adapter": adapter_id,
                 "fixture": fixture,
                 "targets": _case_targets(test_case),
+                "platformRequirements": dict(platform_requirements),
                 "provenance": _case_provenance(test_case),
             }
         )
@@ -412,8 +417,11 @@ def _plan_commands(
             and not target_set.intersection(command_targets)
         ):
             continue
-        adapter_id = command.get("adapter")
-        adapter = adapter_by_id.get(adapter_id) if isinstance(adapter_id, str) else None
+        adapter_ref = command.get("adapter")
+        adapter_id = _adapter_reference_id(adapter_ref)
+        adapter = adapter_by_id.get(adapter_id) if adapter_id is not None else None
+        if adapter is None and isinstance(adapter_ref, Mapping):
+            adapter = adapter_ref
         availability = adapter.get("availability", {}) if adapter is not None else {}
         required = _command_requirements(command, adapter)
         missing_tools = [
@@ -468,6 +476,16 @@ def _plan_commands(
             )
         planned.append(record)
     return planned
+
+
+def _adapter_reference_id(adapter_ref: Any) -> str | None:
+    if isinstance(adapter_ref, str) and adapter_ref.strip():
+        return adapter_ref
+    if isinstance(adapter_ref, Mapping):
+        adapter_id = adapter_ref.get("id")
+        if isinstance(adapter_id, str) and adapter_id.strip():
+            return adapter_id
+    return None
 
 
 def _command_requirements(

--- a/tests/test_project_test_runner.py
+++ b/tests/test_project_test_runner.py
@@ -108,6 +108,60 @@ def test_project_test_runner_plan_records_handoff_commands_and_provenance(tmp_pa
     assert runtime_test["provenance"]["upstreamTestName"] == "project.tests.test_add"
 
 
+def test_runtime_derived_command_inherits_unavailable_adapter_requirements(tmp_path):
+    missing_tool = "crosstl-test-runner-runtime-tool-that-does-not-exist"
+    manifest = _manifest(missing_tool)
+    manifest["tests"][0]["metadata"]["testCommand"] = ["true"]
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        manifest,
+        selected_targets=["opengl"],
+        project_root=tmp_path,
+    )
+
+    runtime_test = plan["runtimeTests"][0]
+    command = plan["testCommands"][0]
+
+    assert runtime_test["status"] == "skipped"
+    assert command["adapter"] == "opengl-native"
+    assert command["requiredAdapters"] == ["opengl-native"]
+    assert command["status"] == "skipped"
+    assert missing_tool in command["requiredTools"]
+    assert missing_tool in command["diagnostics"][0]["missingTools"]
+    assert set(command["diagnostics"][0]["missingTools"]) == set(
+        runtime_test["diagnostics"][0]["missingTools"]
+    )
+
+
+def test_project_test_runner_plans_mapping_adapter_references(tmp_path):
+    missing_tool = "crosstl-test-runner-mapping-tool-that-does-not-exist"
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "mapping adapter command",
+                "command": ["true"],
+                "targets": ["opengl"],
+                "adapter": {
+                    "id": "opengl-mapped",
+                    "platformRequirements": {"requiredTools": [missing_tool]},
+                },
+            }
+        ],
+        project_root=tmp_path,
+    )
+
+    command = plan["testCommands"][0]
+
+    assert command["adapter"] == "opengl-mapped"
+    assert command["requiredAdapters"] == ["opengl-mapped"]
+    assert command["status"] == "skipped"
+    assert command["requiredTools"] == [missing_tool]
+    assert command["diagnostics"][0]["adapter"] == "opengl-mapped"
+
+
 def test_project_test_runner_executes_available_project_command(tmp_path):
     output_file = tmp_path / "command-output.txt"
     plan = build_project_test_runner_plan(


### PR DESCRIPTION
## Summary
- normalize runtime-derived command adapter references to adapter ids
- carry runtime case platform requirements into derived project test commands
- skip derived commands when their adapter requirements are unavailable

## Root cause
Runtime test planning stores the selected adapter as a full object on each runtime case. Project command planning only looked up adapter availability for string adapter ids, so runtime-derived commands bypassed availability and required-tool propagation.

## Tests
- PYTHONDONTWRITEBYTECODE=1 python3 issue #1345 repro snippet
- PYTHONDONTWRITEBYTECODE=1 /private/tmp/crosstl-test-venv-1345/bin/python -m pytest tests/test_project_test_runner.py
- PYTHONDONTWRITEBYTECODE=1 /private/tmp/crosstl-test-venv-1345/bin/python -m pytest tests/test_translator/test_runtime_verification.py::test_plan_runtime_test_manifest_records_structured_skip_and_toolchain_logs tests/test_translator/test_project_translation.py::test_project_package_exposes_public_api_surface tests/test_support_matrix.py::test_project_runtime_test_manifest_is_first_class_support_feature

closes #1345