### PR TITLE
Validate demo third-party notice coverage

### DIFF
--- a/demos/open-source-porting/THIRD_PARTY_NOTICES.md
+++ b/demos/open-source-porting/THIRD_PARTY_NOTICES.md
@@ -62,6 +62,7 @@ should be treated with the same upstream license context when redistributed.
   - `Tutorials/Tutorial02_Cube/assets/cube.vsh`
   - `Tutorials/Tutorial02_Cube/assets/cube.psh`
   - `Tutorials/Tutorial24_VRS/assets/CubeFDM_vs.glsl`
+  - `Tutorials/Tutorial24_VRS/assets/CubeFDM_fs.glsl`
 - License: Apache-2.0
 - License URL:
   https://github.com/DiligentGraphics/DiligentSamples/blob/30b94f26e7d10cde0be48c75a2c252185f564b69/LICENSE
@@ -298,6 +299,7 @@ should be treated with the same upstream license context when redistributed.
 - Repository: https://github.com/Rust-GPU/rust-gpu
 - Commit: `36e3348cdc2f824afec64b3b5af5d369d98a4c0d`
 - Source paths:
+  - `examples/shaders/compute-shader/src/lib.rs`
   - `examples/shaders/sky-shader/src/lib.rs`
   - `examples/shaders/mouse-shader/src/lib.rs`
 - License: Apache-2.0 OR MIT

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -453,9 +453,7 @@ def test_ci_coverage_report_summarizes_required_workflow_dimensions():
         ].values()
     )
     assert all(
-        report["workflows"]["open_source_porting_demo"][
-            "checked_in_artifacts"
-        ].values()
+        report["workflows"]["open_source_porting_demo"]["checked_in_artifacts"].values()
     )
     assert all(
         report["workflows"]["open_source_porting_demo"][
@@ -1046,9 +1044,7 @@ def test_ci_coverage_reports_missing_open_source_porting_demo_fields():
     assert "demo.yml missing policy: metadata_pytest_selector" in errors
     assert "demo.yml OS matrix mismatch: missing=['macOS-latest'], extra=[]" in errors
     assert "demo.yml must keep fail-fast: false" in errors
-    assert (
-        "demo.yml missing path filter: push:demos/open-source-porting/**" in errors
-    )
+    assert "demo.yml missing path filter: push:demos/open-source-porting/**" in errors
     assert "demo.yml push and pull_request path filters must match" in errors
     assert "demo.yml must not use broad path filter: crosstl/**" in errors
     assert "demo.yml missing checked artifact verification: runs_demo_check" in errors

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -44,6 +44,42 @@ def _test_function_names(path):
     }
 
 
+def _upstream_source_path(entry):
+    source_prefix = f"{entry['repository']}/blob/{entry['commit']}/"
+    if not entry["sourceUrl"].startswith(source_prefix):
+        raise AssertionError(f"sourceUrl does not match repository/commit: {entry}")
+    return entry["sourceUrl"][len(source_prefix) :]
+
+
+def test_open_source_demo_third_party_notices_cover_manifest_sources():
+    notices = (DEMO_ROOT / "THIRD_PARTY_NOTICES.md").read_text(encoding="utf-8")
+    notice_blocks = [
+        block for block in re.split(r"(?m)^## ", notices) if block.strip()
+    ]
+    missing = []
+
+    for case_dir in sorted(path for path in CASE_ROOT.iterdir() if path.is_dir()):
+        manifest = json.loads((case_dir / "corpus.json").read_text(encoding="utf-8"))
+
+        for entry in manifest["entries"]:
+            source_path = _upstream_source_path(entry)
+            covered = any(
+                entry["repository"] in block
+                and entry["commit"] in block
+                and (source_path in block or entry["sourceUrl"] in block)
+                for block in notice_blocks
+            )
+            if not covered:
+                missing.append(
+                    f"{case_dir.name}:{entry['id']} missing {source_path}"
+                )
+
+    assert not missing, (
+        "Missing third-party notice coverage for manifest sources:\n"
+        + "\n".join(missing)
+    )
+
+
 def test_open_source_demo_cases_have_pinned_manifests_and_references():
     runner = _load_demo_runner()
     case_dirs = sorted(path for path in CASE_ROOT.iterdir() if path.is_dir())

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -53,9 +53,7 @@ def _upstream_source_path(entry):
 
 def test_open_source_demo_third_party_notices_cover_manifest_sources():
     notices = (DEMO_ROOT / "THIRD_PARTY_NOTICES.md").read_text(encoding="utf-8")
-    notice_blocks = [
-        block for block in re.split(r"(?m)^## ", notices) if block.strip()
-    ]
+    notice_blocks = [block for block in re.split(r"(?m)^## ", notices) if block.strip()]
     missing = []
 
     for case_dir in sorted(path for path in CASE_ROOT.iterdir() if path.is_dir()):
@@ -70,13 +68,12 @@ def test_open_source_demo_third_party_notices_cover_manifest_sources():
                 for block in notice_blocks
             )
             if not covered:
