### PR TITLE
Add MLX runtime readiness planning

### DIFF
--- a/integrations/mlx/README.md
+++ b/integrations/mlx/README.md
@@ -16,7 +16,9 @@ The current harness verifies:
   `ternary.metal`;
 - Vulkan assembly and validator checks when SPIR-V tools are available and no
   active validation blocker is tracked;
-- OpenGL artifact generation for `arange.metal`.
+- OpenGL artifact generation for `arange.metal`;
+- runtime-test manifest and runtime-test plan generation for reduced `arange`
+  readiness probes across DirectX, OpenGL, and Vulkan.
 
 Pull requests run the reduced frontier above. Scheduled and manually triggered
 CI also run the full-corpus artifact scout with finite Metal template
@@ -40,6 +42,11 @@ This is shader/kernel artifact coverage. It does not claim that the MLX host
 runtime has been ported to Direct3D, OpenGL, or Vulkan. Running the upstream MLX
 GPU unit tests against non-Metal targets requires runtime adapters, host-side
 dispatch wiring, data layout validation, and backend-specific build integration.
+The reduced harness now emits runtime readiness artifacts so those gaps are
+visible in CI reports without claiming runtime parity. The current readiness
+plans are blocked because translated project artifacts do not yet carry enough
+entry point, resource binding, and dispatch metadata for adapter-backed
+execution.
 
 ## Running Locally
 
@@ -85,10 +92,11 @@ the reduced DirectX/Vulkan frontier. CrossGL/crosstl#1354 tracks the remaining
 full-corpus Metal template materialization work for backend artifacts.
 CrossGL/crosstl#1376 tracks bounded runtime for the scheduled full-corpus scout.
 CrossGL/crosstl#1312 tracks native toolchain validation coverage for project
-CI. Future scouts should add issue-backed blockers only when there are concrete
-repros. Host runtime integration gaps should be handled in MLX-specific
-integration code or downstream runtime adapters, not hidden as shader
-translation successes.
+CI. CrossGL/crosstl#1388 tracks the artifact execution metadata required by
+runtime-test manifests and native adapters. Future scouts should add
+issue-backed blockers only when there are concrete repros. Host runtime
+integration gaps should be handled in repository integration code or downstream
+runtime adapters, not hidden as shader translation successes.
 
 ## Resolved Frontier Issues
 

--- a/integrations/mlx/expected-gaps.json
+++ b/integrations/mlx/expected-gaps.json
@@ -20,6 +20,23 @@
     "target": "opengl",
     "artifacts": 1
   },
+  "runtime_readiness_status": {
+    "status": "blocked-by-tracked-issues",
+    "source": "mlx/backend/metal/kernels/arange.metal",
+    "targets": [
+      "directx",
+      "opengl",
+      "vulkan"
+    ],
+    "blocked_by": [
+      "https://github.com/CrossGL/crosstl/issues/1388"
+    ],
+    "diagnostics_by_code": {
+      "project.runtime-test-manifest.dispatch-unavailable": 3,
+      "project.runtime-test-manifest.entry-points-unavailable": 3,
+      "project.runtime-test-manifest.resource-bindings-unavailable": 3
+    }
+  },
   "full_corpus_scout": {
     "status": "blocked-by-tracked-issues",
     "sources": 40,
@@ -63,7 +80,8 @@
     "https://github.com/CrossGL/crosstl/issues/1362",
     "https://github.com/CrossGL/crosstl/issues/1312",
     "https://github.com/CrossGL/crosstl/issues/1354",
-    "https://github.com/CrossGL/crosstl/issues/1376"
+    "https://github.com/CrossGL/crosstl/issues/1376",
+    "https://github.com/CrossGL/crosstl/issues/1388"
   ],
   "resolved_issues": [
     "https://github.com/CrossGL/crosstl/issues/1300",

--- a/integrations/mlx/run_mlx_porting.py
+++ b/integrations/mlx/run_mlx_porting.py
@@ -8,9 +8,15 @@ import json
 import shutil
 import subprocess
 import sys
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+
+from crosstl.project.runtime_verification import (
+    build_runtime_test_manifest,
+    plan_runtime_test_manifest,
+)
 
 MLX_REPOSITORY = "https://github.com/ml-explore/mlx"
 MLX_COMMIT = "968d264f2903d578e699c4452a4dbf48633921aa"
@@ -38,10 +44,19 @@ FULL_CORPUS_TRANSLATION_TRACKED_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1354",
     "https://github.com/CrossGL/crosstl/issues/1376",
 )
