### PR TITLE
Mask comments with full-source context in Metal function-header extraction

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import bisect
 import fnmatch
+import functools
 import hashlib
 import json
 import math
@@ -10419,7 +10420,13 @@ def _metal_function_return_type(
 
 
 def _metal_function_header(source: str, function: Any) -> str:
-    return source[function.span[0] : function.body_span[0] - 1]
+    # Mask comments using full-source context before slicing: a function span can
+    # begin inside a comment (e.g. a preceding license block), and masking only
+    # the already-sliced header would miss the opening `/*`/`//` and leak comment
+    # prose into extracted return/parameter types (spuriously read as template
+    # placeholders, e.g. license words like "OR"/"AND").
+    masked = _masked_metal_non_code_text(source)
+    return masked[function.span[0] : function.body_span[0] - 1]
 
 
 def _metal_statement_spans(source: str, start: int, end: int) -> list[tuple[int, int]]:
@@ -12522,6 +12529,7 @@ def _template_materialization_unsupported_location(
     return SourceLocation(file=unit.relative_path)
 
 
+@functools.lru_cache(maxsize=8)
 def _masked_metal_non_code_text(source: str) -> str:
     chars = list(source)
     i = 0

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -1777,3 +1777,27 @@ def test_metal_template_placeholder_scan_ignores_comments():
     )
     # A genuine unresolved template parameter is still detected.
     assert _unresolved_metal_template_placeholders_in_type("T", {"T"}) == ["T"]
+
+
+def test_metal_function_header_masks_comments_spanning_the_header_start():
+    # Regression: a function span can begin inside a preceding comment (e.g. a
+    # license block), so masking only the already-sliced header missed the
+    # opening `/*` and leaked license prose (e.g. "OR"/"AND") into extracted
+    # return/parameter types. _metal_function_header masks with full-source
+    # context so the sliced header is comment-free regardless of where it starts.
+    from types import SimpleNamespace
+
+    from crosstl.project.pipeline import _metal_function_header
+
+    source = "/* ... OR BUSINESS INTERRUPTION ... */ float foo(int x) { return x; }"
+    body_start = source.index("{")
+    # Span deliberately begins mid-comment (after the opening `/*`).
+    function = SimpleNamespace(
+        span=(3, len(source)), body_span=(body_start, len(source))
+    )
+
+    header = _metal_function_header(source, function)
+
+    assert "OR" not in header
+    assert "BUSINESS" not in header
+    assert "float foo(int x)" in header


### PR DESCRIPTION
## Summary

A second residual-template false positive (follow-on to #1444). A function's span can begin **inside a preceding comment** (e.g. a license block), so masking only the already-sliced header missed the opening `/*` and leaked comment prose into extracted return/parameter types. The residual-template placeholder scan then flagged license words (`OR`, `AND`, `ON`, `ANY` from `OR BUSINESS INTERRUPTION ... HOWEVER CAUSED AND ON ANY`) as missing template parameters → a spurious `project.translate.template-materialization-unsupported`.

Fix: `_metal_function_header` now masks comments using **full-source context** before slicing, so the sliced header is comment-free regardless of where its span begins. `_masked_metal_non_code_text` is memoized (`functools.lru_cache`) so per-function header extraction stays O(1) after the first mask per source.

## Impact

The MLX **`unary`** kernel now translates to Vulkan (previously failed with spurious missing `OR`/`AND`/`ON`/`ANY`). Combined with #1444 (softmax / logsumexp / fft), four MLX kernels are now unblocked.

## Verification

- New unit test: a function whose span begins mid-comment yields a comment-free header (no `OR`/`BUSINESS` leak; the real signature survives).
- Full `tests/test_translator` + `tests/test_backend` green (12,591 passed, 0 failed; ~232s — the cache keeps header extraction fast, no perf regression).
- Confirmed via targeted MLX translation that `unary` produces a valid Vulkan artifact.

Part of #1354

Support issue traceability: no issue closed
