### PR TITLE
Scope runtime contracts to selected entry point

### DIFF
--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -611,6 +611,7 @@ class RuntimeFixture:
 
     id: str
     selector: RuntimeArtifactSelector
+    entry_point: str | None = None
     inputs: tuple[RuntimeValue, ...] = field(default_factory=tuple)
     expected_outputs: tuple[RuntimeValue, ...] = field(default_factory=tuple)
     default_tolerance: RuntimeTolerance = field(default_factory=RuntimeTolerance)
@@ -628,6 +629,8 @@ class RuntimeFixture:
         }
         if self.executor is not None:
             payload["executor"] = self.executor
+        if self.entry_point is not None:
+            payload["entryPoint"] = self.entry_point
         if self.adapter_contract is not None:
             adapter_contract = self.adapter_contract.to_json()
             if adapter_contract:
@@ -753,6 +756,7 @@ class RuntimeExecutionRequest:
     adapter_contract: RuntimeAdapterContract = field(
         default_factory=RuntimeAdapterContract
     )
+    diagnostics: tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
     execution_plan: RuntimeExecutionPlan | None = None
 
 
@@ -1844,7 +1848,9 @@ def prepare_runtime_execution(
     constant_bindings, constant_diagnostics = _runtime_bound_constants(
         contract, artifact
     )
-    diagnostics = tuple(resource_diagnostics + constant_diagnostics)
+    diagnostics = tuple(
+        list(request.diagnostics) + resource_diagnostics + constant_diagnostics
+    )
     return RuntimeExecutionPlan(
         artifact=artifact,
         artifact_path=artifact_path,
@@ -2502,7 +2508,10 @@ def _runtime_test_manifest_generation_diagnostics(
         return diagnostics
 
     artifact = selected["artifact"]
-    contract = _runtime_adapter_contract(fixture, artifact)
+    contract, scope_diagnostics = _runtime_adapter_contract_with_diagnostics(
+        fixture, artifact
+    )
+    diagnostics.extend(scope_diagnostics)
     diagnostics.extend(
         _runtime_test_manifest_contract_diagnostics(
             fixture,
@@ -2586,7 +2595,9 @@ def _runtime_test_manifest_contract_diagnostics(
                 artifact=_artifact_result_payload(artifact),
             )
         )
-    if not contract.resource_bindings:
+    if not contract.resource_bindings and not _runtime_contract_scope_is_ambiguous(
+        contract, "resourceBindings"
+    ):
         diagnostics.append(
             _diagnostic(
                 "warning",
@@ -2611,6 +2622,19 @@ def _runtime_test_manifest_contract_diagnostics(
             )
         )
     return diagnostics
+
+
+def _runtime_contract_scope_is_ambiguous(
+    contract: RuntimeAdapterContract, field_name: str
+) -> bool:
+    scope = contract.metadata.get("entryPointScope")
+    if not isinstance(scope, Mapping):
+        return False
+    counts = scope.get("ambiguousCounts")
+    if not isinstance(counts, Mapping):
+        return False
+    count = counts.get(field_name)
+    return isinstance(count, int) and not isinstance(count, bool) and count > 0
 
 
 def _runtime_test_manifest_artifact_manifest(
@@ -3016,6 +3040,8 @@ def _runtime_test_plan_case(
         "status": "planned",
         "diagnostics": [],
     }
+    if test_case.fixture.entry_point is not None:
+        case_payload["entryPoint"] = test_case.fixture.entry_point
     if selected["status"] != PASSED:
         case_payload.update(
             {
@@ -3033,13 +3059,16 @@ def _runtime_test_plan_case(
 
     artifact = selected["artifact"]
     artifact_path = _runtime_artifact_path(artifact, root_path=root_path)
-    adapter_contract = _runtime_adapter_contract(test_case.fixture, artifact)
+    adapter_contract, contract_diagnostics = _runtime_adapter_contract_with_diagnostics(
+        test_case.fixture, artifact
+    )
     request = RuntimeExecutionRequest(
         fixture=test_case.fixture,
         artifact=artifact,
         artifact_path=artifact_path,
         project_root=root_path,
         adapter_contract=adapter_contract,
+        diagnostics=contract_diagnostics,
     )
     execution_plan = prepare_runtime_execution(request)
     diagnostics = list(execution_plan.diagnostics)
@@ -3126,6 +3155,8 @@ def _runtime_test_planned_result(
             if isinstance(diagnostic, Mapping)
         ],
     }
+    if test_case.fixture.entry_point is not None:
+        result["entryPoint"] = test_case.fixture.entry_point
     for key in ("runtimeAdapter", "runtimeExecution", "failurePhase"):
         if key in plan_case:
             result[key] = plan_case[key]
@@ -3398,6 +3429,10 @@ def _parse_runtime_fixture(value: Any, *, index: int) -> RuntimeFixture:
     return RuntimeFixture(
         id=fixture_id,
         selector=selector,
+        entry_point=_optional_string(
+            value.get("entryPoint", value.get("entry_point")),
+            field_name=f"fixtures[{index}].entryPoint",
+        ),
         inputs=inputs,
         expected_outputs=expected_outputs,
         default_tolerance=default_tolerance,
@@ -3571,9 +3606,7 @@ def _parse_runtime_resource_binding(
         raise RuntimeVerificationError(
             f"{field_name} must identify a resource by id, name, or binding."
         )
-    metadata = _parse_runtime_metadata(
-        value.get("metadata", {}), field_name=f"{field_name}.metadata"
-    )
+    metadata = _parse_runtime_contract_item_metadata(value, field_name=field_name)
     if "required" in value:
         metadata["required"] = _optional_bool(
             value.get("required"), field_name=f"{field_name}.required"
@@ -3642,9 +3675,7 @@ def _parse_runtime_specialization_constant(
         required=_optional_bool(
             value.get("required", False), field_name=f"{field_name}.required"
         ),
-        metadata=_parse_runtime_metadata(
-            value.get("metadata", {}), field_name=f"{field_name}.metadata"
-        ),
+        metadata=_parse_runtime_contract_item_metadata(value, field_name=field_name),
     )
 
 
@@ -3702,10 +3733,32 @@ def _parse_runtime_validation_hook(
         required=_optional_bool(
             value.get("required", True), field_name=f"{field_name}.required"
         ),
-        metadata=_parse_runtime_metadata(
-            value.get("metadata", {}), field_name=f"{field_name}.metadata"
-        ),
+        metadata=_parse_runtime_contract_item_metadata(value, field_name=field_name),
     )
+
+
+def _parse_runtime_contract_item_metadata(
+    value: Mapping[str, Any], *, field_name: str
+) -> dict[str, Any]:
+    metadata = _parse_runtime_metadata(
+        value.get("metadata", {}), field_name=f"{field_name}.metadata"
+    )
+    entry_points = list(_runtime_metadata_entry_points(metadata))
+    for key in ("entryPoint", "entry_point"):
+        if key not in value:
+            continue
+        entry_point = _optional_string(value.get(key), field_name=f"{field_name}.{key}")
+        if entry_point is not None:
+            entry_points.append(entry_point)
+    for key in ("entryPoints", "entry_points"):
+        if key not in value:
+            continue
+        entry_points.extend(
+            _string_tuple(value.get(key), field_name=f"{field_name}.{key}")
+        )
+    if entry_points:
+        metadata["entryPoints"] = _dedupe_strings(entry_points)
+    return metadata
 
 
 def _parse_runtime_value_list(value: Any, *, field_name: str):
@@ -4030,13 +4083,16 @@ def _verify_runtime_fixture(
 
     artifact = selected["artifact"]
     artifact_path = _runtime_artifact_path(artifact, root_path=root_path)
-    adapter_contract = _runtime_adapter_contract(fixture, artifact)
+    adapter_contract, contract_diagnostics = _runtime_adapter_contract_with_diagnostics(
+        fixture, artifact
+    )
     initial_request = RuntimeExecutionRequest(
         fixture=fixture,
         artifact=artifact,
         artifact_path=artifact_path,
         project_root=root_path,
         adapter_contract=adapter_contract,
+        diagnostics=contract_diagnostics,
     )
     execution_plan = prepare_runtime_execution(initial_request)
     setup_diagnostics = list(execution_plan.diagnostics)
@@ -4407,10 +4463,303 @@ def _artifact_failed(artifact: Mapping[str, Any]) -> bool:
 def _runtime_adapter_contract(
     fixture: RuntimeFixture, artifact: Mapping[str, Any]
 ) -> RuntimeAdapterContract:
+    contract, _ = _runtime_adapter_contract_with_diagnostics(fixture, artifact)
+    return contract
+
+
+def _runtime_adapter_contract_with_diagnostics(
+    fixture: RuntimeFixture, artifact: Mapping[str, Any]
+) -> tuple[RuntimeAdapterContract, tuple[Mapping[str, Any], ...]]:
     artifact_contract = _runtime_adapter_contract_from_artifact(artifact)
-    if fixture.adapter_contract is None:
-        return artifact_contract
-    return _merge_runtime_adapter_contract(artifact_contract, fixture.adapter_contract)
+    selection_contract = (
+        artifact_contract
+        if fixture.adapter_contract is None
+        else _merge_runtime_adapter_contract(
+            artifact_contract, fixture.adapter_contract
+        )
+    )
+    selected_entry_point, selection_source = _runtime_selected_entry_point(
+        fixture, selection_contract
+    )
+    candidates = tuple(entry.name for entry in artifact_contract.entry_points)
+    if selected_entry_point is None:
+        if len(candidates) <= 1:
+            return selection_contract, ()
+        diagnostic = _runtime_entry_point_scope_diagnostic(
+            "error",
+            "project.runtime-verification.entry-point-selection-ambiguous",
+            "Runtime fixture does not select one entry point from a multi-entry artifact.",
+            fixture,
+            artifact,
+            selected_entry_point=None,
+            candidates=candidates,
+        )
+        scoped_artifact = replace(
+            artifact_contract,
+            resource_bindings=(),
+            specialization_constants=(),
+            validation_hooks=(),
+        )
+        contract = (
+            scoped_artifact
+            if fixture.adapter_contract is None
+            else _merge_runtime_adapter_contract(
+                scoped_artifact, fixture.adapter_contract
+            )
+        )
+        return contract, (diagnostic,)
+
+    if candidates and selected_entry_point not in candidates:
+        diagnostic = _runtime_entry_point_scope_diagnostic(
+            "error",
+            "project.runtime-verification.entry-point-missing",
+            "Runtime fixture selected an entry point that is not present in the artifact contract.",
+            fixture,
+            artifact,
+            selected_entry_point=selected_entry_point,
+            candidates=candidates,
+        )
+        return selection_contract, (diagnostic,)
+
+    scoped_artifact, diagnostics = _scope_runtime_adapter_contract(
+        artifact_contract,
+        fixture=fixture,
+        artifact=artifact,
+        selected_entry_point=selected_entry_point,
+        selection_source=selection_source,
+    )
+    contract = (
+        scoped_artifact
+        if fixture.adapter_contract is None
+        else _merge_runtime_adapter_contract(scoped_artifact, fixture.adapter_contract)
+    )
+    return (
+        _select_runtime_contract_entry_point(
+            contract,
+            selected_entry_point=selected_entry_point,
+            selection_source=selection_source,
+        ),
+        diagnostics,
+    )
+
+
+def _runtime_selected_entry_point(
+    fixture: RuntimeFixture, contract: RuntimeAdapterContract
+) -> tuple[str | None, str | None]:
+    if fixture.entry_point is not None:
+        return fixture.entry_point, "fixture.entryPoint"
+    if contract.dispatch is not None and contract.dispatch.entry_point is not None:
+        return contract.dispatch.entry_point, "runtimeAdapter.dispatch.entryPoint"
+    if len(contract.entry_points) == 1:
+        return contract.entry_points[0].name, "runtimeAdapter.entryPoints"
+    return None, None
+
+
+def _scope_runtime_adapter_contract(
+    contract: RuntimeAdapterContract,
+    *,
+    fixture: RuntimeFixture,
+    artifact: Mapping[str, Any],
+    selected_entry_point: str,
+    selection_source: str | None,
+) -> tuple[RuntimeAdapterContract, tuple[Mapping[str, Any], ...]]:
+    if len(contract.entry_points) <= 1:
+        return (
+            _select_runtime_contract_entry_point(
+                contract,
+                selected_entry_point=selected_entry_point,
+                selection_source=selection_source,
+            ),
+            (),
+        )
+
+    resources, ambiguous_resources = _runtime_owned_contract_items(
+        contract.resource_bindings, selected_entry_point
+    )
+    constants, ambiguous_constants = _runtime_owned_contract_items(
+        contract.specialization_constants, selected_entry_point
+    )
+    hooks, ambiguous_hooks = _runtime_owned_contract_items(
+        contract.validation_hooks, selected_entry_point
+    )
+    diagnostics: list[Mapping[str, Any]] = []
+    if ambiguous_resources:
+        diagnostics.append(
+            _runtime_entry_point_scope_diagnostic(
+                "warning",
+                "project.runtime-verification.entry-point-resource-scope-ambiguous",
+                "Artifact resource ownership cannot be proven for the selected entry point; ambiguous resources were excluded from the runtime contract.",
+                fixture,
+                artifact,
+                selected_entry_point=selected_entry_point,
+                candidates=tuple(entry.name for entry in contract.entry_points),
+                ambiguousResources=[
+                    _runtime_resource_binding_name(binding)
+                    for binding in ambiguous_resources
+                ],
+            )
+        )
+    if ambiguous_constants:
+        diagnostics.append(
+            _runtime_entry_point_scope_diagnostic(
+                "warning",
+                "project.runtime-verification.entry-point-constant-scope-ambiguous",
+                "Artifact constant ownership cannot be proven for the selected entry point; ambiguous constants were excluded from the runtime contract.",
+                fixture,
+                artifact,
+                selected_entry_point=selected_entry_point,
+                candidates=tuple(entry.name for entry in contract.entry_points),
+                ambiguousConstants=[
+                    _runtime_constant_name(constant) for constant in ambiguous_constants
+                ],
+            )
+        )
+    if ambiguous_hooks:
+        diagnostics.append(
+            _runtime_entry_point_scope_diagnostic(
+                "warning",
+                "project.runtime-verification.entry-point-validation-scope-ambiguous",
+                "Artifact validation-hook ownership cannot be proven for the selected entry point; ambiguous hooks were excluded from the runtime contract.",
+                fixture,
+                artifact,
+                selected_entry_point=selected_entry_point,
+                candidates=tuple(entry.name for entry in contract.entry_points),
+                ambiguousValidationHooks=[hook.name for hook in ambiguous_hooks],
+            )
+        )
+
+    scoped = replace(
+        contract,
+        resource_bindings=resources,
+        specialization_constants=constants,
+        validation_hooks=hooks,
+    )
+    return (
+        _select_runtime_contract_entry_point(
+            scoped,
+            selected_entry_point=selected_entry_point,
+            selection_source=selection_source,
+            ambiguous_counts={
+                "resourceBindings": len(ambiguous_resources),
+                "specializationConstants": len(ambiguous_constants),
+                "validationHooks": len(ambiguous_hooks),
+            },
+        ),
+        tuple(diagnostics),
+    )
+
+
+def _runtime_owned_contract_items(
+    items: Sequence[Any], selected_entry_point: str
+) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
+    scoped: list[Any] = []
+    ambiguous: list[Any] = []
+    for item in items:
+        metadata = getattr(item, "metadata", {})
+        owners = _runtime_metadata_entry_points(metadata)
+        if not owners:
+            ambiguous.append(item)
+        elif selected_entry_point in owners:
+            scoped.append(item)
+    return tuple(scoped), tuple(ambiguous)
+
+
+def _runtime_metadata_entry_points(metadata: Any) -> tuple[str, ...]:
+    if not isinstance(metadata, Mapping):
+        return ()
+    names: list[str] = []
+    for key in ("entryPoint", "entry_point"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            names.append(value.strip())
+    for key in ("entryPoints", "entry_points"):
+        value = metadata.get(key)
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            names.extend(
+                item.strip() for item in value if isinstance(item, str) and item.strip()
+            )
+    return tuple(_dedupe_strings(names))
+
+
+def _select_runtime_contract_entry_point(
+    contract: RuntimeAdapterContract,
+    *,
+    selected_entry_point: str,
+    selection_source: str | None,
+    ambiguous_counts: Mapping[str, int] | None = None,
+) -> RuntimeAdapterContract:
+    entry_points = tuple(
+        entry for entry in contract.entry_points if entry.name == selected_entry_point
+    )
+    dispatch = contract.dispatch
+    selected = entry_points[0] if entry_points else None
+    if dispatch is None:
+        dispatch = RuntimeDispatchGeometry(
+            entry_point=selected_entry_point,
+            workgroup_size=(selected.workgroup_size if selected is not None else ()),
+        )
+    else:
+        dispatch = replace(
+            dispatch,
+            entry_point=selected_entry_point,
+            workgroup_size=(
+                selected.workgroup_size
+                if selected is not None and selected.workgroup_size
+                else dispatch.workgroup_size
+            ),
+        )
+    existing_scope = contract.metadata.get("entryPointScope")
+    scope_metadata: dict[str, Any] = (
+        dict(existing_scope) if isinstance(existing_scope, Mapping) else {}
+    )
+    scope_metadata.update(
+        {
+            "entryPoint": selected_entry_point,
+            "status": "scoped",
+        }
+    )
+    if selection_source is not None:
+        scope_metadata["source"] = selection_source
+    if ambiguous_counts is not None:
+        scope_metadata["ambiguousCounts"] = dict(ambiguous_counts)
+    return replace(
+        contract,
+        entry_points=entry_points,
+        dispatch=dispatch,
+        metadata={
+            **dict(contract.metadata),
+            "entryPointScope": scope_metadata,
+        },
+    )
+
+
+def _runtime_entry_point_scope_diagnostic(
+    severity: str,
+    code: str,
+    message: str,
+    fixture: RuntimeFixture,
+    artifact: Mapping[str, Any],
+    *,
+    selected_entry_point: str | None,
+    candidates: Sequence[str],
+    **context: Any,
+) -> dict[str, Any]:
+    return _runtime_execution_diagnostic(
+        severity,
+        code,
+        message,
+        artifact,
+        fixture=fixture.id,
+        artifactId=artifact.get("id"),
+        entryPoint=selected_entry_point,
+        selectedEntryPoint=selected_entry_point,
+        entryPointCandidates=list(candidates),
+        candidateEntryPoints=list(candidates),
+        target=artifact.get("target"),
+        **context,
+    )
 
 
 def _runtime_adapter_contract_from_artifact(
@@ -5434,6 +5783,8 @@ def _fixture_result(
         "comparisons": [dict(comparison) for comparison in comparisons],
         "diagnostics": [dict(diagnostic) for diagnostic in diagnostics],
     }
+    if fixture.entry_point is not None:
+        result["entryPoint"] = fixture.entry_point
     if adapter_contract is not None:
         adapter_payload = adapter_contract.to_json()
         if adapter_payload:

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -47,10 +47,13 @@ The reduced harness now emits runtime readiness artifacts so those gaps are
 visible in CI reports without claiming runtime parity. The current readiness
 manifests consume reflected runtime artifact metadata, including entry points,
 resource bindings, and dispatch geometry. Runtime-test plans now resolve
-source-level fixture names against common generated resource aliases and report
-remaining non-blocking platform or layout warnings. These plans are still
-metadata readiness artifacts; they do not execute the upstream MLX runtime on
-non-Metal backends.
+source-level fixture names against common generated resource aliases. The
+reduced arange fixtures select the translated artifact by source and target,
+then select `CSMain`, `main`, or `arangeuint8` independently for DirectX,
+OpenGL, or Vulkan dispatch. Plans report remaining non-blocking platform,
+layout, and entry-point ownership warnings. These plans are still metadata
+readiness artifacts; they do not execute the upstream MLX runtime on non-Metal
+backends.
 
 ## Running Locally
 
@@ -95,18 +98,17 @@ CrossGL/crosstl#1376 tracks bounded runtime for the scheduled full-corpus scout.
 CrossGL/crosstl#1312 tracks native toolchain validation coverage for project
 CI. CrossGL/crosstl#1388 tracks the artifact execution metadata required by
 runtime-test manifests and native adapters. CrossGL/crosstl#1392 tracks fixture
-resource binding through reflected backend aliases. CrossGL/crosstl#1394 tracks
-entry-point-scoped runtime adapter contracts for multi-entry artifacts.
-CrossGL/crosstl#1396 tracks generated GLSL helper uniforms that reflection
-currently reports as layout-incomplete runtime resources. Future scouts should
-add issue-backed blockers only when there are concrete repros. Host runtime
-integration gaps should be handled in repository integration code or downstream
-runtime adapters, not hidden as shader translation successes.
+resource binding through reflected backend aliases. CrossGL/crosstl#1396 tracks
+generated GLSL helper uniforms that reflection currently reports as
+layout-incomplete runtime resources. Future scouts should add issue-backed
+blockers only when there are concrete repros. Host runtime integration gaps
+should be handled in repository integration code or downstream runtime
+adapters, not hidden as shader translation successes.
 
 ## Resolved Frontier Issues
 
 The current reduced frontier no longer depends on the previously tracked issues:
-CrossGL/crosstl#1317, CrossGL/crosstl#939, CrossGL/crosstl#940,
+CrossGL/crosstl#1394, CrossGL/crosstl#1317, CrossGL/crosstl#939, CrossGL/crosstl#940,
 CrossGL/crosstl#941, CrossGL/crosstl#943, CrossGL/crosstl#944,
 CrossGL/crosstl#945, and CrossGL/crosstl#946. CrossGL/crosstl#979,
 CrossGL/crosstl#980,

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -35,6 +35,8 @@
     },
     "runtime_plan_diagnostics_by_code": {
       "project.runtime-test.platform-requirements-unavailable": 1,
+      "project.runtime-verification.entry-point-constant-scope-ambiguous": 1,
+      "project.runtime-verification.entry-point-resource-scope-ambiguous": 1,
       "project.runtime-verification.resource-unbound": 1
     }
   },
@@ -82,7 +84,6 @@
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1388",
     "https://github.com/CrossGL/crosstl/issues/1392",
-    "https://github.com/CrossGL/crosstl/issues/1394",
     "https://github.com/CrossGL/crosstl/issues/1396"
   ],
   "resolved_issues": [
@@ -169,6 +170,7 @@
     "https://github.com/CrossGL/crosstl/issues/1338",
     "https://github.com/CrossGL/crosstl/issues/1340",
     "https://github.com/CrossGL/crosstl/issues/1346",
-    "https://github.com/CrossGL/crosstl/issues/1355"
+    "https://github.com/CrossGL/crosstl/issues/1355",
+    "https://github.com/CrossGL/crosstl/issues/1394"
   ]
 }

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -47,9 +47,13 @@ FULL_CORPUS_TRANSLATION_TRACKED_ISSUES = (
 RUNTIME_READINESS_TRACKED_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1388",
     "https://github.com/CrossGL/crosstl/issues/1392",
-    "https://github.com/CrossGL/crosstl/issues/1394",
     "https://github.com/CrossGL/crosstl/issues/1396",
 )
+RUNTIME_READINESS_ENTRY_POINTS = {
+    "directx": "CSMain",
+    "opengl": "main",
+    "vulkan": "arangeuint8",
+}
 RUNTIME_READINESS_DIAGNOSTIC_CODES = frozenset(
     (
         "project.runtime-test-manifest.entry-points-unavailable",
@@ -72,6 +76,7 @@ RESOLVED_FRONTIER_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1452",
     "https://github.com/CrossGL/crosstl/issues/1354",
     "https://github.com/CrossGL/crosstl/issues/1362",
+    "https://github.com/CrossGL/crosstl/issues/1394",
     "https://github.com/CrossGL/crosstl/issues/1317",
     "https://github.com/CrossGL/crosstl/issues/1300",
     "https://github.com/CrossGL/crosstl/issues/939",
@@ -644,12 +649,18 @@ def _check_arange_opengl(
 
 
 def _runtime_readiness_fixture(target: str) -> dict[str, Any]:
+    entry_point = RUNTIME_READINESS_ENTRY_POINTS.get(target)
+    _require(
+        entry_point is not None,
+        f"runtime readiness entry point is not configured for target: {target}",
+    )
     return {
         "id": f"mlx-arange-{target}-runtime-readiness",
         "selector": {
             "source": MLX_ARANGE_SOURCE,
             "target": target,
         },
+        "entryPoint": entry_point,
         "inputs": [
             {
                 "name": "start",
@@ -673,6 +684,11 @@ def _runtime_readiness_fixture(target: str) -> dict[str, Any]:
                 "values": [0, 1, 2, 3],
             }
         ],
+        "runtimeAdapter": {
+            "dispatch": {
+                "globalSize": [4, 1, 1],
+            }
+        },
         "metadata": {
             "repository": "mlx",
             "source": MLX_ARANGE_SOURCE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+import shutil
+import subprocess
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+
+@lru_cache(maxsize=1)
+def _xcrun_resolves_missing_metal_toolchain() -> bool:
+    xcrun = shutil.which("xcrun")
+    if xcrun is None:
+        return False
+
+    lookup = subprocess.run(
+        [xcrun, "-sdk", "macosx", "-f", "metal"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    if lookup.returncode != 0:
+        return False
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_path = Path(temp_dir) / "probe.metal"
+        output_path = Path(temp_dir) / "probe.air"
+        source_path.write_text(
+            """
+#include <metal_stdlib>
+using namespace metal;
+kernel void probe() {}
+""".lstrip(),
+            encoding="utf-8",
+        )
+        probe = subprocess.run(
+            [
+                xcrun,
+                "-sdk",
+                "macosx",
+                "metal",
+                "-c",
+                str(source_path),
+                "-o",
+                str(output_path),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+
+    diagnostics = "\n".join(
+        part for part in (probe.stdout, probe.stderr) if part.strip()
+    )
+    return (
+        probe.returncode != 0
+        and "missing Metal Toolchain" in diagnostics
+        and "xcodebuild -downloadComponent MetalToolchain" in diagnostics
+    )
+
+
+@pytest.fixture(autouse=True)
+def hide_xcrun_when_metal_toolchain_is_incomplete(monkeypatch):
+    if not _xcrun_resolves_missing_metal_toolchain():
+        return
+
+    real_which = shutil.which
+
+    def which(name, *args, **kwargs):
+        if name == "xcrun":
+            return None
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "which", which)

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -56,6 +56,7 @@ def _translated_arange_report(module, target):
 
 
 def _runtime_arange_artifact_manifest(module, target, output_name="out"):
+    entry_point = module.RUNTIME_READINESS_ENTRY_POINTS[target]
     return {
         "kind": "crosstl-project-runtime-artifact-manifest",
         "project": {"targets": [target]},
@@ -77,7 +78,7 @@ def _runtime_arange_artifact_manifest(module, target, output_name="out"):
                 "status": "translated",
                 "entryPoints": [
                     {
-                        "name": "main",
+                        "name": entry_point,
                         "stage": "compute",
                         "workgroupSize": [1, 1, 1],
                     }
@@ -100,7 +101,7 @@ def _runtime_arange_artifact_manifest(module, target, output_name="out"):
                     },
                 ],
                 "dispatch": {
-                    "entryPoint": "main",
+                    "entryPoint": entry_point,
                     "workgroupSize": [1, 1, 1],
                     "workgroupCount": [1, 1, 1],
                 },
@@ -149,7 +150,6 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
     assert result["trackedRuntimeIssues"] == [
         "https://github.com/CrossGL/crosstl/issues/1388",
         "https://github.com/CrossGL/crosstl/issues/1392",
-        "https://github.com/CrossGL/crosstl/issues/1394",
         "https://github.com/CrossGL/crosstl/issues/1396",
     ]
     assert result["testCount"] == 1
@@ -168,9 +168,43 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
     assert manifest["metadata"]["trackedIssues"] == [
         "https://github.com/CrossGL/crosstl/issues/1388",
         "https://github.com/CrossGL/crosstl/issues/1392",
-        "https://github.com/CrossGL/crosstl/issues/1394",
         "https://github.com/CrossGL/crosstl/issues/1396",
     ]
+    assert manifest["tests"][0]["selector"] == {
+        "source": module.MLX_ARANGE_SOURCE,
+        "target": "directx",
+    }
+    assert manifest["tests"][0]["entryPoint"] == "CSMain"
+
+    plan = json.loads((mlx_root / result["runtimeTestPlan"]).read_text())
+    assert plan["testCases"][0]["runtimeExecution"]["dispatch"]["entryPoint"] == (
+        "CSMain"
+    )
+
+
+@pytest.mark.parametrize(
+    ("target", "entry_point"),
+    (("directx", "CSMain"), ("opengl", "main"), ("vulkan", "arangeuint8")),
+)
+def test_runtime_readiness_selects_entry_point_independently(target, entry_point):
+    module = _load_harness()
+
+    fixture = module._runtime_readiness_fixture(target)
+
+    assert fixture["selector"] == {
+        "source": module.MLX_ARANGE_SOURCE,
+        "target": target,
+    }
+    assert fixture["entryPoint"] == entry_point
+    assert fixture["runtimeAdapter"]["dispatch"] == {
+        "globalSize": [4, 1, 1],
+    }
+    assert "https://github.com/CrossGL/crosstl/issues/1394" not in (
+        module.RUNTIME_READINESS_TRACKED_ISSUES
+    )
+    assert "https://github.com/CrossGL/crosstl/issues/1394" in (
+        module.RESOLVED_FRONTIER_ISSUES
+    )
 
 
 def test_runtime_readiness_reports_tracked_plan_resource_blockers(

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -22,6 +22,7 @@ from crosstl.project.runtime_verification import (
     NativeRuntimeParityAdapter,
     OpenGLRuntimeParityAdapter,
     RuntimeAdapterContract,
+    RuntimeArtifactSelector,
     RuntimeDispatchGeometry,
     RuntimeEntryPoint,
     RuntimeExecutionAdapter,
@@ -30,6 +31,7 @@ from crosstl.project.runtime_verification import (
     RuntimeExecutorAvailability,
     RuntimeExecutorResult,
     RuntimeExecutorSkipped,
+    RuntimeFixture,
     RuntimeParityAdapter,
     RuntimeResourceBinding,
     RuntimeSpecializationConstant,
@@ -318,6 +320,34 @@ def test_load_runtime_verification_fixtures_parses_adapter_contract(tmp_path):
         1,
         1,
     ]
+
+
+def test_runtime_fixture_round_trips_independent_entry_point():
+    fixture = RuntimeFixture(
+        id="entry-point-fixture",
+        selector=RuntimeArtifactSelector(
+            source="kernels/add.cgl",
+            target="opengl",
+        ),
+        entry_point="vector_add",
+    )
+
+    assert fixture.entry_point == "vector_add"
+    assert fixture.to_json()["entryPoint"] == "vector_add"
+
+    parsed = parse_runtime_verification_fixtures(
+        {
+            "fixtures": [
+                _runtime_fixture(
+                    id="parsed-entry-point-fixture",
+                    entryPoint="reduce_sum",
+                )
+            ]
+        }
+    )[0]
+
+    assert parsed.entry_point == "reduce_sum"
+    assert parsed.to_json()["entryPoint"] == "reduce_sum"
 
 
 def test_parse_runtime_verification_fixtures_rejects_missing_selector():
@@ -781,12 +811,238 @@ def test_plan_runtime_test_manifest_warns_for_unbound_incomplete_layout_resource
     plan = plan_runtime_test_manifest(artifact_report, manifest, project_root=tmp_path)
 
     case = plan["testCases"][0]
-    assert case["status"] == "planned"
+    assert case["status"] in {"planned", "skipped"}
     assert case["diagnostics"][0]["severity"] == "warning"
     assert case["diagnostics"][0]["code"] == (
         "project.runtime-verification.resource-unbound"
     )
     assert plan["summary"]["failedCount"] == 0
+
+
+def test_plan_runtime_test_manifest_scopes_contract_to_fixture_entry_point(tmp_path):
+    artifact_report = _artifact_report(
+        tmp_path,
+        [
+            _translated_artifact(
+                id="multi-entry-artifact",
+                entryPoints=[
+                    {"name": "vector_add", "stage": "compute"},
+                    {"name": "reduce_sum", "stage": "compute"},
+                ],
+                resourceBindings=[
+                    {
+                        "name": "lhs",
+                        "kind": "buffer",
+                        "binding": 0,
+                        "metadata": {"entryPoint": "vector_add"},
+                    },
+                    {
+                        "name": "scratch",
+                        "kind": "buffer",
+                        "binding": 1,
+                        "metadata": {"entryPoints": ["reduce_sum"]},
+                    },
+                    {
+                        "name": "out",
+                        "kind": "buffer",
+                        "binding": 2,
+                        "metadata": {"entryPoints": ["vector_add"]},
+                    },
+                ],
+                specializationConstants=[
+                    {
+                        "name": "vector_width",
+                        "value": 4,
+                        "metadata": {"entryPoint": "vector_add"},
+                    },
+                    {
+                        "name": "reduction_width",
+                        "value": 8,
+                        "metadata": {"entryPoints": ["reduce_sum"]},
+                    },
+                ],
+                validationHooks=[
+                    {
+                        "name": "validate-vector-layout",
+                        "metadata": {"entryPoint": "vector_add"},
+                    },
+                    {
+                        "name": "validate-reduction-layout",
+                        "metadata": {"entryPoints": ["reduce_sum"]},
+                    },
+                ],
+                dispatch={"entryPoint": "reduce_sum", "workgroupCount": [1, 1, 1]},
+            )
+        ],
+    )
+    manifest = {
+        "kind": RUNTIME_TEST_MANIFEST_KIND,
+        "tests": [_runtime_fixture(entryPoint="vector_add")],
+    }
+
+    plan = plan_runtime_test_manifest(artifact_report, manifest, project_root=tmp_path)
+
+    contract = plan["testCases"][0]["runtimeAdapter"]
+    assert [item["name"] for item in contract["resourceBindings"]] == ["lhs", "out"]
+    assert [item["name"] for item in contract["specializationConstants"]] == [
+        "vector_width"
+    ]
+    assert [item["name"] for item in contract["validationHooks"]] == [
+        "validate-vector-layout"
+    ]
+    assert contract["dispatch"]["entryPoint"] == "vector_add"
+
+
+def test_plan_runtime_test_manifest_infers_entry_point_from_dispatch(tmp_path):
+    artifact_report = _artifact_report(
+        tmp_path,
+        [
+            _translated_artifact(
+                entryPoints=[
+                    {"name": "vector_add", "stage": "compute"},
+                    {"name": "reduce_sum", "stage": "compute"},
+                ],
+                resourceBindings=[
+                    {
+                        "name": "lhs",
+                        "kind": "buffer",
+                        "binding": 0,
+                        "metadata": {"entryPoint": "vector_add"},
+                    },
+                    {
+                        "name": "out",
+                        "kind": "buffer",
+                        "binding": 1,
+                        "metadata": {"entryPoints": ["vector_add"]},
+                    },
+                    {
+                        "name": "scratch",
+                        "kind": "buffer",
+                        "binding": 2,
+                        "metadata": {"entryPoint": "reduce_sum"},
+                    },
+                ],
+                dispatch={"entryPoint": "vector_add", "workgroupCount": [1, 1, 1]},
+            )
+        ],
+    )
+
+    plan = plan_runtime_test_manifest(
+        artifact_report,
+        {"kind": RUNTIME_TEST_MANIFEST_KIND, "tests": [_runtime_fixture()]},
+        project_root=tmp_path,
+    )
+
+    contract = plan["testCases"][0]["runtimeAdapter"]
+    assert [item["name"] for item in contract["resourceBindings"]] == ["lhs", "out"]
+    assert contract["dispatch"]["entryPoint"] == "vector_add"
+
+
+def test_plan_runtime_test_manifest_reports_ambiguous_entry_point_resources(tmp_path):
+    artifact_report = _artifact_report(
+        tmp_path,
+        [
+            _translated_artifact(
+                id="multi-entry-artifact",
+                entryPoints=[
+                    {"name": "vector_add", "stage": "compute"},
+                    {"name": "reduce_sum", "stage": "compute"},
+                ],
+                resourceBindings=[
+                    {"name": "lhs", "kind": "buffer", "binding": 0},
+                    {"name": "scratch", "kind": "buffer", "binding": 1},
+                    {"name": "out", "kind": "buffer", "binding": 2},
+                ],
+                dispatch={"entryPoint": "vector_add", "workgroupCount": [1, 1, 1]},
+            )
+        ],
+    )
+
+    plan = plan_runtime_test_manifest(
+        artifact_report,
+        {
+            "kind": RUNTIME_TEST_MANIFEST_KIND,
+            "tests": [_runtime_fixture(entryPoint="vector_add")],
+        },
+        project_root=tmp_path,
+    )
+
+    case = plan["testCases"][0]
+    diagnostic = next(
+        item
+        for item in case["diagnostics"]
+        if item["code"]
+        == "project.runtime-verification.entry-point-resource-scope-ambiguous"
+    )
+    assert case["status"] in {"planned", "skipped"}
+    scoped_resources = case["runtimeAdapter"].get("resourceBindings", [])
+    assert len(scoped_resources) < 3
+    assert "scratch" not in {item["name"] for item in scoped_resources}
+    assert all(
+        item["code"] != "project.runtime-verification.resource-unbound"
+        for item in case["diagnostics"]
+    )
+    assert diagnostic["fixture"] == "add-debug"
+    assert diagnostic["artifact"]["id"] == "multi-entry-artifact"
+    assert diagnostic["selectedEntryPoint"] == "vector_add"
+    assert set(diagnostic["candidateEntryPoints"]) == {"vector_add", "reduce_sum"}
+    assert diagnostic["target"] == "opengl"
+
+
+def test_runtime_test_manifest_preserves_ambiguous_scope_with_fixture_dispatch(
+    tmp_path,
+):
+    artifact_report = _artifact_report(
+        tmp_path,
+        [
+            _translated_artifact(
+                id="multi-entry-artifact",
+                entryPoints=[
+                    {"name": "vector_add", "stage": "compute"},
+                    {"name": "reduce_sum", "stage": "compute"},
+                ],
+                resourceBindings=[
+                    {"name": "lhs", "kind": "buffer", "binding": 0},
+                    {"name": "scratch", "kind": "buffer", "binding": 1},
+                    {"name": "out", "kind": "buffer", "binding": 2},
+                ],
+                dispatch={"entryPoint": "reduce_sum", "workgroupCount": [1, 1, 1]},
+            )
+        ],
+    )
+    fixture = _runtime_fixture(
+        entryPoint="vector_add",
+        runtimeAdapter={"dispatch": {"globalSize": [2, 1, 1]}},
+    )
+
+    manifest = build_runtime_test_manifest(
+        artifact_report,
+        {"kind": "crosstl-project-runtime-fixture-metadata", "fixtures": [fixture]},
+        project_root=tmp_path,
+    )
+    plan = plan_runtime_test_manifest(
+        artifact_report,
+        {"kind": RUNTIME_TEST_MANIFEST_KIND, "tests": [fixture]},
+        project_root=tmp_path,
+    )
+
+    manifest_codes = {item["code"] for item in manifest["diagnostics"]}
+    assert (
+        "project.runtime-verification.entry-point-resource-scope-ambiguous"
+        in manifest_codes
+    )
+    assert all(
+        item["code"] != "project.runtime-test-manifest.resource-bindings-unavailable"
+        for item in manifest["diagnostics"]
+    )
+    assert plan["testCases"][0]["runtimeAdapter"]["dispatch"]["entryPoint"] == (
+        "vector_add"
+    )
+    assert plan["testCases"][0]["runtimeAdapter"]["dispatch"]["globalSize"] == [
+        2,
+        1,
+        1,
+    ]
 
 
 def test_verify_runtime_fixtures_reports_setup_diagnostic_with_source_span(tmp_path):

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -1912,8 +1912,7 @@ def test_metal_struct_member_template_kernel_translates_without_false_positive(
         encoding="utf-8",
     )
     (repo / "crosstl.toml").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             [project]
             source_roots = ["kernels"]
             include = ["kernels/ops.metal"]
@@ -1922,8 +1921,7 @@ def test_metal_struct_member_template_kernel_translates_without_false_positive(
 
             [project.sources]
             "**/*.metal" = "metal"
-            """
-        ).strip(),
+            """).strip(),
         encoding="utf-8",
     )
 
@@ -1986,8 +1984,7 @@ def test_metal_local_constexpr_array_extent_is_not_unresolved_template(tmp_path)
         encoding="utf-8",
     )
     (repo / "crosstl.toml").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             [project]
             source_roots = ["kernels"]
             include = ["kernels/tg.metal"]
@@ -1996,8 +1993,7 @@ def test_metal_local_constexpr_array_extent_is_not_unresolved_template(tmp_path)
 
             [project.sources]
             "**/*.metal" = "metal"
-            """
-        ).strip(),
+            """).strip(),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- add fixture-level runtime entry point selection and scope runtime adapter contracts to the selected entry point
- emit structured diagnostics for ambiguous multi-entry resource, constant, and validation-hook ownership instead of reporting generic metadata gaps
- update the MLX reduced runtime-readiness harness to select backend-specific entry points independently of artifact selection
- skip local Metal validation tests when xcrun resolves but the downloadable Metal Toolchain component is unavailable

## Validation
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest -q -n auto
- .venv/bin/python demos/integrations/mlx/run_mlx_porting.py --mode reduced-frontier --mlx-root /tmp/crosstl-mlx-entrypoint-next --work-dir .crosstl-mlx-entrypoint-next-4

Closes #1394