### PR TITLE
Generate demo CI inputs from metadata

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -12,10 +12,12 @@ on:
       - "crosstl/project/**"
       - "demos/open-source-porting/**"
       - "docs/source/project-porting.rst"
+      - "support/demo-ci-metadata.json"
       - "support/generated/project-porting-roadmap.json"
       - "tests/test_demo_open_source_porting.py"
       - "tests/test_project_test_runner.py"
       - "tests/test_translator/test_project_translation.py"
+      - "tools/demo_ci_metadata.py"
       - "tools/pytest_failure_summary.py"
   pull_request:
     branches:
@@ -25,10 +27,12 @@ on:
       - "crosstl/project/**"
       - "demos/open-source-porting/**"
       - "docs/source/project-porting.rst"
+      - "support/demo-ci-metadata.json"
       - "support/generated/project-porting-roadmap.json"
       - "tests/test_demo_open_source_porting.py"
       - "tests/test_project_test_runner.py"
       - "tests/test_translator/test_project_translation.py"
+      - "tools/demo_ci_metadata.py"
       - "tools/pytest_failure_summary.py"
   workflow_dispatch:
 
@@ -65,9 +69,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p support/generated/demo-reports/${{ matrix.os }}
+          readarray -t demo_test_files < <(python tools/demo_ci_metadata.py emit-pytest-files)
+          demo_selector="$(python tools/demo_ci_metadata.py emit-pytest-selector)"
           python -m pytest -q \
-            tests/test_translator/test_project_translation.py \
-            -k "monogame_sprite_entries or monogame_entries_not_empty_generic_wrapper or cuda_vector_add_demo_directx_outputs_valid_hlsl" \
+            "${demo_test_files[@]}" \
+            -k "$demo_selector" \
             --junitxml support/generated/demo-reports/${{ matrix.os }}/open-source-porting-demo-pytest.xml
 
       - name: Write demo failure summary

--- a/.github/workflows/support-issue-sync.yml
+++ b/.github/workflows/support-issue-sync.yml
@@ -46,6 +46,7 @@ on:
       - "demos/open-source-porting/**"
       - "support/**"
       - "tools/ci_coverage.py"
+      - "tools/demo_ci_metadata.py"
       - "tools/pytest_failure_summary.py"
       - "tools/support_ci_summary.py"
       - "tools/support_matrix.py"

--- a/support/README.md
+++ b/support/README.md
@@ -8,6 +8,8 @@ The matrix is intentionally data-driven:
   test locations, and official documentation sources.
 - `features.json` lists the capabilities CrossGL wants to support and the current
   status per backend.
+- `demo-ci-metadata.json` lists the checked-in open-source porting demo cases
+  that the demo workflow turns into pytest inputs.
 - `generated/support-matrix.json` and `docs/source/support-matrix.rst` are generated
   by `tools/support_matrix.py`.
 - `generated/graphics-backend-roadmap.json` is a focused generated view for the

--- a/support/demo-ci-metadata.json
+++ b/support/demo-ci-metadata.json
@@ -1,0 +1,39 @@
+{
+  "description": "Open-source porting demo CI inputs derived from checked-in test metadata.",
+  "pytest": {
+    "cases": [
+      {
+        "id": "directx-toolchain-monogame-sprite-entry-profiles",
+        "selector": "monogame_sprite_entries",
+        "targets": [
+          "directx"
+        ],
+        "tests": [
+          "test_directx_toolchain_smoke_commands_use_monogame_sprite_entries"
+        ]
+      },
+      {
+        "id": "directx-toolchain-monogame-generic-wrapper",
+        "selector": "monogame_entries_not_empty_generic_wrapper",
+        "targets": [
+          "directx"
+        ],
+        "tests": [
+          "test_project_directx_smoke_runs_monogame_entries_not_empty_generic_wrapper"
+        ]
+      },
+      {
+        "id": "directx-toolchain-cuda-vector-add",
+        "selector": "cuda_vector_add_demo_directx_outputs_valid_hlsl",
+        "targets": [
+          "directx"
+        ],
+        "tests": [
+          "test_translate_project_cli_cuda_vector_add_demo_directx_outputs_valid_hlsl"
+        ]
+      }
+    ],
+    "test_file": "tests/test_translator/test_project_translation.py"
+  },
+  "schema_version": 1
+}

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
 ACTIONS_DIR = ROOT / ".github" / "actions"
 CI_COVERAGE_SCRIPT = ROOT / "tools" / "ci_coverage.py"