-                missing.append(
-                    f"{case_dir.name}:{entry['id']} missing {source_path}"
-                )
+                missing.append(f"{case_dir.name}:{entry['id']} missing {source_path}")
 
-    assert not missing, (
-        "Missing third-party notice coverage for manifest sources:\n"
-        + "\n".join(missing)
+    assert (
+        not missing
+    ), "Missing third-party notice coverage for manifest sources:\n" + "\n".join(
+        missing
     )
 
 
@@ -100,6 +97,7 @@ def test_open_source_demo_case_targets_use_toml_project_config(tmp_path):
     )
 
     assert runner._case_targets(tmp_path) == ["cgl", "opengl", "vulkan"]
+
 
 def test_open_source_demo_cases_have_pinned_manifests_and_references():
     runner = _load_demo_runner()

--- a/tools/ci_coverage.py
+++ b/tools/ci_coverage.py
@@ -1625,8 +1625,7 @@ def open_source_porting_demo_report_artifact_report(
     return {
         "uploads_reports": (
             "actions/upload-artifact@v4" in upload_step
-            and "name: open-source-porting-demo-reports-${{ matrix.os }}"
-            in upload_step
+            and "name: open-source-porting-demo-reports-${{ matrix.os }}" in upload_step
             and "path: support/generated/demo-reports" in upload_step
         ),
         "upload_on_always": "if: always()" in upload_step,
@@ -1707,8 +1706,7 @@ def open_source_porting_demo_report(workflow: str) -> dict[str, Any]:
         )
 
     required_path_filters = {
-        f"push:{path}": path in push_path_filters
-        for path in DEMO_REQUIRED_PATH_FILTERS
+        f"push:{path}": path in push_path_filters for path in DEMO_REQUIRED_PATH_FILTERS
     }
     required_path_filters.update(
         {
@@ -1793,9 +1791,7 @@ def build_report() -> dict[str, Any]:
                 full_workflow,
                 full_workflow_action_text,
             ),
-            "open_source_porting_demo": open_source_porting_demo_report(
-                demo_workflow
-            ),
+            "open_source_porting_demo": open_source_porting_demo_report(demo_workflow),
             "support_matrix": support_matrix_report(support_matrix_workflow),
             "support_issue_sync": support_issue_sync_report(support_issue_workflow),
             "pr_issue_links": pr_issue_links_report(pr_issue_links_workflow),


### PR DESCRIPTION
## Summary

- Add a pytest audit that verifies every open-source demo corpus source is covered by a matching third-party notice block.
- Add missing notice coverage for the Diligent VRS fragment shader and Rust-GPU compute shader source path.

## Validation

- `.venv/bin/python -m pytest tests/test_demo_open_source_porting.py::test_open_source_demo_third_party_notices_cover_manifest_sources`
- `.venv/bin/python -m pytest tests/test_demo_open_source_porting.py`

closes #1372
