### PR TITLE
Stop flagging local constexpr array extents as unresolved Metal templates

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -12902,12 +12902,27 @@ def _unresolved_metal_standalone_template_type_records(
         )
     }
 
-    def append_record(function: Any, type_text: str) -> None:
+    def append_record(function: Any, type_text: str, offset: int) -> None:
         missing = _unresolved_metal_template_placeholders_in_type(
             type_text,
             template_parameter_names,
         )
         if not missing:
+            return
+        # Suppress false positives where the "missing" tokens are actually local
+        # constants in scope at this point (e.g. `constexpr int BN = 32;` used as
+        # an array extent `threadgroup U outputs[BN * BD]`). The struct/class-path
+        # scanner already applies this guard; the standalone-type path must too,
+        # otherwise the over-broad placeholder heuristic flags body-local constexpr
+        # array extents (MLX conv `TGH`/`TGW`/`TGC`/`TH`/`TW`, sdpa `BN`/`BD`) as
+        # unresolved template parameters and wrongly blocks translatable kernels.
+        if _metal_template_arguments_are_local_constants(
+            preprocessor,
+            source,
+            offset,
+            missing,
+            template_spans,
+        ):
             return
         required_signature = _normalize_metal_type_text(type_text)
         declared_type_check = _strip_metal_type_qualifiers(required_signature)
@@ -12950,12 +12965,12 @@ def _unresolved_metal_standalone_template_type_records(
         header = _metal_function_header(source, function)
         return_type = return_types.get(str(function.name))
         if return_type:
-            append_record(function, return_type)
+            append_record(function, return_type, int(function.span[0]))
         for type_text, _name, _variadic in _metal_function_parameter_declarations(
             preprocessor,
             header,
         ):
-            append_record(function, type_text)
+            append_record(function, type_text, int(function.span[0]))
 
         body_start, body_end = function.body_span
         environment = _metal_function_type_environment(
@@ -12974,7 +12989,7 @@ def _unresolved_metal_standalone_template_type_records(
             if declaration is None:
                 continue
             _name, type_text = declaration
-            append_record(function, type_text)
+            append_record(function, type_text, start)
     return records
 
 

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -1949,6 +1949,73 @@ def test_metal_struct_member_template_kernel_translates_without_false_positive(
     assert "template <" not in generated
 
 
+def test_metal_local_constexpr_array_extent_is_not_unresolved_template(tmp_path):
+    # End-to-end regression mirroring MLX conv/sdpa: a materialized kernel body can
+    # size a threadgroup/array with LOCAL `constexpr int` constants
+    # (`constexpr int BN = 32; threadgroup float tile[BN * BD];`). The standalone
+    # residual-template scanner's placeholder heuristic flags short capitalized
+    # tokens like `BN`/`BD`/`TGH` as missing template parameters. The struct/class
+    # path already suppresses these via the local-constant guard; before the fix
+    # the standalone path did not, so it wrongly reported
+    # `template-materialization-unsupported` and blocked translatable kernels.
+    from crosstl.project import load_project_config
+
+    repo = tmp_path / "repo"
+    source_dir = repo / "kernels"
+    source_dir.mkdir(parents=True)
+    (source_dir / "tg.metal").write_text(
+        "#include <metal_stdlib>\n"
+        "using namespace metal;\n"
+        "\n"
+        "template <typename T>\n"
+        "[[kernel]] void tg_sum(\n"
+        "    device const T* a [[buffer(0)]],\n"
+        "    device T* c [[buffer(1)]],\n"
+        "    uint index [[thread_position_in_grid]],\n"
+        "    uint lid [[thread_position_in_threadgroup]]) {\n"
+        "  constexpr int BN = 32;\n"
+        "  constexpr int BD = 4;\n"
+        "  threadgroup T tile[BN * BD];\n"
+        "  tile[lid] = a[index];\n"
+        "  threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+        "  c[index] = tile[lid];\n"
+        "}\n"
+        "\n"
+        'template [[host_name("tg_sum_float")]] [[kernel]] '
+        "decltype(tg_sum<float>) tg_sum<float>;\n",
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent(
+            """
+            [project]
+            source_roots = ["kernels"]
+            include = ["kernels/tg.metal"]
+            targets = ["vulkan"]
+            output_dir = "out"
+
+            [project.sources]
+            "**/*.metal" = "metal"
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    report = translate_project(load_project_config(repo), format_output=False)
+    payload = report.to_json()
+
+    unsupported = [
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic.get("code")
+        == "project.translate.template-materialization-unsupported"
+    ]
+    assert unsupported == [], unsupported
+
+    artifact = payload["artifacts"][0]
+    assert artifact.get("status") == "translated", artifact.get("error")
+
+
 def test_metal_function_header_masks_comments_spanning_the_header_start():
     # Regression: a function span can begin inside a preceding comment (e.g. a
     # license block), so masking only the already-sliced header missed the


### PR DESCRIPTION
## Summary

Another residual-template false positive (follow-on to #1444 / #1445 / #1446), this time blocking MLX `conv` and `scaled_dot_product_attention`.

The post-materialization residual-template scanner flags short capitalized identifiers (`BN`, `BD`, `TGH`, `TGW`, `TGC`, `TH`, `TW`, …) as missing template parameters via an over-broad placeholder heuristic. When a *materialized* kernel body sizes a threadgroup/array with **local `constexpr int` constants** —

```cpp
constexpr int BN = 32;
constexpr int BD = 32;
threadgroup float outputs[BN * BD];
```

— those extents were wrongly reported as unresolved template parameters, producing a spurious `project.translate.template-materialization-unsupported`. (The materializer was already correct; this is purely a scanner false positive.)

The struct/class-path scanner (`_unresolved_metal_template_type_records`) already guards against exactly this by calling `_metal_template_arguments_are_local_constants`. The standalone-type path (`_unresolved_metal_standalone_template_type_records`) did not. This threads the declaration offset into its `append_record` helper and applies the same guard for **body-local** declarations: candidates that resolve to in-scope local `constexpr`/`const` names are suppressed. Header return/parameter types are passed the function's own offset (outside any body), so their behavior is unchanged and genuine unresolved placeholders are still reported.

## Impact

- MLX **`conv`** and **`scaled_dot_product_attention`** now translate to Vulkan — valid SPIR-V, the local extents fold to constants (verified: 0 `template-materialization-unsupported` diagnostics, well-formed `.spvasm`, no leftover `template`/`<...>` constructs).

## Verification

- New end-to-end test `test_metal_local_constexpr_array_extent_is_not_unresolved_template`: a kernel whose threadgroup array is sized by body-local `constexpr` constants (`BN`/`BD`) translates to Vulkan with no `template-materialization-unsupported`.
- Full `tests/test_translator` + `tests/test_backend` green (**12,596 passed, 405 skipped, 0 failed**).
- MLX reduced-frontier harness passes.

Part of #1354

Support issue traceability: no issue closed
