### PR TITLE
Strip comments from Metal type text in template-placeholder scan

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -10187,7 +10187,13 @@ def _strip_metal_attribute_blocks(text: str) -> str:
 
 
 def _normalize_metal_type_text(type_text: str) -> str:
-    text = _strip_metal_attribute_blocks(type_text)
+    # Strip C/C++ comments first: a type spelling never legitimately contains a
+    # comment, but extraction can pick one up (e.g. a trailing `// ...` after a
+    # return type). Leaving it in makes downstream token scans treat comment
+    # words as identifiers (e.g. flagging "Get" as a missing template parameter).
+    text = re.sub(r"/\*.*?\*/", " ", type_text, flags=re.DOTALL)
+    text = re.sub(r"//[^\n]*", " ", text)
+    text = _strip_metal_attribute_blocks(text)
     text = re.sub(r"\b(?:struct|class|typename)\s+", "", text)
     text = re.sub(r"\s+", " ", text).strip()
     text = re.sub(r"\s*([<>,*&\[\]()])\s*", r"\1", text)

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -1750,3 +1750,30 @@ def test_native_compute_extension_aliases_report_webgl_diagnostics(
         match="WebGL target does not support shader stage\\(s\\): compute",
     ):
         crosstl.translate(str(source_path), backend="webgl", format_output=False)
+
+
+def test_metal_template_placeholder_scan_ignores_comments():
+    # Regression: the residual-template placeholder scan treated comment words as
+    # identifiers, so a comment captured in an extracted type (e.g. a trailing
+    # `// Get the max ...`) produced a spurious "missing template parameter 'Get'"
+    # and wrongly blocked otherwise-translatable kernels (MLX softmax/logsumexp).
+    from crosstl.project.pipeline import (
+        _normalize_metal_type_text,
+        _unresolved_metal_template_placeholders_in_type,
+    )
+
+    # Comments are stripped from normalized type text.
+    assert (
+        _normalize_metal_type_text("void // Get the max and the normalizer") == "void"
+    )
+    assert _normalize_metal_type_text("float /* T */ x").replace(" ", "") == "floatx"
+
+    # No spurious placeholder is reported for comment words.
+    assert (
+        _unresolved_metal_template_placeholders_in_type(
+            "void // Get the max and the normalizer", set()
+        )
+        == []
+    )
+    # A genuine unresolved template parameter is still detected.
+    assert _unresolved_metal_template_placeholders_in_type("T", {"T"}) == ["T"]


### PR DESCRIPTION
## Summary

The Metal residual-template **placeholder scan** (`_unresolved_metal_template_placeholders_in_type`) tokenizes its input and flags any short capitalized identifier as a likely unresolved template placeholder. Because extracted type text could include a **comment** (e.g. a trailing `// Get the max and the normalizer in one go` picked up after a return type), the scan flagged the comment word `Get` as a missing template parameter — a spurious `project.translate.template-materialization-unsupported` failure that wrongly blocked otherwise-translatable kernels.

Fix: strip C/C++ comments in `_normalize_metal_type_text` (a type spelling never legitimately contains a comment), so downstream token scans never see comment words.

## Impact

Real MLX kernels unblocked: **`softmax` and `logsumexp` now translate to OpenGL and Vulkan** (both previously reported `template-materialization-unsupported`). They still fail on DirectX — but now via the unresolved-construct guardrail (#1441) catching a leaked `gl_*` subgroup builtin in HLSL, a separate DX follow-on, **not** a false positive.

## Verification

- New unit test: comments stripped from normalized type text; no spurious placeholder for comment words; a genuine unresolved parameter (`T`) is still detected.
- Full `tests/test_translator` + `tests/test_backend` green (12,590 passed, 0 failed).
- Confirmed via targeted MLX translation that `softmax` / `logsumexp` produce valid GLSL + SPIR-V artifacts.

Part of #1354

Support issue traceability: no issue closed
