### PR TITLE
Fix Metal template alias materialization in CI

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -11730,14 +11730,14 @@ def _metal_block_spans(preprocessor: Any, source: str) -> list[tuple[int, int]]:
     return spans
 
 
-def _metal_enclosing_block_end(
+def _metal_enclosing_block_span(
     block_spans: Sequence[tuple[int, int]],
     position: int,
-) -> int | None:
+) -> tuple[int, int] | None:
     enclosing = [span for span in block_spans if span[0] < position < span[1]]
     if not enclosing:
         return None
-    return min(enclosing, key=lambda span: span[1] - span[0])[1]
+    return min(enclosing, key=lambda span: span[1] - span[0])
 
 
 def _metal_statement_semicolon(
@@ -11791,6 +11791,21 @@ def _metal_concrete_using_alias_type(alias_type: str) -> str | None:
     if any(character in alias_type for character in "{};="):
         return None
     return alias_type
+
+
+def _metal_local_integer_constants_before(
+    source: str,
+    block_start: int,
+    position: int,
+) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    for start, end in _metal_statement_spans(source, block_start + 1, position):
+        constant = _metal_local_constant_declaration(source[start:end], constants)
+        if constant is None:
+            continue
+        name, value = constant
+        constants[name] = value
+    return constants
 
 
 def _metal_template_struct_members(
@@ -11965,10 +11980,27 @@ def _inline_metal_concrete_using_template_aliases(
                         continue
                     alias_type = (candidate.get("members") or {}).get(member)
                     break
-        scope_end = _metal_enclosing_block_end(block_spans, i)
-        if alias_type is None or scope_end is None:
+        scope_span = _metal_enclosing_block_span(block_spans, i)
+        if alias_type is None or scope_span is None:
             i = semicolon + 1
             continue
+        scope_start, scope_end = scope_span
+        scoped_aliases = {
+            str(alias["name"]): str(alias["type"])
+            for alias in aliases
+            if int(alias["end"]) <= i and int(alias["scope_end"]) >= scope_end
+        }
+        scoped_constants = _metal_local_integer_constants_before(
+            source,
+            scope_start,
+            i,
+        )
+        alias_type = _metal_resolve_type_identifiers(
+            preprocessor,
+            alias_type,
+            aliases=scoped_aliases,
+            constants=scoped_constants,
+        )
         members = _metal_concrete_template_struct_members(
             preprocessor,
             template_structs,

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -12640,6 +12640,7 @@ def test_metal_project_materialization_concretizes_steel_attention_load_helper(
         "Rows": "2",
         "T": "float",
     }
+    assert "LoadTile<float,2,2> tile;" in materialized.text
     assert "load_float_2_2(tile, src[gid]);" in materialized.text
     assert not re.search(r"\bload\s*\(", materialized.text)
 


### PR DESCRIPTION
## Summary
- resolve local constexpr constants when inlining concrete Metal using aliases
- keep OpenGL template materialization diagnostics for genuinely unresolved template types
- cover the steel attention LoadTile helper with a concrete emitted type assertion

## Failure
The Complete Test Suite failure came from Metal-to-OpenGL project materialization for steel_attention_nax.metal. The load helper was specialized correctly as load_float_2_2, but alias inlining left the local tile declaration as LoadTile<float, Rows, Cols>. The post-materialization unresolved-template check then reported project.translate.template-materialization-unsupported for Rows and Cols even though those values were concrete constexpr expressions in the materialized kernel.

## Validation
- pytest tests/test_translator/test_project_translation.py::test_metal_project_materialization_concretizes_steel_attention_load_helper -q
- pytest tests/test_translator/test_project_translation.py::test_metal_project_materialization_concretizes_steel_attention_tile_helper tests/test_translator/test_project_translation.py::test_metal_project_materialization_concretizes_steel_attention_load_helper tests/test_translator/test_project_translation.py::test_translate_project_opengl_missing_accumulator_template_diagnostic tests/test_translator/test_project_translation.py::test_translate_project_opengl_reports_unresolved_metal_template_kernel tests/test_translator/test_project_translation.py::test_translate_project_opengl_rejects_unresolved_metal_template_type_before_codegen tests/test_translator/test_project_translation.py::test_translate_project_opengl_rejects_post_materialization_template_type_leak -q

Support issue traceability: no issue closed
