### PR TITLE
Skip redundant comment-scan startswith in Metal preprocessor

### DIFF
--- a/crosstl/backend/Metal/preprocessor.py
+++ b/crosstl/backend/Metal/preprocessor.py
@@ -1789,23 +1789,24 @@ class MetalPreprocessor(HLSLPreprocessor):
         angle_depth = 0
         i = start
         while i < len(code):
-            if code[i] in "\"'":
+            ch = code[i]
+            if ch == '"' or ch == "'":
                 _literal, consumed = self._read_string(code, i)
                 i += consumed
                 continue
-            if code.startswith("//", i):
-                end = code.find("\n", i)
-                if end == -1:
-                    return None
-                i = end + 1
-                continue
-            if code.startswith("/*", i):
-                end = code.find("*/", i + 2)
-                if end == -1:
-                    return None
-                i = end + 2
-                continue
-            ch = code[i]
+            if ch == "/":
+                if code.startswith("//", i):
+                    end = code.find("\n", i)
+                    if end == -1:
+                        return None
+                    i = end + 1
+                    continue
+                if code.startswith("/*", i):
+                    end = code.find("*/", i + 2)
+                    if end == -1:
+                        return None
+                    i = end + 2
+                    continue
             if (
                 ch == target
                 and paren_depth == 0
@@ -1835,23 +1836,24 @@ class MetalPreprocessor(HLSLPreprocessor):
         brace_depth = 0
         i = start
         while i < len(code):
-            if code[i] in "\"'":
+            ch = code[i]
+            if ch == '"' or ch == "'":
                 _literal, consumed = self._read_string(code, i)
                 i += consumed
                 continue
-            if code.startswith("//", i):
-                end = code.find("\n", i)
-                if end == -1:
-                    return len(code)
-                i = end + 1
-                continue
-            if code.startswith("/*", i):
-                end = code.find("*/", i + 2)
-                if end == -1:
-                    return None
-                i = end + 2
-                continue
-            ch = code[i]
+            if ch == "/":
+                if code.startswith("//", i):
+                    end = code.find("\n", i)
+                    if end == -1:
+                        return len(code)
+                    i = end + 1
+                    continue
+                if code.startswith("/*", i):
+                    end = code.find("*/", i + 2)
+                    if end == -1:
+                        return None
+                    i = end + 2
+                    continue
             if (
                 ch == ";"
                 and paren_depth == 0


### PR DESCRIPTION
## Summary

The Metal preprocessor's top-level scanners `_find_next_top_level_char` and `_statement_end` checked `code.startswith("//", i)` and `code.startswith("/*", i)` at **every** character — hundreds of millions of `startswith` calls on large, template-heavy sources. Guard those checks behind a cheap `ch == "/"` test (a non-`/` character can never start a comment), eliminating the redundant calls.

## Impact

Byte-identical output — the comment/string-skip and bracket-depth decisions are unchanged, only the redundant `startswith` calls are removed. Measured **~6% faster** on the heaviest MLX kernel (`quantized.metal` at the harness template budgets: 514s → 484s), with proportional gains on other heavy kernels.

This does not by itself resolve the full MLX-corpus materialization timeout (which is bounded by materialization volume and corpus size — tracked in #1354), but it removes a real hot-path inefficiency in the template-materialization scanners.

## Validation

- Reduced-frontier MLX porting harness output is byte-identical to baseline.
- `tests/test_backend/test_metal` + `tests/test_translator/test_codegen` green.

Part of #1354

Support issue traceability: no issue closed
