### PR TITLE
Run project runtime tests with supplied executors

### DIFF
--- a/crosstl/project/test_runner.py
+++ b/crosstl/project/test_runner.py
@@ -164,6 +164,7 @@ def execute_project_test_runner_plan(
     project_root: str | os.PathLike[str] | None = None,
     output_path: str | os.PathLike[str] | None = None,
     run_runtime_tests: bool = True,
+    runtime_executors: Mapping[str, Any] | Sequence[Any] | None = None,
 ) -> dict[str, Any]:
     """Run available project commands and runtime tests from a plan."""
 
@@ -188,7 +189,11 @@ def execute_project_test_runner_plan(
         and runtime_plan.get("kind") == RUNTIME_TEST_PLAN_KIND
     ):
         runtime_report = _execute_runtime_plan(
-            runtime_plan, plan_payload.get("runtimeTestManifest"), root
+            runtime_plan,
+            plan_payload.get("runtimeTestManifest"),
+            root,
+            artifact_source=plan_payload.get("sourceArtifacts"),
+            executors=runtime_executors,
         )
     results = list(command_results)
     if isinstance(runtime_report, Mapping):
@@ -752,7 +757,12 @@ def _execute_command(
 
 
 def _execute_runtime_plan(
-    runtime_plan: Mapping[str, Any], manifest_payload: Any, root: Path
+    runtime_plan: Mapping[str, Any],
+    manifest_payload: Any,
+    root: Path,
+    *,
+    artifact_source: Any = None,
+    executors: Mapping[str, Any] | Sequence[Any] | None = None,
 ) -> Mapping[str, Any] | None:
     manifest = (
         dict(manifest_payload)
@@ -761,16 +771,25 @@ def _execute_runtime_plan(
     )
     if not manifest.get("tests"):
         return None
-    artifact_source = runtime_plan.get("sourceArtifacts", {})
+    runtime_artifact_source = runtime_plan.get("sourceArtifacts", {})
     artifact_path = (
-        artifact_source.get("path") if isinstance(artifact_source, Mapping) else None
+        runtime_artifact_source.get("path")
+        if isinstance(runtime_artifact_source, Mapping)
+        else None
     )
+    if not artifact_path:
+        artifact_path = (
+            artifact_source.get("path")
+            if isinstance(artifact_source, Mapping)
+            else None
+        )
     if not artifact_path:
         return None
     return verify_runtime_test_manifest(
         artifact_path,
         manifest,
         project_root=root,
+        executors=executors,
     )
 
 

--- a/tests/test_project_test_runner.py
+++ b/tests/test_project_test_runner.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from crosstl.project import (
     execute_project_test_runner_plan,
     inspect_project_test_runner_plan,
 )
+from crosstl.project.runtime_verification import RuntimeParityAdapter
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -192,6 +194,115 @@ def test_project_test_runner_executes_available_project_command(tmp_path):
     assert report["results"][0]["status"] == "passed"
     assert report["results"][0]["logs"][0]["returncode"] == 0
     assert output_file.read_text(encoding="utf-8") == "ok"
+
+
+def test_project_test_runner_executes_runtime_tests_with_supplied_executor(tmp_path):
+    artifact_path = tmp_path / "out" / "opengl" / "add.glsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("#version 450\nvoid main() {}\n", encoding="utf-8")
+    artifact_report_path = tmp_path / "artifact-report.json"
+    artifact_report_path.write_text(
+        json.dumps(
+            _artifact_report(
+                tmp_path,
+                [
+                    _artifact(
+                        path="out/opengl/add.glsl",
+                        dispatch={
+                            "entryPoint": "main",
+                            "globalSize": [1, 1, 1],
+                            "workgroupSize": [1, 1, 1],
+                        },
+                    )
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
+    manifest = {
+        "kind": "crosstl-project-runtime-test-manifest",
+        "adapters": [
+            {
+                "id": "fixture-runtime",
+                "executor": "fixture-runtime",
+                "adapterKind": "fixture-runtime-parity",
+                "platformRequirements": {"requiredTools": []},
+            }
+        ],
+        "tests": [
+            {
+                "id": "increment-fixture",
+                "selector": {
+                    "source": "kernels/add.cgl",
+                    "target": "opengl",
+                    "variant": "debug",
+                },
+                "adapter": "fixture-runtime",
+                "inputs": [
+                    {
+                        "name": "lhs",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [1.0],
+                    }
+                ],
+                "expectedOutputs": [
+                    {
+                        "name": "out",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [2.0],
+                    }
+                ],
+            }
+        ],
+    }
+
+    class IncrementRuntime(RuntimeParityAdapter):
+        name = "increment-runtime"
+        target = "opengl"
+
+        def prepare_buffers(self, state):
+            return dict(state.resource_values)
+
+        def dispatch(self, state, prepared_buffers):
+            assert state.plan.dispatch.entry_point == "main"
+            assert prepared_buffers["out"] is None
+            return {"out": [value + 1.0 for value in prepared_buffers["lhs"]]}
+
+        def collect_outputs(self, state, dispatch_result):
+            return {
+                name: {
+                    "dtype": "float32",
+                    "shape": [len(values)],
+                    "values": values,
+                }
+                for name, values in dispatch_result.items()
+            }
+
+    plan = build_project_test_runner_plan(
+        artifact_report_path,
+        manifest,
+        project_root=tmp_path,
+    )
+
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=tmp_path,
+        runtime_executors={"fixture-runtime": IncrementRuntime()},
+    )
+
+    runtime_report = report["runtimeTestReport"]
+    runtime_result = runtime_report["results"][0]
+    assert report["success"] is True
+    assert runtime_report["success"] is True
+    assert plan["runtimeTestPlan"]["testCases"][0]["platformRequirements"] == {}
+    assert runtime_result["status"] == "passed"
+    assert (
+        runtime_result["executor"]["details"]["runtimeParityAdapter"]["runtimeAdapter"]
+        == "increment-runtime"
+    )
+    assert report["summary"]["passedCount"] == 1
 
 
 def test_project_test_runner_inspection_summarizes_unavailable_adapters(tmp_path):


### PR DESCRIPTION
## Summary\n- allow project test-runner execution to receive runtime executor implementations\n- fall back to the outer artifact report path when executing nested runtime plans\n- add a project-level regression test that runs a supplied OpenGL runtime adapter through the execution report\n\n## Validation\n- .venv/bin/pre-commit run --all-files\n- .venv/bin/python -m pytest -q -n auto\n\nRefs #1462

Support issue traceability: no issue closed
