### PR TITLE
Fix Metal residual-template false positives from struct member templates

### DIFF
--- a/crosstl/backend/Metal/preprocessor.py
+++ b/crosstl/backend/Metal/preprocessor.py
@@ -3,7 +3,7 @@
 import operator
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Set, Tuple
 
 from crosstl.backend.DirectX.preprocessor import HLSLPreprocessor, Macro
@@ -1902,7 +1902,43 @@ class MetalPreprocessor(HLSLPreprocessor):
         instantiations.extend(self._find_raw_mlx_kernel_instantiations(code))
         instantiations.extend(self._find_declared_mlx_kernel_instantiations(code))
         instantiations.extend(self._find_declared_template_instantiations(code))
+        instantiations = self._dedupe_template_instantiations(instantiations)
         return sorted(instantiations, key=lambda item: item.span[0])
+
+    def _dedupe_template_instantiations(
+        self, instantiations: List[_MLXKernelInstantiation]
+    ) -> List[_MLXKernelInstantiation]:
+        # The same expanded `template [[host_name(...)]] ... Name<args>;`
+        # declaration is matched by more than one detector (the declared-host-name
+        # scanner and the generic declared-template scanner), so an instantiation
+        # can be reported twice with slightly different (overlapping) spans. Those
+        # duplicates double the instantiation count, which both inflates the
+        # `max_template_specializations` budget check (causing a spurious bail-out
+        # that leaves generic templates un-materialized and later flagged as
+        # unresolved) and adds redundant removal spans. Collapse entries that share
+        # the same target specialization — identical function name, normalized
+        # template arguments, and host name — keeping the widest covering span so
+        # the declaration is fully removed during materialization.
+        unique: dict[tuple[str, tuple[str, ...], str], _MLXKernelInstantiation] = {}
+        for instantiation in instantiations:
+            key = (
+                instantiation.function_name,
+                tuple(
+                    self._normalize_template_argument_text(argument)
+                    for argument in instantiation.template_arguments
+                ),
+                instantiation.host_name,
+            )
+            existing = unique.get(key)
+            if existing is None:
+                unique[key] = instantiation
+                continue
+            # Keep the widest span so the full declaration text is removed.
+            start = min(existing.span[0], instantiation.span[0])
+            end = max(existing.span[1], instantiation.span[1])
+            if (start, end) != existing.span:
+                unique[key] = replace(existing, span=(start, end))
+        return list(unique.values())
 
     def _find_raw_mlx_kernel_instantiations(
         self, code: str

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -13083,6 +13083,39 @@ def _unmaterialized_metal_template_functor_records(
     return records
 
 
+def _metal_concrete_struct_member_spans(
+    preprocessor: Any,
+    source: str,
+) -> list[tuple[int, int]]:
+    # Body spans of every CONCRETE (non-template) struct/class. A `template <...>`
+    # header found inside one of these is a MEMBER template (a templated
+    # constructor, conversion operator, or `operator()` functor) — never a free
+    # template function. Member templates are specialized implicitly when the
+    # enclosing type's member is used and are lowered to free functions by
+    # `_lower_struct_member_functions`; they must NOT be reported as unresolved
+    # standalone templates. Template structs are intentionally excluded here: the
+    # struct materializer owns those, so their member templates stay in scope for
+    # the existing standalone scanners.
+    try:
+        structs = preprocessor._find_concrete_struct_definitions(source)
+    except Exception:  # noqa: BLE001
+        return []
+    return [struct.body_span for struct in structs]
+
+
+def _metal_template_is_struct_member(
+    preprocessor: Any,
+    template: Any,
+    member_spans: Sequence[tuple[int, int]],
+) -> bool:
+    if not member_spans:
+        return False
+    return (
+        preprocessor._containing_span(int(template.span[0]), list(member_spans))
+        is not None
+    )
+
+
 def _project_template_materialization_for_artifact(
     *,
     unit: ProjectTranslationUnit,
@@ -13537,6 +13570,10 @@ def _project_template_materialization_for_artifact(
         current_template_spans,
     )
     remaining_templates = preprocessor._find_template_functions(materialized)
+    concrete_struct_member_spans = _metal_concrete_struct_member_spans(
+        preprocessor,
+        materialized,
+    )
     reachable_template_names = _reachable_metal_template_function_names(
         preprocessor,
         materialized,
@@ -13545,6 +13582,19 @@ def _project_template_materialization_for_artifact(
         current_reachable_function_spans,
     )
     for template in remaining_templates:
+        if _metal_template_is_struct_member(
+            preprocessor,
+            template,
+            concrete_struct_member_spans,
+        ):
+            # Templated struct members (constructors, conversion operators,
+            # `operator()` functors) are specialized implicitly via their enclosing
+            # type and lowered by `_lower_struct_member_functions`. They are not
+            # free template functions, so they must be left in place rather than
+            # stripped or reported as unresolved template materializations (e.g. the
+            # spurious `complex64_t<T>` / `operator<T>` records from MLX complex.h
+            # and the binary-op functors).
+            continue
         if (
             template.name in explicit_template_names
             or template.name in inherited_template_names

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -2,6 +2,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -1777,6 +1778,175 @@ def test_metal_template_placeholder_scan_ignores_comments():
     )
     # A genuine unresolved template parameter is still detected.
     assert _unresolved_metal_template_placeholders_in_type("T", {"T"}) == ["T"]
+
+
+def test_metal_struct_member_templates_are_not_unresolved_free_templates():
+    # Regression: templated struct MEMBERS (constructors, conversion operators,
+    # `operator()` functors) carry their own `template <...>` header, so the
+    # residual-template scanner misread them as free template functions and
+    # reported spurious "missing template parameter" records such as
+    # `complex64_t<T>` / `operator<T>` / `T<T>` from MLX complex.h and the binary
+    # op functors — wrongly blocking otherwise-translatable kernels
+    # (MLX binary/copy/arg_reduce). Member templates are lowered to free functions
+    # by `_lower_struct_member_functions`; they must be excluded from the
+    # unresolved-free-template loop while genuine free templates still are not.
+    from crosstl.backend.Metal.preprocessor import MetalPreprocessor
+    from crosstl.project.pipeline import (
+        _metal_concrete_struct_member_spans,
+        _metal_template_is_struct_member,
+    )
+
+    preprocessor = MetalPreprocessor()
+    source = (
+        "struct complex64_t {\n"
+        "  float real;\n"
+        "  float imag;\n"
+        "  template <typename T>\n"
+        "  constexpr complex64_t(T x) thread : real(x), imag(0) {}\n"
+        "  template <typename T>\n"
+        "  constexpr operator T() const thread { return static_cast<T>(real); }\n"
+        "};\n"
+        "struct Add {\n"
+        "  template <typename T>\n"
+        "  T operator()(T x, T y) { return x + y; }\n"
+        "};\n"
+        "template <typename T, typename U, typename Op>\n"
+        "[[kernel]] void binary_ss(device const T* a, device U* c) {\n"
+        "  c[0] = Op()(a[0], a[0]);\n"
+        "}\n"
+    )
+
+    member_spans = _metal_concrete_struct_member_spans(preprocessor, source)
+    templates = preprocessor._find_template_functions(source)
+    classification = {
+        template.name: _metal_template_is_struct_member(
+            preprocessor, template, member_spans
+        )
+        for template in templates
+    }
+
+    # The templated constructor (name == struct name), the templated conversion
+    # operator (name == "T"), and the templated functor (name == "operator") are
+    # all member templates.
+    assert classification["complex64_t"] is True
+    assert classification["T"] is True
+    assert classification["operator"] is True
+    # The genuine free kernel template is NOT a member template and stays subject
+    # to materialization / unresolved detection.
+    assert classification["binary_ss"] is False
+
+
+def test_metal_project_template_instantiations_are_deduplicated():
+    # Regression: the same expanded `template [[host_name(...)]] ... Name<args>;`
+    # declaration is matched by more than one detector, so each instantiation was
+    # counted twice (overlapping spans). That doubled count inflated the
+    # `max_template_specializations` budget check and could spuriously bail out of
+    # materialization, leaving generic templates un-stripped and later flagged as
+    # unresolved (e.g. MLX binary/copy `binary_ss<T, U, Op>`). Identical
+    # specializations (same function, args, host) must collapse to one entry.
+    from crosstl.backend.Metal.preprocessor import MetalPreprocessor
+
+    preprocessor = MetalPreprocessor()
+    source = (
+        "template <typename T, typename U>\n"
+        "[[kernel]] void copy_s(device const T* a, device U* c) { c[0] = a[0]; }\n"
+        'template [[host_name("copy_s_float")]] [[kernel]] '
+        "decltype(copy_s<float, float>) copy_s<float, float>;\n"
+    )
+
+    instantiations = preprocessor._find_project_template_instantiations(source)
+
+    copy_s = [inst for inst in instantiations if inst.function_name == "copy_s"]
+    assert len(copy_s) == 1, [
+        (inst.host_name, tuple(inst.template_arguments)) for inst in copy_s
+    ]
+    assert copy_s[0].host_name == "copy_s_float"
+    assert copy_s[0].template_arguments == ["float", "float"]
+
+
+def test_metal_struct_member_template_kernel_translates_without_false_positive(
+    tmp_path,
+):
+    # End-to-end regression mirroring MLX binary/copy/arg_reduce: a concrete struct
+    # with templated member constructors / conversion operators plus a templated
+    # `operator()` functor, used by an explicitly instantiated free kernel
+    # template. Before the fix the materializer reported a spurious
+    # `template-materialization-unsupported` for `complex64_t<T>` / `operator<T>`;
+    # now the kernel translates and emits no dangling template/member constructs.
+    from crosstl.project import load_project_config
+
+    repo = tmp_path / "repo"
+    source_dir = repo / "kernels"
+    source_dir.mkdir(parents=True)
+    (source_dir / "ops.metal").write_text(
+        "#include <metal_stdlib>\n"
+        "using namespace metal;\n"
+        "\n"
+        "struct complex64_t {\n"
+        "  float real;\n"
+        "  float imag;\n"
+        "  constexpr complex64_t(float r, float i) : real(r), imag(i) {}\n"
+        "  constexpr complex64_t() : real(0), imag(0) {}\n"
+        "  template <typename T>\n"
+        "  constexpr complex64_t(T x) thread : real(x), imag(0) {}\n"
+        "  template <typename T>\n"
+        "  constexpr operator T() const thread { return static_cast<T>(real); }\n"
+        "};\n"
+        "\n"
+        "struct Add {\n"
+        "  template <typename T>\n"
+        "  T operator()(T x, T y) { return x + y; }\n"
+        "};\n"
+        "\n"
+        "template <typename T, typename Op>\n"
+        "[[kernel]] void binary_op(\n"
+        "    device const T* a [[buffer(0)]],\n"
+        "    device const T* b [[buffer(1)]],\n"
+        "    device T* c [[buffer(2)]],\n"
+        "    uint index [[thread_position_in_grid]]) {\n"
+        "  c[index] = Op()(a[index], b[index]);\n"
+        "}\n"
+        "\n"
+        'template [[host_name("add_float")]] [[kernel]] '
+        "decltype(binary_op<float, Add>) binary_op<float, Add>;\n",
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent(
+            """
+            [project]
+            source_roots = ["kernels"]
+            include = ["kernels/ops.metal"]
+            targets = ["vulkan"]
+            output_dir = "out"
+
+            [project.sources]
+            "**/*.metal" = "metal"
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo), format_output=False)
+    payload = report.to_json()
+
+    unsupported = [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic.get("code")
+        == "project.translate.template-materialization-unsupported"
+    ]
+    assert unsupported == [], unsupported
+
+    artifact = payload["artifacts"][0]
+    assert artifact.get("status") == "translated", artifact.get("error")
+
+    generated = (repo / artifact["path"]).read_text(encoding="utf-8")
+    _assert_generated_output_is_usable(generated)
+    # No residual template/member-template scaffolding leaks into the output.
+    assert "complex64_t<" not in generated
+    assert "operator<T>" not in generated
+    assert "template <" not in generated
 
 
 def test_metal_function_header_masks_comments_spanning_the_header_start():


### PR DESCRIPTION
## Summary

Two related fixes to the Metal project template materializer, both of which produced a spurious `project.translate.template-materialization-unsupported` for kernels that are in fact translatable (follow-on to #1444 / #1445 in the residual-template false-positive series).

**1. Struct member templates were misread as unresolved free templates.**
Templated struct members — templated constructors, conversion operators, and `operator()` functors — carry their own `template <...>` header, so the post-materialization residual-template scan reported them as unresolved *free* templates with bogus signatures such as `complex64_t<T>`, `operator<T>`, and `T<T>` (from MLX `complex.h` and the binary-op functors). These members are specialized implicitly via their enclosing type and are lowered to free functions by `_lower_struct_member_functions`, so they are now skipped when their declaration begins inside a **concrete** (non-template) struct body. Template structs stay excluded so the struct materializer keeps ownership of their members.

**2. Project template instantiations were counted twice.**
The same expanded `template [[host_name(...)]] ... Name<args>;` declaration is matched by more than one detector, so each instantiation was reported twice with overlapping spans. The doubled count inflated the `max_template_specializations` budget check, causing a premature bail-out that left generic templates un-materialized — which then survived as "unresolved" residue. Identical specializations (same function name, normalized arguments, host name) now collapse to a single entry, keeping the widest covering span.

## Impact

- MLX **`arg_reduce`** (pure false positive) and **`copy`** (2497 unique specializations ≤ limit after dedup) now translate to Vulkan.
- The `complex64_t<T>` / `operator<T>` / `T<T>` false positives no longer block **`binary`**. `binary` still requires a higher `max_template_specializations` (4123 genuine unique specializations) — a legitimate, accurate limit rather than a misparse (confirmed: it translates cleanly at limit 5000).

## Verification

- New tests in `tests/test_translator/test_translation_pipeline.py`:
  - `test_metal_struct_member_templates_are_not_unresolved_free_templates` — member-template classification (constructor / conversion operator / functor are members; the free kernel template is not).
  - `test_metal_project_template_instantiations_are_deduplicated` — duplicate instantiations collapse to one.
  - `test_metal_struct_member_template_kernel_translates_without_false_positive` — end-to-end `translate_project`: a struct with templated members + a functor + an instantiated free kernel translates to Vulkan with no `template-materialization-unsupported` and no residual template/member scaffolding in the output.
- Full `tests/test_translator` + `tests/test_backend` green (**12,595 passed, 405 skipped, 0 failed**).
- MLX reduced-frontier harness passes.

Part of #1354

Support issue traceability: no issue closed
