### PR TITLE
Revalidate host roots during integration checks

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -2879,6 +2879,7 @@ def _run_execute_host_integration(args):
 
     payload = execute_runtime_host_integration(
         args.execution_plan,
+        host_root=args.host_root,
         scaffold_root=args.scaffold_root,
         package_root=args.package_root,
     )
@@ -6863,6 +6864,10 @@ def _build_parser():
     )
     execute_host_integration_parser.add_argument(
         "execution_plan", help="Host integration execution plan JSON"
+    )
+    execute_host_integration_parser.add_argument(
+        "--host-root",
+        help="Optional host repository root for host integration readiness checks",
     )
     execute_host_integration_parser.add_argument(
         "--scaffold-root",

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -24924,6 +24924,57 @@ def _runtime_host_integration_execution_scaffold_root(
     return root, str(root), "ready", []
 
 
+def _runtime_host_integration_execution_result_host_root(
+    host_root: str | os.PathLike[str] | None,
+    plan: Mapping[str, Any],
+    *,
+    plan_path: Path,
+) -> tuple[str | None, str, list[ProjectDiagnostic]]:
+    if host_root is None:
+        planned_host_root = plan.get("hostRoot")
+        if not _is_non_empty_string(planned_host_root):
+            planned_status = plan.get("hostRootStatus")
+            return (
+                None,
+                (
+                    str(planned_status)
+                    if _is_non_empty_string(planned_status)
+                    else "not-provided"
+                ),
+                [],
+            )
+        root_arg: str | os.PathLike[str] = str(planned_host_root)
+    else:
+        root_arg = host_root
+
+    root = _filesystem_path_arg(root_arg, field_name="Host root")
+    if not root.exists():
+        return (
+            str(root),
+            "missing",
+            [
+                _runtime_host_integration_execution_result_diagnostic(
+                    plan_path,
+                    "host-root-missing",
+                    f"Host root does not exist: {root}",
+                )
+            ],
+        )
+    if not root.is_dir():
+        return (
+            str(root),
+            "not-directory",
+            [
+                _runtime_host_integration_execution_result_diagnostic(
+                    plan_path,
+                    "host-root-not-directory",
+                    f"Host root is not a directory: {root}",
+                )
+            ],
+        )
+    return str(root), "ready", []
+
+
 def _runtime_host_integration_execution_check_payload(
     kind: str,
     status: str,
@@ -25275,6 +25326,7 @@ def _runtime_host_integration_execution_result_target(
 def execute_runtime_host_integration(
     execution_plan_path: str | os.PathLike[str],
     *,
+    host_root: str | os.PathLike[str] | None = None,
     scaffold_root: str | os.PathLike[str] | None = None,
     package_root: str | os.PathLike[str] | None = None,
 ) -> dict[str, Any]:
@@ -25289,6 +25341,11 @@ def execute_runtime_host_integration(
         diagnostics.extend(
             _runtime_host_integration_execution_plan_diagnostics(plan_path, plan)
         )
+    host_root_value, host_root_status, host_root_diagnostics = (
+        _runtime_host_integration_execution_result_host_root(
+            host_root, plan, plan_path=plan_path
+        )
+    )
     package_root_path, package_root_value, package_root_status, package_diagnostics = (
         _runtime_host_integration_execution_package_root(
             package_root, plan_path=plan_path
@@ -25302,6 +25359,7 @@ def execute_runtime_host_integration(
     ) = _runtime_host_integration_execution_scaffold_root(
         scaffold_root, plan_path=plan_path
     )
+    diagnostics.extend(host_root_diagnostics)
     diagnostics.extend(package_diagnostics)
     diagnostics.extend(scaffold_diagnostics)
 
@@ -25372,8 +25430,8 @@ def execute_runtime_host_integration(
         "scope": RUNTIME_HOST_INTEGRATION_EXECUTION_RESULT_SCOPE,
         "nonGoals": list(RUNTIME_HOST_INTEGRATION_EXECUTION_RESULT_NON_GOALS),
         "handoffRoot": plan.get("handoffRoot") if plan else None,
-        "hostRoot": plan.get("hostRoot") if plan else None,
-        "hostRootStatus": plan.get("hostRootStatus") if plan else None,
+        "hostRoot": host_root_value,
+        "hostRootStatus": host_root_status,
         "scaffoldRoot": scaffold_root_value,
         "scaffoldRootStatus": scaffold_root_status,
         "packageRoot": package_root_value,

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -750,20 +750,23 @@ Execute deterministic host integration checks from a saved execution plan:
 
    python -m crosstl execute-host-integration \
      crosstl-host-integration-execution-plan.json \
+     --host-root . \
      --scaffold-root crosstl-host-loader-scaffolds \
      --package-root crosstl-runtime-package \
      --format text
 
 Host integration execution results emit a
 ``crosstl-runtime-host-integration-execution-result`` JSON document. Execution
-validates the plan, records scaffold-root and package-root readiness, verifies
-generated loader scaffold files when ``--scaffold-root`` is provided, checks
-package artifact and source-remap paths when ``--package-root`` is provided,
-checks required host tools on ``PATH``, and reports project-specific host
-responsibilities as skipped actionable steps. Blocked plan steps remain blocked
-in the result, and missing files or invalid paths are emitted as structured
-diagnostics. This command still does not rewrite host application code, execute
-device code, generate runtime framework code, or install target SDKs.
+validates the plan, revalidates the planned host root or an explicit
+``--host-root`` override, records scaffold-root and package-root readiness,
+verifies generated loader scaffold files when ``--scaffold-root`` is provided,
+checks package artifact and source-remap paths when ``--package-root`` is
+provided, checks required host tools on ``PATH``, and reports project-specific
+host responsibilities as skipped actionable steps. Blocked plan steps remain
+blocked in the result, and missing files or invalid paths are emitted as
+structured diagnostics. This command still does not rewrite host application
+code, execute device code, generate runtime framework code, or install target
+SDKs.
 
 Diagnostics with ``originalLocation`` keep the generated or validation
 location as the primary SARIF location and attach the original source span as a

--- a/support/features.json
+++ b/support/features.json
@@ -11094,10 +11094,12 @@
       "support": {
         "directx": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11106,10 +11108,12 @@
         },
         "opengl": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11118,10 +11122,12 @@
         },
         "webgl": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11130,10 +11136,12 @@
         },
         "metal": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11142,10 +11150,12 @@
         },
         "vulkan": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11154,10 +11164,12 @@
         },
         "cuda": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11166,10 +11178,12 @@
         },
         "hip": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11178,10 +11192,12 @@
         },
         "mojo": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11190,10 +11206,12 @@
         },
         "rust": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11202,10 +11220,12 @@
         },
         "slang": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
