### PR TITLE
Use runtime artifact manifests for MLX readiness

### DIFF
--- a/integrations/mlx/README.md
+++ b/integrations/mlx/README.md
@@ -17,8 +17,9 @@ The current harness verifies:
 - Vulkan assembly and validator checks when SPIR-V tools are available and no
   active validation blocker is tracked;
 - OpenGL artifact generation for `arange.metal`;
-- runtime-test manifest and runtime-test plan generation for reduced `arange`
-  readiness probes across DirectX, OpenGL, and Vulkan.
+- runtime artifact manifest, runtime-test manifest, and runtime-test plan
+  generation for reduced `arange` readiness probes across DirectX, OpenGL, and
+  Vulkan.
 
 Pull requests run the reduced frontier above. Scheduled and manually triggered
 CI also run the full-corpus artifact scout with finite Metal template
@@ -44,9 +45,10 @@ GPU unit tests against non-Metal targets requires runtime adapters, host-side
 dispatch wiring, data layout validation, and backend-specific build integration.
 The reduced harness now emits runtime readiness artifacts so those gaps are
 visible in CI reports without claiming runtime parity. The current readiness
-plans are blocked because translated project artifacts do not yet carry enough
-entry point, resource binding, and dispatch metadata for adapter-backed
-execution.
+manifests consume reflected runtime artifact metadata, including entry points,
+resource bindings, and dispatch geometry. The generated runtime-test plans are
+still blocked because fixture resources must be resolved through source-level
+and target-reflected aliases before adapter-backed execution can run.
 
 ## Running Locally
 
@@ -93,7 +95,8 @@ full-corpus Metal template materialization work for backend artifacts.
 CrossGL/crosstl#1376 tracks bounded runtime for the scheduled full-corpus scout.
 CrossGL/crosstl#1312 tracks native toolchain validation coverage for project
 CI. CrossGL/crosstl#1388 tracks the artifact execution metadata required by
-runtime-test manifests and native adapters. Future scouts should add
+runtime-test manifests and native adapters. CrossGL/crosstl#1392 tracks fixture
+resource binding through reflected backend aliases. Future scouts should add
 issue-backed blockers only when there are concrete repros. Host runtime
 integration gaps should be handled in repository integration code or downstream
 runtime adapters, not hidden as shader translation successes.

--- a/integrations/mlx/expected-gaps.json
+++ b/integrations/mlx/expected-gaps.json
@@ -28,13 +28,17 @@
       "opengl",
       "vulkan"
     ],
+    "artifact_manifest_included": true,
+    "metadata_manifest_status": "passing",
     "blocked_by": [
-      "https://github.com/CrossGL/crosstl/issues/1388"
+      "https://github.com/CrossGL/crosstl/issues/1392"
     ],
