### PR TITLE
Parse demo targets with project TOML config

### DIFF
--- a/demos/open-source-porting/run_demo.py
+++ b/demos/open-source-porting/run_demo.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import ast
 import difflib
 import json
 import re
@@ -14,11 +13,12 @@ import sys
 import tempfile
 from pathlib import Path
 
+from crosstl.project import load_project_config
+
 DEMO_ROOT = Path(__file__).resolve().parent
 CASE_ROOT = DEMO_ROOT / "cases"
 OUTPUT_DIR_NAME = "crosstl-out"
 REPORT_NAME = "portability-report.json"
-TARGET_RE = re.compile(r"(?m)^\s*targets\s*=\s*(\[[^\]]*\])")
 DIRECTX_DEFAULT_ENTRY_PROFILES = (
     ("VSMain", "vs_6_0"),
     ("PSMain", "ps_6_0"),
@@ -37,15 +37,9 @@ def _case_dirs() -> list[Path]:
 
 
 def _case_targets(case_dir: Path) -> list[str]:
-    config_text = (case_dir / "crosstl.toml").read_text(encoding="utf-8")
-    match = TARGET_RE.search(config_text)
-    if match is None:
+    targets = list(load_project_config(case_dir).targets)
+    if not targets:
         raise ValueError(f"{case_dir}/crosstl.toml does not declare project targets")
-    targets = ast.literal_eval(match.group(1))
-    if not isinstance(targets, list) or not all(
-        isinstance(target, str) for target in targets
-    ):
-        raise ValueError(f"{case_dir}/crosstl.toml targets must be a string list")
     return targets
 
 

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -44,6 +44,28 @@ def _test_function_names(path):
     }
 
 
+def test_open_source_demo_case_targets_use_toml_project_config(tmp_path):
+    runner = _load_demo_runner()
+    (tmp_path / "crosstl.toml").write_text(
+        """
+        [project]
+        output_dir = "crosstl-out"
+        targets = [
+            "cgl", # checked source-form target
+            "opengl",
+            # keep this trailing entry on a separate line
+            "vulkan",
+        ]
+
+        [project.sources]
+        "shaders/*.hlsl" = "directx"
+        """,
+        encoding="utf-8",
+    )
+
+    assert runner._case_targets(tmp_path) == ["cgl", "opengl", "vulkan"]
+
+
 def test_open_source_demo_cases_have_pinned_manifests_and_references():
     runner = _load_demo_runner()
     case_dirs = sorted(path for path in CASE_ROOT.iterdir() if path.is_dir())


### PR DESCRIPTION
## Summary
- Route open-source demo target discovery through the project TOML config loader.
- Keep demo cases failing clearly when `project.targets` is absent.
- Add a regression test for commented multiline `project.targets` arrays.

## Validation
- `.venv/bin/python -m pytest tests/test_demo_open_source_porting.py` -> 14 passed
- `.venv/bin/python demos/open-source-porting/run_demo.py --emit-case-args vulkan` -> exit 0
- `git diff --check HEAD~1..HEAD` -> exit 0
- parser symbol scan in `demos/open-source-porting/run_demo.py` -> no matches

closes #1368