@@ -11214,10 +11234,12 @@
         },
         "wgsl": {
           "status": "supported",
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -3467,36 +3467,42 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -6251,132 +6251,154 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "wgsl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -12524,132 +12524,154 @@
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "directx": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "hip": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "metal": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "mojo": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "opengl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "rust": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "slang": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "vulkan": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "webgl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         },
         "wgsl": {
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_checked_and_skipped_steps",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_package_artifact",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_revalidates_planned_host_root",
+            "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_accepts_host_root_override",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_blocked_steps_without_failure",
             "tests/test_translator/test_project_translation.py::def test_execute_runtime_host_integration_reports_missing_tool_as_blocked",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_text_outputs_results",
             "tests/test_translator/test_project_translation.py::def test_project_cli_execute_host_integration_json_writes_output"
           ],
-          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
+          "notes": "execute-host-integration consumes crosstl-runtime-host-integration-execution-plan JSON and emits crosstl-runtime-host-integration-execution-result JSON, text, and SARIF output, validates execution plans, revalidates the planned host root or an explicit --host-root override, records scaffold-root and package-root readiness, verifies loader scaffold output paths when --scaffold-root is provided, verifies package artifact and source-remap paths when --package-root is provided, checks required host tools on PATH, preserves blocked plan steps, reports project-specific host responsibilities as skipped actionable steps, and emits structured diagnostics for missing files, unsafe paths, unavailable tools, and invalid plans. It does not rewrite host application code, execute device code, generate runtime framework code, or install target SDKs.",
           "status": "supported"
         }
       }

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -37100,6 +37100,57 @@ def test_execute_runtime_host_integration_reports_checked_and_skipped_steps(
     assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
 
 
+def test_execute_runtime_host_integration_revalidates_planned_host_root(
+    tmp_path,
+):
+    repo, handoff_dir, _ = _build_runtime_host_integration_handoff_fixture(tmp_path)
+    host_root = repo / "host-app"
+    host_root.mkdir()
+    plan_payload = plan_runtime_host_integration_execution(
+        handoff_dir / "host-integration.json",
+        host_root=host_root,
+    )
+    plan_path = repo / "host-integration-execution-plan.json"
+    plan_path.write_text(json.dumps(plan_payload, indent=2), encoding="utf-8")
+    host_root.rmdir()
+
+    payload = execute_runtime_host_integration(
+        plan_path,
+        scaffold_root=repo / "host-loader-scaffolds",
+        package_root=repo / "runtime-package",
+    )
+
+    assert payload["success"] is False
+    assert payload["status"] == "failed"
+    assert payload["hostRoot"] == str(host_root)
+    assert payload["hostRootStatus"] == "missing"
+    assert payload["summary"]["stepCount"] == 0
+    assert payload["diagnostics"][0]["code"] == (
+        "project.runtime-host-integration-execution.host-root-missing"
+    )
+
+
+def test_execute_runtime_host_integration_accepts_host_root_override(tmp_path):
+    repo, plan_path, _ = _write_runtime_host_integration_execution_plan_fixture(
+        tmp_path
+    )
+    host_root = repo / "host-override"
+    host_root.mkdir()
+
+    payload = execute_runtime_host_integration(
+        plan_path,
+        host_root=host_root,
+        scaffold_root=repo / "host-loader-scaffolds",
+        package_root=repo / "runtime-package",
+    )
+
+    assert payload["success"] is True
+    assert payload["status"] == "partial"
+    assert payload["hostRoot"] == str(host_root)
+    assert payload["hostRootStatus"] == "ready"
+    assert payload["diagnosticCounts"] == {"note": 0, "warning": 0, "error": 0}
+
+
 def test_execute_runtime_host_integration_reports_missing_package_artifact(
     tmp_path,
 ):
@@ -37205,6 +37256,8 @@ def test_project_cli_execute_host_integration_text_outputs_results(tmp_path):
             "crosstl._crosstl",
             "execute-host-integration",
             str(plan_path),
+            "--host-root",
+            str(repo),
             "--scaffold-root",
             str(repo / "host-loader-scaffolds"),
             "--package-root",


### PR DESCRIPTION
## Summary
- Revalidate the planned host root, or an explicit --host-root override, when executing host integration checks.
- Add CLI support for --host-root on execute-host-integration.
- Update tests, documentation, and generated support artifacts for the execution-result contract.

## Validation
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest -q -n auto
- .venv/bin/python tools/sync_support_issues.py --dry-run --repo CrossGL/crosstl --plan-output /tmp/crosstl-support-issue-plan.json
- git diff --check

Support issue traceability: no issue closed