+RUNTIME_READINESS_TRACKED_ISSUES = ("https://github.com/CrossGL/crosstl/issues/1388",)
+RUNTIME_READINESS_DIAGNOSTIC_CODES = frozenset(
+    (
+        "project.runtime-test-manifest.entry-points-unavailable",
+        "project.runtime-test-manifest.resource-bindings-unavailable",
+        "project.runtime-test-manifest.dispatch-unavailable",
+    )
+)
 FULL_CORPUS_TRACKED_ISSUES = (
     *FRONTIER_VALIDATION_TRACKED_ISSUES,
     "https://github.com/CrossGL/crosstl/issues/1312",
     *FULL_CORPUS_TRANSLATION_TRACKED_ISSUES,
+    *RUNTIME_READINESS_TRACKED_ISSUES,
 )
 RESOLVED_FRONTIER_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1317",
@@ -159,6 +174,14 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise PortingCheckError(f"{path} must contain a JSON object")
     return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _require(condition: bool, message: str) -> None:
@@ -562,6 +585,189 @@ def _check_arange_opengl(
     }
 
 
+def _runtime_readiness_fixture(target: str) -> dict[str, Any]:
+    return {
+        "id": f"mlx-arange-{target}-runtime-readiness",
+        "selector": {
+            "source": MLX_ARANGE_SOURCE,
+            "target": target,
+        },
+        "inputs": [
+            {
+                "name": "start",
+                "kind": "scalar",
+                "dtype": "uint32",
+                "value": 0,
+            },
+            {
+                "name": "step",
+                "kind": "scalar",
+                "dtype": "uint32",
+                "value": 1,
+            },
+        ],
+        "expectedOutputs": [
+            {
+                "name": "out",
+                "kind": "buffer",
+                "dtype": "uint32",
+                "shape": [4],
+                "values": [0, 1, 2, 3],
+            }
+        ],
+        "metadata": {
+            "repository": "mlx",
+            "source": MLX_ARANGE_SOURCE,
+            "purpose": "runtime-readiness-metadata-probe",
+        },
+    }
+
+
+def _runtime_readiness_fixture_metadata(targets: Sequence[str]) -> dict[str, Any]:
+    return {
+        "kind": "crosstl-project-runtime-fixture-metadata",
+        "metadata": {
+            "repository": "mlx",
+            "fixtureSet": "reduced-arange-runtime-readiness",
+            "scope": "artifact-execution-metadata-readiness",
+            "shaderArtifactsOnly": True,
+            "runtimeIntegrationIncluded": False,
+            "trackedIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
+        },
+        "fixtures": [_runtime_readiness_fixture(target) for target in targets],
+    }
+
+
+def _diagnostics_by_code(diagnostics: Sequence[Any]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for diagnostic in diagnostics:
+        if not isinstance(diagnostic, Mapping):
+            continue
+        code = diagnostic.get("code")
+        if isinstance(code, str) and code:
+            counts[code] += 1
+    return dict(sorted(counts.items()))
+
+
+def _plan_runtime_readiness_for_report(
+    *,
+    mlx_root: Path,
+    report_dir: Path,
+    name: str,
+    artifact_report: Path,
+    targets: Sequence[str],
+) -> dict[str, Any]:
+    _require(
+        artifact_report.is_file(),
+        f"runtime readiness artifact report is missing: {artifact_report}",
+    )
+    metadata_path = report_dir / f"{name}.fixture-metadata.json"
+    manifest_path = report_dir / f"{name}.runtime-test-manifest.json"
+    plan_path = report_dir / f"{name}.runtime-test-plan.json"
+    metadata = _runtime_readiness_fixture_metadata(targets)
+    _write_json(metadata_path, metadata)
+    manifest = build_runtime_test_manifest(
+        artifact_report,
+        metadata_path,
+        project_root=mlx_root,
+    )
+    _write_json(manifest_path, manifest)
+    plan = plan_runtime_test_manifest(
+        artifact_report,
+        manifest,
+        project_root=mlx_root,
+    )
+    _write_json(plan_path, plan)
+
+    diagnostic_counts = manifest.get("diagnosticCounts", {})
+    _require(
+        isinstance(diagnostic_counts, dict),
+        "runtime readiness diagnostic counts must be an object",
+    )
+    _require(
+        diagnostic_counts.get("error", 0) == 0,
+        "runtime readiness manifest reported fixture or artifact selection errors",
+    )
+    diagnostics_by_code = _diagnostics_by_code(manifest.get("diagnostics", []))
+    metadata_gap_codes = sorted(
+        code
+        for code in diagnostics_by_code
+        if code in RUNTIME_READINESS_DIAGNOSTIC_CODES
+    )
+    if metadata_gap_codes:
+        _require(
+            RUNTIME_READINESS_TRACKED_ISSUES,
+            "runtime readiness manifest reported artifact execution metadata gaps "
+            "without tracked issue references",
+        )
+    status = "blocked-by-tracked-issues" if metadata_gap_codes else "planned"
+    plan_summary = plan.get("summary", {})
+    _require(isinstance(plan_summary, dict), "runtime readiness plan summary missing")
+    manifest_summary = manifest.get("summary", {})
+    _require(
+        isinstance(manifest_summary, dict),
+        "runtime readiness manifest summary missing",
+    )
+    return {
+        "name": name,
+        "status": status,
+        "artifactReport": _relpath(artifact_report, mlx_root),
+        "fixtureMetadata": _relpath(metadata_path, mlx_root),
+        "runtimeTestManifest": _relpath(manifest_path, mlx_root),
+        "runtimeTestPlan": _relpath(plan_path, mlx_root),
+        "targets": list(targets),
+        "testCount": manifest_summary.get("testCount", 0),
+        "diagnosticCounts": diagnostic_counts,
+        "diagnosticsByCode": diagnostics_by_code,
+        "runtimePlanSummary": plan_summary,
+        "metadataGapCodes": metadata_gap_codes,
+        "shaderArtifactsOnly": True,
+        "runtimeIntegrationIncluded": False,
+        "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
+    }
+
+
+def _plan_reduced_runtime_readiness(
+    mlx_root: Path,
+    report_dir: Path,
+) -> dict[str, Any]:
+    reports = [
+        _plan_runtime_readiness_for_report(
+            mlx_root=mlx_root,
+            report_dir=report_dir,
+            name="directx-vulkan-runtime-readiness",
+            artifact_report=report_dir / "directx-vulkan-frontier.json",
+            targets=("directx", "vulkan"),
+        ),
+        _plan_runtime_readiness_for_report(
+            mlx_root=mlx_root,
+            report_dir=report_dir,
+            name="opengl-runtime-readiness",
+            artifact_report=report_dir / "arange-opengl.json",
+            targets=("opengl",),
+        ),
+    ]
+    status = (
+        "blocked-by-tracked-issues"
+        if any(report["status"] == "blocked-by-tracked-issues" for report in reports)
+        else "planned"
+    )
+    diagnostics_by_code: Counter[str] = Counter()
+    for report in reports:
+        diagnostics_by_code.update(report.get("diagnosticsByCode", {}))
+    return {
+        "name": "runtime-readiness",
+        "status": status,
+        "reports": reports,
+        "targets": ["directx", "opengl", "vulkan"],
+        "testCount": sum(int(report.get("testCount", 0)) for report in reports),
+        "diagnosticsByCode": dict(sorted(diagnostics_by_code.items())),
+        "shaderArtifactsOnly": True,
+        "runtimeIntegrationIncluded": False,
+        "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
+    }
+
+
 def _translate_full_corpus(
     mlx_root: Path,
     work_dir: Path,
@@ -758,26 +964,32 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
         ),
     ]
     if args.mode == REDUCED_FRONTIER_MODE:
-        checks.extend(
-            [
-                _translate_directx_vulkan_frontier(
-                    mlx_root,
-                    work_dir,
-                    config_dir,
-                    report_dir,
-                    log_dir,
-                    args.python,
-                    require_vulkan_toolchain=args.require_vulkan_toolchain,
-                ),
-                _check_arange_opengl(
-                    mlx_root,
-                    work_dir,
-                    config_dir,
-                    report_dir,
-                    log_dir,
-                    args.python,
-                ),
-            ]
+        checks.append(
+            _translate_directx_vulkan_frontier(
+                mlx_root,
+                work_dir,
+                config_dir,
+                report_dir,
+                log_dir,
+                args.python,
+                require_vulkan_toolchain=args.require_vulkan_toolchain,
+            )
+        )
+        checks.append(
+            _check_arange_opengl(
+                mlx_root,
+                work_dir,
+                config_dir,
+                report_dir,
+                log_dir,
+                args.python,
+            )
+        )
+        checks.append(
+            _plan_reduced_runtime_readiness(
+                mlx_root,
+                report_dir,
+            )
         )
     elif args.mode == FULL_CORPUS_MODE:
         checks.append(
@@ -808,6 +1020,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             "fullCorpusExpectedArtifactCount": FULL_CORPUS_EXPECTED_ARTIFACT_COUNT,
             "shaderArtifactsOnly": True,
             "runtimeIntegrationIncluded": False,
+            "runtimeReadinessIncluded": args.mode == REDUCED_FRONTIER_MODE,
         },
         "trackedIssues": list(FULL_CORPUS_TRACKED_ISSUES),
         "resolvedFrontierIssues": list(RESOLVED_FRONTIER_ISSUES),

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2135,7 +2135,9 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "FULL_CORPUS_TRANSLATION_TIMEOUT_SECONDS = 900" in harness
     assert "blocked-by-tracked-issues" in harness
     assert "without tracked issue references" in harness
-    for tracked_issue_number in (1312, 1354, 1362, 1376):
+    assert "runtime-readiness" in harness
+    assert "runtime-test-manifest" in harness
+    for tracked_issue_number in (1312, 1354, 1362, 1376, 1388):
         assert f"https://github.com/CrossGL/crosstl/issues/{tracked_issue_number}" in (
             harness
         )

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -39,6 +39,64 @@ def _full_corpus_report(module, **summary_overrides):
     return {"summary": summary, "validation": {"summary": {"failedCount": 0}}}
 
 
+def _translated_arange_report(module, target):
+    return {
+        "kind": "crosstl-project-portability-report",
+        "project": {"targets": [target]},
+        "artifacts": [
+            {
+                "source": module.MLX_ARANGE_SOURCE,
+                "path": f"out/{target}/arange",
+                "target": target,
+                "sourceBackend": "metal",
+                "status": "translated",
+            }
+        ],
+    }
+
+
+def test_runtime_readiness_reports_tracked_artifact_metadata_gaps(tmp_path):
+    module = _load_harness()
+    mlx_root = tmp_path / "mlx"
+    report_dir = mlx_root / ".crosstl-mlx-porting" / "reports"
+    report_dir.mkdir(parents=True)
+    artifact_report = report_dir / "directx-readiness-artifacts.json"
+    artifact_report.write_text(
+        json.dumps(_translated_arange_report(module, "directx")),
+        encoding="utf-8",
+    )
+
+    result = module._plan_runtime_readiness_for_report(
+        mlx_root=mlx_root,
+        report_dir=report_dir,
+        name="directx-runtime-readiness",
+        artifact_report=artifact_report,
+        targets=("directx",),
+    )
+
+    assert result["status"] == "blocked-by-tracked-issues"
+    assert result["trackedRuntimeIssues"] == [
+        "https://github.com/CrossGL/crosstl/issues/1388"
+    ]
+    assert result["testCount"] == 1
+    assert result["diagnosticCounts"] == {"error": 0, "note": 0, "warning": 3}
+    assert result["metadataGapCodes"] == [
+        "project.runtime-test-manifest.dispatch-unavailable",
+        "project.runtime-test-manifest.entry-points-unavailable",
+        "project.runtime-test-manifest.resource-bindings-unavailable",
+    ]
+    assert (mlx_root / result["fixtureMetadata"]).is_file()
+    assert (mlx_root / result["runtimeTestManifest"]).is_file()
+    assert (mlx_root / result["runtimeTestPlan"]).is_file()
+
+    manifest = json.loads((mlx_root / result["runtimeTestManifest"]).read_text())
+    assert manifest["success"] is True
+    assert manifest["summary"]["testsByTarget"] == {"directx": 1}
+    assert manifest["metadata"]["trackedIssues"] == [
+        "https://github.com/CrossGL/crosstl/issues/1388"
+    ]
+
+
 def test_full_corpus_mode_writes_bounded_config_and_checks_counts(
     tmp_path, monkeypatch
 ):
@@ -266,3 +324,66 @@ def test_run_checks_full_corpus_mode_skips_reduced_frontier(tmp_path, monkeypatc
     assert result["scope"]["mode"] == module.FULL_CORPUS_MODE
     assert result["scope"]["fullCorpusExpectedUnitCount"] == 40
     assert result["scope"]["fullCorpusExpectedArtifactCount"] == 120
+
+
+def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkeypatch):
+    module = _load_harness()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+
+    monkeypatch.setattr(
+        module,
+        "_verify_mlx_checkout",
+        lambda *args: {"name": "mlx-checkout", "status": "passed"},
+    )
+    monkeypatch.setattr(
+        module,
+        "_scan_metal_kernels",
+        lambda *args: {"name": "metal-kernel-scan", "status": "passed"},
+    )
+    monkeypatch.setattr(
+        module,
+        "_translate_directx_vulkan_frontier",
+        lambda *args, **kwargs: {
+            "name": "directx-vulkan-frontier",
+            "status": "passed",
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "_check_arange_opengl",
+        lambda *args: {"name": "arange-opengl", "status": "passed"},
+    )
+    monkeypatch.setattr(
+        module,
+        "_plan_reduced_runtime_readiness",
+        lambda *args: {
+            "name": "runtime-readiness",
+            "status": "blocked-by-tracked-issues",
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "_translate_full_corpus",
+        lambda *args: pytest.fail("full-corpus check should not run"),
+    )
+
+    result = module.run_checks(
+        SimpleNamespace(
+            mlx_root=str(mlx_root),
+            work_dir=None,
+            no_clean=False,
+            python="python",
+            require_vulkan_toolchain=False,
+            mode=module.REDUCED_FRONTIER_MODE,
+        )
+    )
+
+    assert [check["name"] for check in result["checks"]] == [
+        "mlx-checkout",
+        "metal-kernel-scan",
+        "directx-vulkan-frontier",
+        "arange-opengl",
+        "runtime-readiness",
+    ]
+    assert result["scope"]["runtimeReadinessIncluded"] is True


### PR DESCRIPTION
## Summary

- Generate MLX runtime-readiness fixture metadata, runtime-test manifests, and runtime-test plans for the reduced arange probe across DirectX, OpenGL, and Vulkan.
- Surface the current artifact execution metadata gap behind #1388 without claiming runtime parity or native adapter execution.
- Update MLX expected gaps, README scope, and CI workflow contract tests for the new readiness artifacts.

## Validation

- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n auto tests/test_mlx_porting_harness.py tests/test_ci_workflows.py::test_mlx_project_porting_workflow_runs_tracked_porting_harness`
- `.venv/bin/python -m pytest -q -n auto`
- `.venv/bin/python integrations/mlx/run_mlx_porting.py --mlx-root /tmp/crosstl-mlx-porting-upstream --work-dir .crosstl-mlx-runtime-next`

Support issue traceability: no issue closed