-    "diagnostics_by_code": {
-      "project.runtime-test-manifest.dispatch-unavailable": 3,
-      "project.runtime-test-manifest.entry-points-unavailable": 3,
-      "project.runtime-test-manifest.resource-bindings-unavailable": 3
+    "metadata_diagnostics_by_code": {},
+    "runtime_artifact_diagnostics_by_code": {
+      "project.runtime-manifest.resource-binding-layout-incomplete": 1
+    },
+    "runtime_plan_diagnostics_by_code": {
+      "project.runtime-verification.resource-unbound": 84
     }
   },
   "full_corpus_scout": {
@@ -81,7 +85,8 @@
     "https://github.com/CrossGL/crosstl/issues/1312",
     "https://github.com/CrossGL/crosstl/issues/1354",
     "https://github.com/CrossGL/crosstl/issues/1376",
-    "https://github.com/CrossGL/crosstl/issues/1388"
+    "https://github.com/CrossGL/crosstl/issues/1388",
+    "https://github.com/CrossGL/crosstl/issues/1392"
   ],
   "resolved_issues": [
     "https://github.com/CrossGL/crosstl/issues/1300",

--- a/integrations/mlx/run_mlx_porting.py
+++ b/integrations/mlx/run_mlx_porting.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from crosstl.project import build_runtime_artifact_manifest
 from crosstl.project.runtime_verification import (
     build_runtime_test_manifest,
     plan_runtime_test_manifest,
@@ -44,13 +45,19 @@ FULL_CORPUS_TRANSLATION_TRACKED_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1354",
     "https://github.com/CrossGL/crosstl/issues/1376",
 )
-RUNTIME_READINESS_TRACKED_ISSUES = ("https://github.com/CrossGL/crosstl/issues/1388",)
+RUNTIME_READINESS_TRACKED_ISSUES = (
+    "https://github.com/CrossGL/crosstl/issues/1388",
+    "https://github.com/CrossGL/crosstl/issues/1392",
+)
 RUNTIME_READINESS_DIAGNOSTIC_CODES = frozenset(
     (
         "project.runtime-test-manifest.entry-points-unavailable",
         "project.runtime-test-manifest.resource-bindings-unavailable",
         "project.runtime-test-manifest.dispatch-unavailable",
     )
+)
+RUNTIME_READINESS_PLAN_DIAGNOSTIC_CODES = frozenset(
+    ("project.runtime-verification.resource-unbound",)
 )
 FULL_CORPUS_TRACKED_ISSUES = (
     *FRONTIER_VALIDATION_TRACKED_ISSUES,
@@ -649,6 +656,17 @@ def _diagnostics_by_code(diagnostics: Sequence[Any]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
+def _runtime_plan_diagnostics(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    diagnostics: list[Mapping[str, Any]] = []
+    for test_case in plan.get("testCases", []):
+        if not isinstance(test_case, Mapping):
+            continue
+        for diagnostic in test_case.get("diagnostics", []):
+            if isinstance(diagnostic, Mapping):
+                diagnostics.append(diagnostic)
+    return diagnostics
+
+
 def _plan_runtime_readiness_for_report(
     *,
     mlx_root: Path,
@@ -662,23 +680,31 @@ def _plan_runtime_readiness_for_report(
         f"runtime readiness artifact report is missing: {artifact_report}",
     )
     metadata_path = report_dir / f"{name}.fixture-metadata.json"
+    runtime_artifact_manifest_path = (
+        report_dir / f"{name}.runtime-artifact-manifest.json"
+    )
     manifest_path = report_dir / f"{name}.runtime-test-manifest.json"
     plan_path = report_dir / f"{name}.runtime-test-plan.json"
     metadata = _runtime_readiness_fixture_metadata(targets)
     _write_json(metadata_path, metadata)
+    runtime_artifact_manifest = build_runtime_artifact_manifest(artifact_report)
+    _write_json(runtime_artifact_manifest_path, runtime_artifact_manifest)
     manifest = build_runtime_test_manifest(
-        artifact_report,
+        runtime_artifact_manifest_path,
         metadata_path,
         project_root=mlx_root,
     )
     _write_json(manifest_path, manifest)
     plan = plan_runtime_test_manifest(
-        artifact_report,
+        runtime_artifact_manifest_path,
         manifest,
         project_root=mlx_root,
     )
     _write_json(plan_path, plan)
 
+    runtime_artifact_diagnostics_by_code = _diagnostics_by_code(
+        runtime_artifact_manifest.get("runtimeDiagnostics", [])
+    )
     diagnostic_counts = manifest.get("diagnosticCounts", {})
     _require(
         isinstance(diagnostic_counts, dict),
@@ -694,13 +720,29 @@ def _plan_runtime_readiness_for_report(
         for code in diagnostics_by_code
         if code in RUNTIME_READINESS_DIAGNOSTIC_CODES
     )
+    plan_diagnostics_by_code = _diagnostics_by_code(_runtime_plan_diagnostics(plan))
+    plan_blocker_codes = sorted(
+        code
+        for code in plan_diagnostics_by_code
+        if code in RUNTIME_READINESS_PLAN_DIAGNOSTIC_CODES
+    )
     if metadata_gap_codes:
         _require(
             RUNTIME_READINESS_TRACKED_ISSUES,
             "runtime readiness manifest reported artifact execution metadata gaps "
             "without tracked issue references",
         )
-    status = "blocked-by-tracked-issues" if metadata_gap_codes else "planned"
+    if plan_blocker_codes:
+        _require(
+            RUNTIME_READINESS_TRACKED_ISSUES,
+            "runtime readiness plan reported adapter setup blockers without "
+            "tracked issue references",
+        )
+    status = (
+        "blocked-by-tracked-issues"
+        if metadata_gap_codes or plan_blocker_codes
+        else "planned"
+    )
     plan_summary = plan.get("summary", {})
     _require(isinstance(plan_summary, dict), "runtime readiness plan summary missing")
     manifest_summary = manifest.get("summary", {})
@@ -713,14 +755,22 @@ def _plan_runtime_readiness_for_report(
         "status": status,
         "artifactReport": _relpath(artifact_report, mlx_root),
         "fixtureMetadata": _relpath(metadata_path, mlx_root),
+        "runtimeArtifactManifest": _relpath(runtime_artifact_manifest_path, mlx_root),
         "runtimeTestManifest": _relpath(manifest_path, mlx_root),
         "runtimeTestPlan": _relpath(plan_path, mlx_root),
         "targets": list(targets),
         "testCount": manifest_summary.get("testCount", 0),
+        "runtimeArtifactSummary": runtime_artifact_manifest.get("summary", {}),
+        "runtimeArtifactDiagnosticCounts": runtime_artifact_manifest.get(
+            "runtimeDiagnosticCounts", {}
+        ),
+        "runtimeArtifactDiagnosticsByCode": runtime_artifact_diagnostics_by_code,
         "diagnosticCounts": diagnostic_counts,
         "diagnosticsByCode": diagnostics_by_code,
+        "runtimePlanDiagnosticsByCode": plan_diagnostics_by_code,
         "runtimePlanSummary": plan_summary,
         "metadataGapCodes": metadata_gap_codes,
+        "planBlockerCodes": plan_blocker_codes,
         "shaderArtifactsOnly": True,
         "runtimeIntegrationIncluded": False,
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
@@ -753,8 +803,16 @@ def _plan_reduced_runtime_readiness(
         else "planned"
     )
     diagnostics_by_code: Counter[str] = Counter()
+    runtime_artifact_diagnostics_by_code: Counter[str] = Counter()
+    runtime_plan_diagnostics_by_code: Counter[str] = Counter()
     for report in reports:
         diagnostics_by_code.update(report.get("diagnosticsByCode", {}))
+        runtime_artifact_diagnostics_by_code.update(
+            report.get("runtimeArtifactDiagnosticsByCode", {})
+        )
+        runtime_plan_diagnostics_by_code.update(
+            report.get("runtimePlanDiagnosticsByCode", {})
+        )
     return {
         "name": "runtime-readiness",
         "status": status,
@@ -762,6 +820,12 @@ def _plan_reduced_runtime_readiness(
         "targets": ["directx", "opengl", "vulkan"],
         "testCount": sum(int(report.get("testCount", 0)) for report in reports),
         "diagnosticsByCode": dict(sorted(diagnostics_by_code.items())),
+        "runtimeArtifactDiagnosticsByCode": dict(
+            sorted(runtime_artifact_diagnostics_by_code.items())
+        ),
+        "runtimePlanDiagnosticsByCode": dict(
+            sorted(runtime_plan_diagnostics_by_code.items())
+        ),
         "shaderArtifactsOnly": True,
         "runtimeIntegrationIncluded": False,
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2137,7 +2137,7 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "without tracked issue references" in harness
     assert "runtime-readiness" in harness
     assert "runtime-test-manifest" in harness
-    for tracked_issue_number in (1312, 1354, 1362, 1376, 1388):
+    for tracked_issue_number in (1312, 1354, 1362, 1376, 1388, 1392):
         assert f"https://github.com/CrossGL/crosstl/issues/{tracked_issue_number}" in (
             harness
         )

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -55,7 +55,65 @@ def _translated_arange_report(module, target):
     }
 
 
-def test_runtime_readiness_reports_tracked_artifact_metadata_gaps(tmp_path):
+def _runtime_arange_artifact_manifest(module, target, output_name="out"):
+    return {
+        "kind": "crosstl-project-runtime-artifact-manifest",
+        "project": {"targets": [target]},
+        "summary": {
+            "artifactCount": 1,
+            "entryPointCount": 1,
+            "resourceBindingCount": 3,
+            "dispatchMetadataCount": 1,
+        },
+        "artifacts": [
+            {
+                "id": (
+                    f"{module.MLX_ARANGE_SOURCE}|{target}|default|out/{target}/arange"
+                ),
+                "source": module.MLX_ARANGE_SOURCE,
+                "path": f"out/{target}/arange",
+                "target": target,
+                "sourceBackend": "metal",
+                "status": "translated",
+                "entryPoints": [
+                    {
+                        "name": "main",
+                        "stage": "compute",
+                        "workgroupSize": [1, 1, 1],
+                    }
+                ],
+                "resourceBindings": [
+                    {
+                        "name": "start",
+                        "kind": "constant",
+                        "binding": 0,
+                    },
+                    {
+                        "name": "step",
+                        "kind": "constant",
+                        "binding": 1,
+                    },
+                    {
+                        "name": output_name,
+                        "kind": "buffer",
+                        "binding": 2,
+                    },
+                ],
+                "dispatch": {
+                    "entryPoint": "main",
+                    "workgroupSize": [1, 1, 1],
+                    "workgroupCount": [1, 1, 1],
+                },
+            }
+        ],
+        "runtimeDiagnosticCounts": {"note": 0, "warning": 0, "error": 0},
+        "runtimeDiagnostics": [],
+    }
+
+
+def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
+    tmp_path, monkeypatch
+):
     module = _load_harness()
     mlx_root = tmp_path / "mlx"
     report_dir = mlx_root / ".crosstl-mlx-porting" / "reports"
@@ -66,6 +124,18 @@ def test_runtime_readiness_reports_tracked_artifact_metadata_gaps(tmp_path):
         encoding="utf-8",
     )
 
+    build_calls = []
+
+    def fake_runtime_artifact_manifest(report_path):
+        build_calls.append(Path(report_path))
+        return _runtime_arange_artifact_manifest(module, "directx")
+
+    monkeypatch.setattr(
+        module,
+        "build_runtime_artifact_manifest",
+        fake_runtime_artifact_manifest,
+    )
+
     result = module._plan_runtime_readiness_for_report(
         mlx_root=mlx_root,
         report_dir=report_dir,
@@ -74,18 +144,19 @@ def test_runtime_readiness_reports_tracked_artifact_metadata_gaps(tmp_path):
         targets=("directx",),
     )
 
-    assert result["status"] == "blocked-by-tracked-issues"
+    assert build_calls == [artifact_report]
+    assert result["status"] == "planned"
     assert result["trackedRuntimeIssues"] == [
-        "https://github.com/CrossGL/crosstl/issues/1388"
+        "https://github.com/CrossGL/crosstl/issues/1388",
+        "https://github.com/CrossGL/crosstl/issues/1392",
     ]
     assert result["testCount"] == 1
-    assert result["diagnosticCounts"] == {"error": 0, "note": 0, "warning": 3}
-    assert result["metadataGapCodes"] == [
-        "project.runtime-test-manifest.dispatch-unavailable",
-        "project.runtime-test-manifest.entry-points-unavailable",
-        "project.runtime-test-manifest.resource-bindings-unavailable",
-    ]
+    assert result["diagnosticCounts"] == {"error": 0, "note": 0, "warning": 0}
+    assert result["metadataGapCodes"] == []
+    assert result["planBlockerCodes"] == []
+    assert result["runtimeArtifactSummary"]["resourceBindingCount"] == 3
     assert (mlx_root / result["fixtureMetadata"]).is_file()
+    assert (mlx_root / result["runtimeArtifactManifest"]).is_file()
     assert (mlx_root / result["runtimeTestManifest"]).is_file()
     assert (mlx_root / result["runtimeTestPlan"]).is_file()
 
@@ -93,8 +164,56 @@ def test_runtime_readiness_reports_tracked_artifact_metadata_gaps(tmp_path):
     assert manifest["success"] is True
     assert manifest["summary"]["testsByTarget"] == {"directx": 1}
     assert manifest["metadata"]["trackedIssues"] == [
-        "https://github.com/CrossGL/crosstl/issues/1388"
+        "https://github.com/CrossGL/crosstl/issues/1388",
+        "https://github.com/CrossGL/crosstl/issues/1392",
     ]
+
+
+def test_runtime_readiness_reports_tracked_plan_resource_blockers(
+    tmp_path, monkeypatch
+):
+    module = _load_harness()
+    mlx_root = tmp_path / "mlx"
+    report_dir = mlx_root / ".crosstl-mlx-porting" / "reports"
+    report_dir.mkdir(parents=True)
+    artifact_report = report_dir / "opengl-readiness-artifacts.json"
+    artifact_report.write_text(
+        json.dumps(_translated_arange_report(module, "opengl")),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        module,
+        "build_runtime_artifact_manifest",
+        lambda report_path: _runtime_arange_artifact_manifest(
+            module, "opengl", output_name="out_Buffer"
+        ),
+    )
+
+    result = module._plan_runtime_readiness_for_report(
+        mlx_root=mlx_root,
+        report_dir=report_dir,
+        name="opengl-runtime-readiness",
+        artifact_report=artifact_report,
+        targets=("opengl",),
+    )
+
+    assert result["status"] == "blocked-by-tracked-issues"
+    assert result["diagnosticCounts"] == {"error": 0, "note": 0, "warning": 0}
+    assert result["metadataGapCodes"] == []
+    assert result["planBlockerCodes"] == [
+        "project.runtime-verification.resource-unbound"
+    ]
+    assert (
+        result["runtimePlanDiagnosticsByCode"][
+            "project.runtime-verification.resource-unbound"
+        ]
+        == 1
+    )
+    assert (
+        "https://github.com/CrossGL/crosstl/issues/1392"
+        in result["trackedRuntimeIssues"]
+    )
 
 
 def test_full_corpus_mode_writes_bounded_config_and_checks_counts(


### PR DESCRIPTION
## Summary

- generate runtime artifact manifests for the reduced MLX readiness reports before building runtime-test manifests
- build runtime-test manifests and plans from reflected runtime artifact metadata instead of raw project reports
- report plan-level runtime setup blockers separately from metadata diagnostics and track the fixture resource binding gap in #1392
- update MLX expected gaps, README coverage notes, and harness tests

## Validation

- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n auto tests/test_mlx_porting_harness.py tests/test_ci_workflows.py::test_mlx_project_porting_workflow_runs_tracked_porting_harness`
- `.venv/bin/python integrations/mlx/run_mlx_porting.py --mlx-root /tmp/crosstl-mlx-porting-upstream --work-dir .crosstl-mlx-runtime-metadata-next`
- `.venv/bin/python -m pytest -q -n auto`

## Notes

The readiness manifests now have runtime artifact metadata for entry points, resource bindings, and dispatch geometry. Native execution is still blocked by fixture resource binding through reflected backend aliases, tracked in #1392. This does not claim MLX runtime parity on DirectX, OpenGL, or Vulkan.
