### PR TITLE
Emit demo failure summaries

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -62,6 +62,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+    env:
+      DEMO_FAILURE_SUMMARY_DIR: support/generated/demo-reports/${{ matrix.os }}
 
     steps:
       - name: Checkout repository
@@ -112,6 +114,58 @@ jobs:
           python -m pip install -e . pytest
         shell: bash
 
+      - name: Prepare demo failure summary helper
+        shell: bash
+        run: |
+          mkdir -p "$DEMO_FAILURE_SUMMARY_DIR"
+          cat > support/generated/demo-failure-summary.sh <<'BASH'
+          command_text() {
+            local text
+            printf -v text "%q " "$@"
+            printf "%s" "${text% }"
+          }
+
+          demo_case_from_artifact_path() {
+            local relative="${1#demos/open-source-porting/cases/}"
+            printf "%s" "${relative%%/*}"
+          }
+
+          write_demo_failure_summary() {
+            local summary_base="$1"
+            local step_name="$2"
+            local case_name="$3"
+            local target_backend="$4"
+            local category="$5"
+            local failed_command="$6"
+            local report_path="${7:-}"
+            local artifact_path="${8:-}"
+            local summary_dir="${DEMO_FAILURE_SUMMARY_DIR:?DEMO_FAILURE_SUMMARY_DIR is required}"
+            local summary_json="$summary_dir/${summary_base}-failure-summary.json"
+            local summary_markdown="$summary_dir/${summary_base}-failure-summary.md"
+            local summary_args=(
+              python tools/pytest_failure_summary.py
+              --demo-step
+              --demo-step-name "$step_name"
+              --case-name "$case_name"
+              --target-backend "$target_backend"
+              --category "$category"
+              --command "$failed_command"
+              --json-output "$summary_json"
+              --markdown-output "$summary_markdown"
+            )
+            if [ -n "$report_path" ]; then
+              summary_args+=(--report-path "$report_path")
+            fi
+            if [ -n "$artifact_path" ]; then
+              summary_args+=(--artifact-path "$artifact_path")
+            fi
+            "${summary_args[@]}"
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              cat "$summary_markdown" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+          BASH
+
       - name: Run open-source porting demo tests
         id: run_demo_tests
         shell: bash
@@ -141,56 +195,163 @@ jobs:
 
       - name: Verify checked-in demo artifacts
         run: |
-          python demos/open-source-porting/run_demo.py \
-            --check \
-            --reports-dir support/generated/demo-reports/${{ matrix.os }}/artifacts
+          set -euo pipefail
+          source support/generated/demo-failure-summary.sh
+          reports_dir="support/generated/demo-reports/${{ matrix.os }}/artifacts"
+          while IFS= read -r config_path; do
+            config_path="${config_path%$'\r'}"
+            case_dir="$(dirname "$config_path")"
+            case_name="$(basename "$case_dir")"
+            command=(
+              python demos/open-source-porting/run_demo.py
+              --check
+              --case="$case_name"
+              --reports-dir "$reports_dir"
+            )
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-artifacts \
+                "Verify checked-in demo artifacts" \
+                "$case_name" \
+                all \
+                demo_artifact \
+                "$failed_command" \
+                "$reports_dir/$case_name-portability-report.json"
+              exit 1
+            fi
+          done < <(find demos/open-source-porting/cases -mindepth 2 -maxdepth 2 -name crosstl.toml | sort)
         shell: bash
 
       - name: Linux OpenGL smoke checks
         if: runner.os == 'Linux'
         run: |
-          python demos/open-source-porting/run_demo.py \
-            --check \
-            --run-toolchains \
-            --require-toolchain-runs \
-            $(python demos/open-source-porting/run_demo.py --emit-case-args opengl) \
-            --target opengl \
-            --reports-dir support/generated/demo-reports/linux-opengl
+          set -euo pipefail
+          source support/generated/demo-failure-summary.sh
+          reports_dir="support/generated/demo-reports/linux-opengl"
+          case_args=()
+          read -r -a case_args <<< "$(python demos/open-source-porting/run_demo.py --emit-case-args opengl)"
+          for ((index = 1; index < ${#case_args[@]}; index += 2)); do
+            case_name="${case_args[$index]}"
+            case_name="${case_name%$'\r'}"
+            command=(
+              python demos/open-source-porting/run_demo.py
+              --check
+              --run-toolchains
+              --require-toolchain-runs
+              --case="$case_name"
+              --target opengl
+              --reports-dir "$reports_dir"
+            )
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-linux-opengl \
+                "Linux OpenGL smoke checks" \
+                "$case_name" \
+                opengl \
+                demo_toolchain \
+                "$failed_command" \
+                "$reports_dir/$case_name-portability-report.json"
+              exit 1
+            fi
+          done
         shell: bash
 
       - name: Linux Vulkan smoke checks
         if: runner.os == 'Linux'
         run: |
-          python demos/open-source-porting/run_demo.py \
-            --check \
-            --run-toolchains \
-            --require-toolchain-runs \
-            $(python demos/open-source-porting/run_demo.py --emit-case-args vulkan) \
-            --target vulkan \
-            --reports-dir support/generated/demo-reports/linux-vulkan
+          set -euo pipefail
+          source support/generated/demo-failure-summary.sh
+          reports_dir="support/generated/demo-reports/linux-vulkan"
+          case_args=()
+          read -r -a case_args <<< "$(python demos/open-source-porting/run_demo.py --emit-case-args vulkan)"
+          for ((index = 1; index < ${#case_args[@]}; index += 2)); do
+            case_name="${case_args[$index]}"
+            case_name="${case_name%$'\r'}"
+            command=(
+              python demos/open-source-porting/run_demo.py
+              --check
+              --run-toolchains
+              --require-toolchain-runs
+              --case="$case_name"
+              --target vulkan
+              --reports-dir "$reports_dir"
+            )
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-linux-vulkan \
+                "Linux Vulkan smoke checks" \
+                "$case_name" \
+                vulkan \
+                demo_toolchain \
+                "$failed_command" \
+                "$reports_dir/$case_name-portability-report.json"
+              exit 1
+            fi
+          done
         shell: bash
 
       - name: macOS Metal smoke checks
         if: runner.os == 'macOS'
         run: |
-          python demos/open-source-porting/run_demo.py \
-            --check \
-            --run-toolchains \
-            --require-toolchain-runs \
-            $(python demos/open-source-porting/run_demo.py --emit-case-args metal) \
-            --target metal \
-            --reports-dir support/generated/demo-reports/macos-metal
+          set -euo pipefail
+          source support/generated/demo-failure-summary.sh
+          reports_dir="support/generated/demo-reports/macos-metal"
+          case_args=()
+          read -r -a case_args <<< "$(python demos/open-source-porting/run_demo.py --emit-case-args metal)"
+          for ((index = 1; index < ${#case_args[@]}; index += 2)); do
+            case_name="${case_args[$index]}"
+            case_name="${case_name%$'\r'}"
+            command=(
+              python demos/open-source-porting/run_demo.py
+              --check
+              --run-toolchains
+              --require-toolchain-runs
+              --case="$case_name"
+              --target metal
+              --reports-dir "$reports_dir"
+            )
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-macos-metal \
+                "macOS Metal smoke checks" \
+                "$case_name" \
+                metal \
+                demo_toolchain \
+                "$failed_command" \
+                "$reports_dir/$case_name-portability-report.json"
+              exit 1
+            fi
+          done
         shell: bash
 
       - name: macOS Metal compile references
         if: runner.os == 'macOS'
         run: |
           set -euo pipefail
+          source support/generated/demo-failure-summary.sh
           out_dir="${RUNNER_TEMP}/demo-metal-air"
           mkdir -p "$out_dir"
           while IFS= read -r shader; do
+            shader="${shader%$'\r'}"
             output="$(printf '%s' "$shader" | tr '/.' '__').air"
-            xcrun -sdk macosx metal -c "$shader" -o "$out_dir/$output"
+            command=(xcrun -sdk macosx metal -c "$shader" -o "$out_dir/$output")
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-macos-metal-compile \
+                "macOS Metal compile references" \
+                "$(demo_case_from_artifact_path "$shader")" \
+                metal \
+                demo_toolchain \
+                "$failed_command" \
+                "" \
+                "$shader"
+              exit 1
+            fi
           done < <(
             python demos/open-source-porting/run_demo.py \
               --emit-artifact-paths metal \
@@ -201,19 +362,43 @@ jobs:
       - name: Windows DirectX smoke checks
         if: runner.os == 'Windows'
         run: |
-          python demos/open-source-porting/run_demo.py \
-            --check \
-            --run-toolchains \
-            --require-toolchain-runs \
-            $(python demos/open-source-porting/run_demo.py --emit-case-args directx) \
-            --target directx \
-            --reports-dir support/generated/demo-reports/windows-directx
+          set -euo pipefail
+          source support/generated/demo-failure-summary.sh
+          reports_dir="support/generated/demo-reports/windows-directx"
+          case_args=()
+          read -r -a case_args <<< "$(python demos/open-source-porting/run_demo.py --emit-case-args directx)"
+          for ((index = 1; index < ${#case_args[@]}; index += 2)); do
+            case_name="${case_args[$index]}"
+            case_name="${case_name%$'\r'}"
+            command=(
+              python demos/open-source-porting/run_demo.py
+              --check
+              --run-toolchains
+              --require-toolchain-runs
+              --case="$case_name"
+              --target directx
+              --reports-dir "$reports_dir"
+            )
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-windows-directx \
+                "Windows DirectX smoke checks" \
+                "$case_name" \
+                directx \
+                demo_toolchain \
+                "$failed_command" \
+                "$reports_dir/$case_name-portability-report.json"
+              exit 1
+            fi
+          done
         shell: bash
 
       - name: Windows DirectX compile references
         if: runner.os == 'Windows'
         run: |
           set -euo pipefail
+          source support/generated/demo-failure-summary.sh
           out_dir="${RUNNER_TEMP}/demo-directx-dxil"
           mkdir -p "$out_dir"
           compile_hlsl() {
@@ -222,7 +407,20 @@ jobs:
             local profile="$3"
             local output
             output="$(printf '%s_%s_%s' "$shader" "$entry" "$profile" | tr '/.:' '____').dxil"
-            dxc -T "$profile" -E "$entry" "$shader" -Fo "$out_dir/$output"
+            command=(dxc -T "$profile" -E "$entry" "$shader" -Fo "$out_dir/$output")
+            failed_command="$(command_text "${command[@]}")"
+            if ! "${command[@]}"; then
+              write_demo_failure_summary \
+                open-source-porting-demo-windows-directx-compile \
+                "Windows DirectX compile references" \
+                "$(demo_case_from_artifact_path "$shader")" \
+                directx \
+                demo_toolchain \
+                "$failed_command" \
+                "" \
+                "$shader"
+              return 1
+            fi
           }
           while read -r shader entry profile; do
             shader="${shader%$'\r'}"
@@ -246,7 +444,7 @@ jobs:
           retention-days: 30
 
       - name: Upload demo failure summary
-        if: failure() && steps.run_demo_tests.outcome == 'failure'
+        if: failure()
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
@@ -255,5 +453,7 @@ jobs:
             support/generated/demo-reports/${{ matrix.os }}/open-source-porting-demo-pytest.xml
             support/generated/demo-reports/${{ matrix.os }}/open-source-porting-demo-failure-summary.json
             support/generated/demo-reports/${{ matrix.os }}/open-source-porting-demo-failure-summary.md
+            support/generated/demo-reports/**/*-failure-summary.json
+            support/generated/demo-reports/**/*-failure-summary.md
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -206,7 +206,7 @@ jobs:
               python demos/open-source-porting/run_demo.py
               --check
               --case="$case_name"
-              --reports-dir "$reports_dir"
+              --reports-dir support/generated/demo-reports/${{ matrix.os }}/artifacts
             )
             failed_command="$(command_text "${command[@]}")"
             if ! "${command[@]}"; then

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -328,14 +328,17 @@ def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
     assert "name: open-source-porting-demo-reports-${{ matrix.os }}" in demo
     assert "name: Upload demo failure summary" in demo
     assert "name: open-source-porting-demo-failure-summary-${{ matrix.os }}" in demo
-    assert "DEMO_FAILURE_SUMMARY_DIR: support/generated/demo-reports/${{ matrix.os }}" in demo
+    assert (
+        "DEMO_FAILURE_SUMMARY_DIR: support/generated/demo-reports/${{ matrix.os }}"
+        in demo
+    )
     assert "name: Prepare demo failure summary helper" in demo
     assert "write_demo_failure_summary()" in demo
     assert "python tools/pytest_failure_summary.py" in demo
     assert "--demo-step" in demo
-    assert "--case-name \"$case_name\"" in demo
-    assert "--target-backend \"$target_backend\"" in demo
-    assert "--command \"$failed_command\"" in demo
+    assert '--case-name "$case_name"' in demo
+    assert '--target-backend "$target_backend"' in demo
+    assert '--command "$failed_command"' in demo
     assert "demo_artifact" in demo
     assert "demo_toolchain" in demo
     for summary_base in (
@@ -348,8 +351,8 @@ def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
         "open-source-porting-demo-windows-directx-compile",
     ):
         assert summary_base in demo
-    assert '${summary_base}-failure-summary.json' in demo
-    assert '${summary_base}-failure-summary.md' in demo
+    assert "${summary_base}-failure-summary.json" in demo
+    assert "${summary_base}-failure-summary.md" in demo
     assert "profile=\"${profile%$'\\r'}\"" in demo
     assert "if: failure() && steps.run_demo_tests.outcome == 'failure'" in demo
     assert "support/generated/demo-reports/**/*-failure-summary.json" in demo
@@ -477,9 +480,7 @@ def test_ci_coverage_report_summarizes_required_workflow_dimensions():
         ].values()
     )
     assert all(
-        report["workflows"]["open_source_porting_demo"][
-            "checked_in_artifacts"
-        ].values()
+        report["workflows"]["open_source_porting_demo"]["checked_in_artifacts"].values()
     )
     assert all(
         report["workflows"]["open_source_porting_demo"][
@@ -1070,9 +1071,7 @@ def test_ci_coverage_reports_missing_open_source_porting_demo_fields():
     assert "demo.yml missing policy: metadata_pytest_selector" in errors
     assert "demo.yml OS matrix mismatch: missing=['macOS-latest'], extra=[]" in errors
     assert "demo.yml must keep fail-fast: false" in errors
-    assert (
-        "demo.yml missing path filter: push:demos/open-source-porting/**" in errors
-    )
+    assert "demo.yml missing path filter: push:demos/open-source-porting/**" in errors
     assert "demo.yml push and pull_request path filters must match" in errors
     assert "demo.yml must not use broad path filter: crosstl/**" in errors
     assert "demo.yml missing checked artifact verification: runs_demo_check" in errors

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -328,8 +328,32 @@ def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
     assert "name: open-source-porting-demo-reports-${{ matrix.os }}" in demo
     assert "name: Upload demo failure summary" in demo
     assert "name: open-source-porting-demo-failure-summary-${{ matrix.os }}" in demo
+    assert "DEMO_FAILURE_SUMMARY_DIR: support/generated/demo-reports/${{ matrix.os }}" in demo
+    assert "name: Prepare demo failure summary helper" in demo
+    assert "write_demo_failure_summary()" in demo
+    assert "python tools/pytest_failure_summary.py" in demo
+    assert "--demo-step" in demo
+    assert "--case-name \"$case_name\"" in demo
+    assert "--target-backend \"$target_backend\"" in demo
+    assert "--command \"$failed_command\"" in demo
+    assert "demo_artifact" in demo
+    assert "demo_toolchain" in demo
+    for summary_base in (
+        "open-source-porting-demo-artifacts",
+        "open-source-porting-demo-linux-opengl",
+        "open-source-porting-demo-linux-vulkan",
+        "open-source-porting-demo-macos-metal",
+        "open-source-porting-demo-macos-metal-compile",
+        "open-source-porting-demo-windows-directx",
+        "open-source-porting-demo-windows-directx-compile",
+    ):
+        assert summary_base in demo
+    assert '${summary_base}-failure-summary.json' in demo
+    assert '${summary_base}-failure-summary.md' in demo
     assert "profile=\"${profile%$'\\r'}\"" in demo
     assert "if: failure() && steps.run_demo_tests.outcome == 'failure'" in demo
+    assert "support/generated/demo-reports/**/*-failure-summary.json" in demo
+    assert "support/generated/demo-reports/**/*-failure-summary.md" in demo
     assert "if-no-files-found: ignore" in demo
     assert "retention-days: 30" in demo
 

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -201,7 +201,7 @@ def _assert_workflow_step_uses_case_generator(
     block = _workflow_step_block(workflow, step_name)
     assert f"--emit-case-args {target}" in block
     assert '--case="$case_name"' in block
-    assert 'write_demo_failure_summary \\' in block
+    assert "write_demo_failure_summary \\" in block
     assert "--case " not in block
 
 

--- a/tests/test_demo_open_source_porting.py
+++ b/tests/test_demo_open_source_porting.py
@@ -149,6 +149,13 @@ def test_open_source_demo_workflow_runs_platform_toolchain_smokes():
     assert "--emit-directx-compile-jobs" in workflow
     assert "profile=\"${profile%$'\\r'}\"" in workflow
     assert "open-source-porting-demo-reports-${{ matrix.os }}" in workflow
+    assert "write_demo_failure_summary" in workflow
+    assert "--demo-step" in workflow
+    assert "open-source-porting-demo-linux-opengl" in workflow
+    assert "open-source-porting-demo-linux-vulkan" in workflow
+    assert "open-source-porting-demo-macos-metal-compile" in workflow
+    assert "open-source-porting-demo-windows-directx-compile" in workflow
+    assert "support/generated/demo-reports/**/*-failure-summary.json" in workflow
 
 
 def _workflow_step_block(workflow: str, step_name: str) -> str:
@@ -171,6 +178,8 @@ def _assert_workflow_step_uses_case_generator(
 ) -> None:
     block = _workflow_step_block(workflow, step_name)
     assert f"--emit-case-args {target}" in block
+    assert '--case="$case_name"' in block
+    assert 'write_demo_failure_summary \\' in block
     assert "--case " not in block
 
 

--- a/tests/test_pytest_failure_summary.py
+++ b/tests/test_pytest_failure_summary.py
@@ -142,6 +142,65 @@ def test_cli_writes_json_and_markdown_outputs(tmp_path):
     assert "support_automation" in markdown
 
 
+def test_cli_writes_demo_step_failure_summary(tmp_path):
+    json_output = tmp_path / "demo-summary.json"
+    markdown_output = tmp_path / "demo-summary.md"
+    report_path = (
+        "support/generated/demo-reports/linux-opengl/"
+        "glfw-opengl-triangle-portability-report.json"
+    )
+    command = (
+        "python demos/open-source-porting/run_demo.py --check "
+        "--case glfw-opengl-triangle --target opengl"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--demo-step",
+            "--demo-step-name",
+            "Linux OpenGL smoke checks",
+            "--case-name",
+            "glfw-opengl-triangle",
+            "--target-backend",
+            "opengl",
+            "--command",
+            command,
+            "--category",
+            "demo_toolchain",
+            "--report-path",
+            report_path,
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(json_output.read_text(encoding="utf-8"))
+    markdown = markdown_output.read_text(encoding="utf-8")
+    failure = payload["failures"][0]
+    assert payload["generator"] == "tools/pytest_failure_summary.py"
+    assert payload["summary"]["categories"] == {"demo_toolchain": 1}
+    assert payload["summary"]["backends"] == {"opengl": 1}
+    assert payload["reports"][0]["failed_testcases"] == [failure]
+    assert failure["name"] == "glfw-opengl-triangle"
+    assert failure["backend"] == "opengl"
+    assert failure["command"] == command
+    assert failure["report_path"] == report_path
+    assert "case=glfw-opengl-triangle" in failure["message"]
+    assert "target=opengl" in failure["message"]
+    assert "command=python demos/open-source-porting/run_demo.py" in failure["message"]
+    assert "demo_toolchain" in markdown
+    assert "glfw-opengl-triangle" in markdown
+
+
 def test_cli_writes_clean_workflow_summary_without_junit_input(tmp_path):
     json_output = tmp_path / "clean-summary.json"
     markdown_output = tmp_path / "clean-summary.md"

--- a/tools/ci_coverage.py
+++ b/tools/ci_coverage.py
@@ -1604,7 +1604,13 @@ def open_source_porting_demo_failure_summary_report(
             and json_report in upload_step
             and markdown_report in upload_step
         ),
-        "upload_on_pytest_failure": failure_condition in upload_step,
+        # The demo upload step intentionally fires on any step failure
+        # (artifact verification and toolchain smoke checks emit their own
+        # failure summaries), so accept the broader ``if: failure()`` guard in
+        # addition to the run-scoped condition used by the test job.
+        "upload_on_pytest_failure": (
+            failure_condition in upload_step or "if: failure()" in upload_step
+        ),
         "upload_ignores_missing_files": "if-no-files-found: ignore" in upload_step,
         "upload_retention": "retention-days: 30" in upload_step,
         "upload_nonfatal": "continue-on-error: true" in upload_step,
@@ -1625,8 +1631,7 @@ def open_source_porting_demo_report_artifact_report(
     return {
         "uploads_reports": (
             "actions/upload-artifact@v4" in upload_step
-            and "name: open-source-porting-demo-reports-${{ matrix.os }}"
-            in upload_step
+            and "name: open-source-porting-demo-reports-${{ matrix.os }}" in upload_step
             and "path: support/generated/demo-reports" in upload_step
         ),
         "upload_on_always": "if: always()" in upload_step,
@@ -1707,8 +1712,7 @@ def open_source_porting_demo_report(workflow: str) -> dict[str, Any]:
         )
 
     required_path_filters = {
-        f"push:{path}": path in push_path_filters
-        for path in DEMO_REQUIRED_PATH_FILTERS
+        f"push:{path}": path in push_path_filters for path in DEMO_REQUIRED_PATH_FILTERS
     }
     required_path_filters.update(
         {
@@ -1793,9 +1797,7 @@ def build_report() -> dict[str, Any]:
                 full_workflow,
                 full_workflow_action_text,
             ),
-            "open_source_porting_demo": open_source_porting_demo_report(
-                demo_workflow
-            ),
+            "open_source_porting_demo": open_source_porting_demo_report(demo_workflow),
             "support_matrix": support_matrix_report(support_matrix_workflow),
             "support_issue_sync": support_issue_sync_report(support_issue_workflow),
             "pr_issue_links": pr_issue_links_report(pr_issue_links_workflow),

--- a/tools/pytest_failure_summary.py
+++ b/tools/pytest_failure_summary.py
@@ -223,6 +223,90 @@ def build_summary(
     }
 
 
+def demo_step_message(
+    *,
+    step_name: str,
+    case_name: str,
+    target_backend: str,
+    command: str,
+    report_path: str,
+    artifact_path: str,
+) -> str:
+    details = [
+        f"Demo step failed: {step_name}",
+        f"case={case_name}",
+        f"target={target_backend}",
+        f"command={command}",
+    ]
+    if report_path:
+        details.append(f"report={report_path}")
+    if artifact_path:
+        details.append(f"artifact={artifact_path}")
+    return "; ".join(details)
+
+
+def build_demo_step_summary(
+    *,
+    step_name: str,
+    case_name: str,
+    target_backend: str,
+    command: str,
+    category: str,
+    report_path: str = "",
+    artifact_path: str = "",
+) -> dict[str, Any]:
+    file_path = report_path or artifact_path or f"demo-step:{step_name}"
+    failure = {
+        "nodeid": f"demo::{step_name}::{case_name}",
+        "file": file_path,
+        "name": case_name,
+        "kind": "failure",
+        "category": category,
+        "backend": target_backend,
+        "message": demo_step_message(
+            step_name=step_name,
+            case_name=case_name,
+            target_backend=target_backend,
+            command=command,
+            report_path=report_path,
+            artifact_path=artifact_path,
+        )[:1000],
+        "case": case_name,
+        "target_backend": target_backend,
+        "command": command,
+    }
+    if report_path:
+        failure["report_path"] = report_path
+    if artifact_path:
+        failure["artifact_path"] = artifact_path
+    report = {
+        "path": file_path,
+        "tests": 1,
+        "failures": 1,
+        "errors": 0,
+        "skipped": 0,
+        "failed_testcases": [failure],
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generator": GENERATOR,
+        "summary": {
+            "report_count": 1,
+            "load_error_count": 0,
+            "testcase_count": 1,
+            "failure_count": 1,
+            "error_count": 0,
+            "skipped_count": 0,
+            "failed_testcase_count": 1,
+            "categories": {category: 1},
+            "backends": {target_backend: 1},
+        },
+        "reports": [report],
+        "clean_workflow_runs": [],
+        "failures": [failure],
+    }
+
+
 def markdown_table(headers: list[str], rows: list[list[Any]]) -> str:
     def cell(value: Any) -> str:
         return str(value).replace("|", "\\|").replace("\n", " ").strip()
@@ -277,13 +361,15 @@ def render_markdown(summary: dict[str, Any], sample_limit: int = 20) -> str:
     if summary["failures"]:
         lines.extend(["", "## Failure Samples", ""])
         for failure in summary["failures"][:sample_limit]:
-            lines.append(
-                "- `{}`: {} / {}".format(
-                    failure["nodeid"],
-                    failure["category"],
-                    failure["backend"],
-                )
+            message = str(failure.get("message", "")).splitlines()[0][:240]
+            sample = "- `{}`: {} / {}".format(
+                failure["nodeid"],
+                failure["category"],
+                failure["backend"],
             )
+            if message:
+                sample += f" - {message}"
+            lines.append(sample)
         omitted = len(summary["failures"]) - sample_limit
         if omitted > 0:
             lines.append(f"- Additional failures omitted: {omitted}")
@@ -302,6 +388,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("junit_xml", nargs="*", type=Path)
     parser.add_argument(
+        "--demo-step",
+        action="store_true",
+        help="Write a synthetic failure summary for a failed demo workflow step.",
+    )
+    parser.add_argument("--demo-step-name", default="")
+    parser.add_argument("--case-name", default="")
+    parser.add_argument("--target-backend", default="")
+    parser.add_argument("--command", default="")
+    parser.add_argument("--category", default="demo_toolchain")
+    parser.add_argument("--report-path", default="")
+    parser.add_argument("--artifact-path", default="")
+    parser.add_argument(
         "--clean-workflow",
         help="Record a completed workflow with no pytest failures.",
     )
@@ -312,7 +410,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--markdown-output", type=Path)
     parser.add_argument("--sample-limit", type=int, default=20)
     args = parser.parse_args(argv)
-    if not args.junit_xml and not args.clean_workflow:
+    if args.demo_step:
+        required = {
+            "--demo-step-name": args.demo_step_name,
+            "--case-name": args.case_name,
+            "--target-backend": args.target_backend,
+            "--command": args.command,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            parser.error("--demo-step requires " + ", ".join(missing))
+    if not args.junit_xml and not args.clean_workflow and not args.demo_step:
         parser.error("at least one junit_xml path or --clean-workflow is required")
     return args
 
@@ -329,7 +437,18 @@ def main(argv: list[str] | None = None) -> int:
                 "head_sha": args.clean_head_sha,
             }
         )
-    summary = build_summary(args.junit_xml, clean_workflow_runs=clean_workflow_runs)
+    if args.demo_step:
+        summary = build_demo_step_summary(
+            step_name=args.demo_step_name,
+            case_name=args.case_name,
+            target_backend=args.target_backend,
+            command=args.command,
+            category=args.category,
+            report_path=args.report_path,
+            artifact_path=args.artifact_path,
+        )
+    else:
+        summary = build_summary(args.junit_xml, clean_workflow_runs=clean_workflow_runs)
     json_text = stable_json(summary)
     markdown_text = render_markdown(summary, sample_limit=args.sample_limit)
     if args.json_output is None and args.markdown_output is None:


### PR DESCRIPTION
## Summary
- add demo-step mode to the existing failure summary generator
- write summaries for demo artifact, backend smoke, and native compile-reference failures
- upload all generated demo `*-failure-summary` files for support issue sync

## Validation
- `pytest tests/test_ci_workflows.py tests/test_demo_open_source_porting.py tests/test_pytest_failure_summary.py`

closes #1367