+DEMO_CI_METADATA_PATH = ROOT / "support" / "demo-ci-metadata.json"
 PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12", "3.13"}
 RUNNER_OSES = {"ubuntu-latest", "windows-latest", "macOS-latest"}
 BACKEND_TEST_MATRIX_NAMES = {
@@ -207,6 +208,8 @@ def test_full_suite_runs_runtime_parity_only_for_available_adapters():
 def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
     workflows = _workflow_texts()
     demo = workflows.get("demo.yml", "")
+    demo_metadata = json.loads(DEMO_CI_METADATA_PATH.read_text(encoding="utf-8"))
+    demo_selectors = [case["selector"] for case in demo_metadata["pytest"]["cases"]]
 
     assert demo, "demo.yml must exist"
     assert "name: Open-Source Porting Demo" in demo
@@ -218,16 +221,24 @@ def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
     assert "os: [ubuntu-latest]" in demo
     assert '".github/workflows/demo.yml"' in demo
     assert '"demos/open-source-porting/**"' in demo
+    assert '"support/demo-ci-metadata.json"' in demo
     assert '"tests/test_demo_open_source_porting.py"' in demo
     assert '"tests/test_project_test_runner.py"' in demo
     assert '"tests/test_translator/test_project_translation.py"' in demo
+    assert '"tools/demo_ci_metadata.py"' in demo
     assert "id: run_demo_tests" in demo
-    for selector in (
-        "monogame_sprite_entries",
-        "monogame_entries_not_empty_generic_wrapper",
-        "cuda_vector_add_demo_directx_outputs_valid_hlsl",
-    ):
-        assert selector in demo
+    assert (
+        "readarray -t demo_test_files < <(python tools/demo_ci_metadata.py "
+        "emit-pytest-files)"
+    ) in demo
+    assert (
+        'demo_selector="$(python tools/demo_ci_metadata.py emit-pytest-selector)"'
+        in demo
+    )
+    assert '"${demo_test_files[@]}"' in demo
+    assert '-k "$demo_selector"' in demo
+    for selector in demo_selectors:
+        assert selector not in demo
     assert (
         "--junitxml support/generated/demo-reports/${{ matrix.os }}/"
         "open-source-porting-demo-pytest.xml"
@@ -2038,6 +2049,7 @@ def test_support_issue_sync_workflow_validates_and_creates_managed_issues():
         '"docs/source/project-porting.rst"',
         '"docs/source/support-matrix.rst"',
         '"examples/test.py"',
+        '"tools/demo_ci_metadata.py"',
         '"tests/test_backend/**"',
         '"tests/test_demo_open_source_porting.py"',
         '"tests/test_examples_test_script.py"',

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -1,0 +1,104 @@
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO_CI_METADATA_PATH = ROOT / "support" / "demo-ci-metadata.json"
+DEMO_CI_TOOL_PATH = ROOT / "tools" / "demo_ci_metadata.py"
+DEMO_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "demo.yml"
+
+
+def _load_demo_ci_tool():
+    spec = importlib.util.spec_from_file_location("demo_ci_metadata", DEMO_CI_TOOL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _test_function_names(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+
+
+def test_demo_ci_metadata_matches_checked_in_pytest_cases():
+    tool = _load_demo_ci_tool()
+    metadata = tool.load_metadata(DEMO_CI_METADATA_PATH)
+    test_file = ROOT / metadata["pytest"]["test_file"]
+    test_names = _test_function_names(test_file)
+
+    assert tool.pytest_files(metadata) == [metadata["pytest"]["test_file"]]
+    assert metadata["pytest"]["cases"]
+
+    for case in metadata["pytest"]["cases"]:
+        selector = case["selector"]
+        matched_tests = sorted(name for name in test_names if selector in name)
+
+        assert matched_tests, selector
+        assert sorted(case["tests"]) == matched_tests
+        assert case["targets"]
+        assert all(target == target.lower() for target in case["targets"])
+
+
+def test_demo_ci_metadata_generates_workflow_pytest_inputs():
+    tool = _load_demo_ci_tool()
+    metadata = tool.load_metadata(DEMO_CI_METADATA_PATH)
+    selectors = [case["selector"] for case in metadata["pytest"]["cases"]]
+
+    assert tool.pytest_selectors(metadata) == selectors
+    assert tool.pytest_selector_expression(metadata) == " or ".join(selectors)
+
+
+def test_demo_workflow_consumes_generated_demo_ci_inputs():
+    metadata = json.loads(DEMO_CI_METADATA_PATH.read_text(encoding="utf-8"))
+    workflow = DEMO_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "tools/demo_ci_metadata.py emit-pytest-files" in workflow
+    assert "tools/demo_ci_metadata.py emit-pytest-selector" in workflow
+    assert '"${demo_test_files[@]}"' in workflow
+    assert '-k "$demo_selector"' in workflow
+
+    for case in metadata["pytest"]["cases"]:
+        assert case["selector"] not in workflow
+
+
+def test_demo_ci_metadata_cli_check_and_emitters():
+    check = subprocess.run(
+        [sys.executable, "tools/demo_ci_metadata.py", "check"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert check.returncode == 0, check.stdout + check.stderr
+    assert "demo CI metadata is valid" in check.stdout
+
+    files = subprocess.run(
+        [sys.executable, "tools/demo_ci_metadata.py", "emit-pytest-files"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    selector = subprocess.run(
+        [sys.executable, "tools/demo_ci_metadata.py", "emit-pytest-selector"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    metadata = json.loads(DEMO_CI_METADATA_PATH.read_text(encoding="utf-8"))
+
+    assert files.stdout.splitlines() == [metadata["pytest"]["test_file"]]
+    assert selector.stdout.strip() == " or ".join(
+        case["selector"] for case in metadata["pytest"]["cases"]
+    )

--- a/tools/ci_coverage.py
+++ b/tools/ci_coverage.py
@@ -143,6 +143,7 @@ SUPPORT_ISSUE_SYNC_REQUIRED_PATH_FILTERS = [
     "examples/test.py",
     "support/**",
     "tools/ci_coverage.py",
+    "tools/demo_ci_metadata.py",
     "tools/pytest_failure_summary.py",
     "tools/support_ci_summary.py",
     "tools/support_matrix.py",

--- a/tools/demo_ci_metadata.py
+++ b/tools/demo_ci_metadata.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Emit and validate CI inputs for the open-source porting demo."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_METADATA_PATH = ROOT / "support" / "demo-ci-metadata.json"
+SELECTOR_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+class DemoCiMetadataError(ValueError):
+    """Raised when demo CI metadata cannot be consumed safely."""
+
+
+def _repo_path(path: str, root: Path = ROOT) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        raise DemoCiMetadataError(f"metadata path must be repository-relative: {path}")
+    return root / candidate
+
+
+def _test_function_names(test_file: Path) -> set[str]:
+    try:
+        tree = ast.parse(test_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise DemoCiMetadataError(f"unable to read pytest file {test_file}: {exc}") from exc
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+
+
+def validation_errors(metadata: dict[str, Any], *, root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    if metadata.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    pytest_config = metadata.get("pytest")
+    if not isinstance(pytest_config, dict):
+        return errors + ["pytest must be an object"]
+
+    test_file = pytest_config.get("test_file")
+    if not isinstance(test_file, str) or not test_file:
+        errors.append("pytest.test_file must be a non-empty string")
+        test_names: set[str] = set()
+    else:
+        try:
+            test_path = _repo_path(test_file, root)
+            if not test_path.is_file():
+                errors.append(f"pytest.test_file does not exist: {test_file}")
+                test_names = set()
+            else:
+                test_names = _test_function_names(test_path)
+        except DemoCiMetadataError as exc:
+            errors.append(str(exc))
+            test_names = set()
+
+    cases = pytest_config.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return errors + ["pytest.cases must be a non-empty list"]
+
+    seen_ids: set[str] = set()
+    seen_selectors: set[str] = set()
+    for index, case in enumerate(cases):
+        field = f"pytest.cases[{index}]"
+        if not isinstance(case, dict):
+            errors.append(f"{field} must be an object")
+            continue
+
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            errors.append(f"{field}.id must be a non-empty string")
+        elif case_id in seen_ids:
+            errors.append(f"{field}.id is duplicated: {case_id}")
+        else:
+            seen_ids.add(case_id)
+
+        selector = case.get("selector")
+        if not isinstance(selector, str) or not selector:
+            errors.append(f"{field}.selector must be a non-empty string")
+            selector_matches: set[str] = set()
+        elif not SELECTOR_RE.fullmatch(selector):
+            errors.append(f"{field}.selector must be a pytest -k safe token: {selector}")
+            selector_matches = set()
+        elif selector in seen_selectors:
+            errors.append(f"{field}.selector is duplicated: {selector}")
+            selector_matches = set()
+        else:
+            seen_selectors.add(selector)
+            selector_matches = {name for name in test_names if selector in name}
+
+        targets = case.get("targets")
+        if (
+            not isinstance(targets, list)
+            or not targets
+            or not all(isinstance(target, str) and target for target in targets)
+        ):
+            errors.append(f"{field}.targets must be a non-empty string list")
+
+        tests = case.get("tests")
+        if (
+            not isinstance(tests, list)
+            or not tests
+            or not all(isinstance(test, str) and test for test in tests)
+        ):
+            errors.append(f"{field}.tests must be a non-empty string list")
+            continue
+
+        missing = sorted(test for test in tests if test not in test_names)
+        if missing:
+            errors.append(f"{field}.tests are missing from {test_file}: {missing}")
+
+        if selector_matches and sorted(tests) != sorted(selector_matches):
+            errors.append(
+                f"{field}.selector {selector!r} matches {sorted(selector_matches)}, "
+                f"but metadata lists {sorted(tests)}"
+            )
+        elif not selector_matches:
+            errors.append(f"{field}.selector does not match any test in {test_file}")
+
+    return errors
+
+
+def load_metadata(path: Path = DEFAULT_METADATA_PATH, *, root: Path = ROOT) -> dict[str, Any]:
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise DemoCiMetadataError(f"unable to read demo CI metadata {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise DemoCiMetadataError(f"invalid demo CI metadata JSON {path}: {exc}") from exc
+    if not isinstance(metadata, dict):
+        raise DemoCiMetadataError("demo CI metadata must be a JSON object")
+
+    errors = validation_errors(metadata, root=root)
+    if errors:
+        raise DemoCiMetadataError("\n".join(errors))
+    return metadata
+
+
+def pytest_files(metadata: dict[str, Any]) -> list[str]:
+    return [metadata["pytest"]["test_file"]]
+
+
+def pytest_selectors(metadata: dict[str, Any]) -> list[str]:
+    return [case["selector"] for case in metadata["pytest"]["cases"]]
+
+
+def pytest_selector_expression(metadata: dict[str, Any]) -> str:
+    return " or ".join(pytest_selectors(metadata))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit and validate open-source porting demo CI inputs."
+    )
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        default=DEFAULT_METADATA_PATH,
+        help="Path to demo CI metadata JSON.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("check", help="Validate the checked-in metadata.")
+    subparsers.add_parser(
+        "emit-pytest-files",
+        help="Print pytest files, one per line, for the demo CI workflow.",
+    )
+    subparsers.add_parser(
+        "emit-pytest-selector",
+        help="Print the pytest -k selector for the demo CI workflow.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        metadata = load_metadata(args.metadata)
+    except DemoCiMetadataError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.command == "check":
+        print("demo CI metadata is valid")
+        return 0
+    if args.command == "emit-pytest-files":
+        print("\n".join(pytest_files(metadata)))
+        return 0
+    if args.command == "emit-pytest-selector":
+        print(pytest_selector_expression(metadata))
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary:
- Add checked-in demo CI metadata and a helper that emits pytest files/selectors for the demo workflow.
- Update demo/support workflow contracts so CI consumes generated inputs instead of hardcoded selector lists.
- Add tests that validate metadata against the checked-in pytest corpus and workflow usage.

Validation:
- .venv/bin/python -m pytest -q tests/test_demo_open_source_porting.py tests/test_ci_workflows.py::test_open_source_porting_demo_workflow_feeds_support_failure_summaries tests/test_ci_workflows.py::test_support_issue_sync_workflow_validates_and_creates_managed_issues
- .venv/bin/python -m pytest -q tests/test_ci_workflows.py::test_ci_coverage_report_summarizes_required_workflow_dimensions
- .venv/bin/python tools/ci_coverage.py check
- .venv/bin/python tools/demo_ci_metadata.py check

closes #1359