### PR TITLE
Execute MLX runtime fixtures through project runner

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -1,6 +1,9 @@
 """High-level translation API and command-line entry point for CrossGL Translator."""
 
 import argparse
+import importlib
+import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -908,6 +911,77 @@ def _load_project_test_runner_config(path):
     return dict(payload)
 
 
+def _load_project_runtime_executors(specs):
+    executors = {}
+    for spec in specs or ():
+        key, separator, reference = spec.partition("=")
+        key = key.strip()
+        reference = reference.strip()
+        if not separator or not key or not reference:
+            raise ValueError("Runtime executor specs must use EXECUTOR=MODULE:OBJECT.")
+        executor = _load_project_runtime_executor(reference)
+        executors[key] = executor
+    return executors
+
+
+def _load_project_runtime_executor(reference):
+    module_ref, separator, object_name = reference.rpartition(":")
+    module_ref = module_ref.strip()
+    object_name = object_name.strip()
+    if not separator or not module_ref or not object_name:
+        raise ValueError("Runtime executor references must use MODULE:OBJECT.")
+    module = _load_project_runtime_executor_module(module_ref)
+    try:
+        value = getattr(module, object_name)
+    except AttributeError as exc:
+        raise ValueError(
+            f"Runtime executor object {object_name!r} was not found in {module_ref!r}."
+        ) from exc
+    executor = _project_runtime_executor_instance(value)
+    if not _project_runtime_executor_like(executor):
+        raise ValueError(
+            "Runtime executor objects must expose run(request) or "
+            "prepare_buffers(state), dispatch(state, buffers), and "
+            "collect_outputs(state, result)."
+        )
+    return executor
+
+
+def _load_project_runtime_executor_module(module_ref):
+    module_path = Path(module_ref)
+    if module_path.suffix == ".py" or module_path.exists():
+        module_path = module_path.resolve()
+        if not module_path.is_file():
+            raise ValueError(f"Runtime executor module is not a file: {module_path}")
+        module_name = f"crosstl_runtime_executor_{abs(hash(str(module_path)))}"
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load runtime executor module: {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    return importlib.import_module(module_ref)
+
+
+def _project_runtime_executor_instance(value):
+    if inspect.isclass(value):
+        return value()
+    if _project_runtime_executor_like(value):
+        return value
+    if callable(value):
+        return value()
+    return value
+
+
+def _project_runtime_executor_like(value):
+    if callable(getattr(value, "run", None)):
+        return True
+    return all(
+        callable(getattr(value, method, None))
+        for method in ("prepare_buffers", "dispatch", "collect_outputs")
+    )
+
+
 def _format_project_test_runner_plan(payload):
     lines = [
         f"Project test-runner plan: {payload.get('sourceArtifacts', {}).get('path')}"
@@ -1101,6 +1175,7 @@ def _run_execute_project_test_runner(args):
         project_root=args.project_root,
         output_path=args.output if args.format == "json" else None,
         run_runtime_tests=not args.no_runtime_tests,
+        runtime_executors=_load_project_runtime_executors(args.runtime_executor),
     )
     if args.format == "sarif":
         _write_json_payload(
@@ -6610,6 +6685,16 @@ def _build_parser():
         "--no-runtime-tests",
         action="store_true",
         help="Run project commands only and skip runtime fixture execution",
+    )
+    execute_test_runner_parser.add_argument(
+        "--runtime-executor",
+        action="append",
+        default=[],
+        metavar="EXECUTOR=MODULE:OBJECT",
+        help=(
+            "Runtime executor implementation to load for fixture execution; "
+            "repeatable. MODULE may be a dotted module name or a Python file path."
+        ),
     )
     execute_test_runner_parser.add_argument(
         "--format",

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -3974,12 +3974,15 @@ def _parse_runtime_value(
     if aliases:
         existing_aliases = _runtime_metadata_aliases(metadata)
         metadata["aliases"] = _dedupe_strings((*existing_aliases, *aliases))
+    values = value.get("values")
+    if "values" not in value and "value" in value:
+        values = value.get("value")
     return RuntimeValue(
         name=name,
         kind=kind,
         dtype=dtype,
         shape=shape,
-        values=value.get("values"),
+        values=values,
         tolerance=tolerance,
         metadata=metadata,
     )

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -19,7 +19,10 @@ The current harness verifies:
 - OpenGL artifact generation for `arange.metal`;
 - runtime artifact manifest, runtime-test manifest, and runtime-test plan
   generation for reduced `arange` readiness probes across DirectX, OpenGL, and
-  Vulkan.
+  Vulkan;
+- reference runtime fixture execution reports for the reduced `arange`
+  readiness probes, using supplied project test-runner adapters and
+  deterministic expected-output checks.
 
 Pull requests run the reduced frontier above. Scheduled and manually triggered
 CI also run the full-corpus artifact scout with finite Metal template
@@ -52,8 +55,9 @@ reduced arange fixtures select the translated artifact by source and target,
 then select `CSMain`, `main`, or `arangeuint8` independently for DirectX,
 OpenGL, or Vulkan dispatch. Plans report remaining non-blocking platform,
 layout, and entry-point ownership warnings. These plans are still metadata
-readiness artifacts; they do not execute the upstream MLX runtime on non-Metal
-backends.
+readiness artifacts. The reduced fixture execution report exercises the
+project runner and adapter contract with reference buffers; it does not execute
+the upstream MLX runtime or native Direct3D, OpenGL, or Vulkan device code.
 
 ## Running Locally
 

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -13,8 +13,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from crosstl.project import build_runtime_artifact_manifest
+from crosstl.project import (
+    build_project_test_runner_plan,
+    build_runtime_artifact_manifest,
+    execute_project_test_runner_plan,
+)
 from crosstl.project.runtime_verification import (
+    RuntimeParityAdapter,
     build_runtime_test_manifest,
     plan_runtime_test_manifest,
 )
@@ -54,6 +59,7 @@ RUNTIME_READINESS_ENTRY_POINTS = {
     "opengl": "main",
     "vulkan": "arangeuint8",
 }
+RUNTIME_FIXTURE_EXECUTION_ADAPTER_KIND = "mlx-arange-reference-runtime"
 RUNTIME_READINESS_DIAGNOSTIC_CODES = frozenset(
     (
         "project.runtime-test-manifest.entry-points-unavailable",
@@ -712,6 +718,103 @@ def _runtime_readiness_fixture_metadata(targets: Sequence[str]) -> dict[str, Any
     }
 
 
+def _runtime_fixture_execution_adapter_id(target: str) -> str:
+    return f"mlx-arange-reference-{target}"
+
+
+def _runtime_fixture_execution_metadata(targets: Sequence[str]) -> dict[str, Any]:
+    metadata = _runtime_readiness_fixture_metadata(targets)
+    metadata["metadata"] = {
+        **metadata["metadata"],
+        "scope": "reference-runtime-fixture-execution",
+        "runtimeFixtureExecutionIncluded": True,
+    }
+    metadata["adapters"] = [
+        {
+            "id": _runtime_fixture_execution_adapter_id(target),
+            "executor": _runtime_fixture_execution_adapter_id(target),
+            "adapterKind": RUNTIME_FIXTURE_EXECUTION_ADAPTER_KIND,
+            "platformRequirements": {"requiredTools": []},
+            "metadata": {
+                "target": target,
+                "scope": "reference-runtime-fixture-execution",
+            },
+        }
+        for target in targets
+    ]
+    metadata["fixtures"] = [
+        {
+            **fixture,
+            "adapter": _runtime_fixture_execution_adapter_id(
+                str(fixture["selector"]["target"])
+            ),
+        }
+        for fixture in metadata["fixtures"]
+        if isinstance(fixture.get("selector"), Mapping)
+    ]
+    return metadata
+
+
+class MlxArangeReferenceRuntime(RuntimeParityAdapter):
+    """Reference executor for MLX reduced arange runtime fixtures."""
+
+    name = RUNTIME_FIXTURE_EXECUTION_ADAPTER_KIND
+
+    def __init__(self, target: str):
+        self.target = target
+
+    def prepare_buffers(self, state):
+        return dict(state.resource_values)
+
+    def dispatch(self, state, prepared_buffers):
+        start = _runtime_fixture_scalar(prepared_buffers.get("start"), default=0)
+        step = _runtime_fixture_scalar(prepared_buffers.get("step"), default=1)
+        output = state.request.fixture.expected_outputs[0]
+        count = _runtime_fixture_output_count(state, output)
+        return {output.name: [start + index * step for index in range(count)]}
+
+    def collect_outputs(self, state, dispatch_result):
+        outputs = {}
+        for output in state.request.fixture.expected_outputs:
+            values = dispatch_result.get(output.name, [])
+            outputs[output.name] = {
+                "dtype": output.dtype,
+                "shape": list(output.shape),
+                "values": values,
+            }
+        return outputs
+
+
+def _runtime_fixture_scalar(value: Any, *, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if not value:
+            return default
+        value = value[0]
+    return int(value)
+
+
+def _runtime_fixture_output_count(state: Any, output: Any) -> int:
+    if output.shape:
+        return int(output.shape[0])
+    if isinstance(output.values, Sequence) and not isinstance(
+        output.values, (str, bytes, bytearray)
+    ):
+        return len(output.values)
+    dispatch = state.plan.dispatch
+    if dispatch is not None and dispatch.global_size:
+        return int(dispatch.global_size[0])
+    return 1
+
+
+def _runtime_fixture_execution_executors(targets: Sequence[str]) -> dict[str, Any]:
+    return {
+        _runtime_fixture_execution_adapter_id(target): MlxArangeReferenceRuntime(target)
+        for target in targets
+    }
+
+
 def _diagnostics_by_code(diagnostics: Sequence[Any]) -> dict[str, int]:
     counts: Counter[str] = Counter()
     for diagnostic in diagnostics:
@@ -734,6 +837,20 @@ def _runtime_plan_diagnostics(plan: Mapping[str, Any]) -> list[Mapping[str, Any]
     return diagnostics
 
 
+def _runtime_report_diagnostics(report: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    diagnostics: list[Mapping[str, Any]] = []
+    for result in report.get("results", []):
+        if not isinstance(result, Mapping):
+            continue
+        for diagnostic in result.get("diagnostics", []):
+            if isinstance(diagnostic, Mapping):
+                diagnostics.append(diagnostic)
+    runtime_report = report.get("runtimeTestReport")
+    if isinstance(runtime_report, Mapping):
+        diagnostics.extend(_runtime_report_diagnostics(runtime_report))
+    return diagnostics
+
+
 def _error_diagnostics(
     diagnostics: Sequence[Mapping[str, Any]],
 ) -> list[Mapping[str, Any]]:
@@ -742,6 +859,75 @@ def _error_diagnostics(
         for diagnostic in diagnostics
         if diagnostic.get("severity") == "error"
     ]
+
+
+def _execute_runtime_fixtures_for_report(
+    *,
+    mlx_root: Path,
+    report_dir: Path,
+    name: str,
+    runtime_artifact_manifest_path: Path,
+    targets: Sequence[str],
+) -> dict[str, Any]:
+    metadata_path = report_dir / f"{name}.runtime-fixture-execution-metadata.json"
+    manifest_path = report_dir / f"{name}.runtime-fixture-execution-manifest.json"
+    plan_path = report_dir / f"{name}.runtime-fixture-execution-plan.json"
+    report_path = report_dir / f"{name}.runtime-fixture-execution-report.json"
+    metadata = _runtime_fixture_execution_metadata(targets)
+    _write_json(metadata_path, metadata)
+    manifest = build_runtime_test_manifest(
+        runtime_artifact_manifest_path,
+        metadata_path,
+        project_root=mlx_root,
+    )
+    _write_json(manifest_path, manifest)
+    plan = build_project_test_runner_plan(
+        runtime_artifact_manifest_path,
+        manifest,
+        selected_targets=targets,
+        project_root=mlx_root,
+    )
+    _write_json(plan_path, plan)
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=mlx_root,
+        runtime_executors=_runtime_fixture_execution_executors(targets),
+    )
+    _write_json(report_path, report)
+    project_runner_summary = report.get("summary", {})
+    _require(
+        isinstance(project_runner_summary, dict),
+        "runtime fixture execution project-runner summary missing",
+    )
+    runtime_report = report.get("runtimeTestReport", {})
+    _require(
+        isinstance(runtime_report, Mapping),
+        "runtime fixture execution runtime report missing",
+    )
+    summary = runtime_report.get("summary", {})
+    _require(isinstance(summary, dict), "runtime fixture execution summary missing")
+    diagnostics = _runtime_report_diagnostics(report)
+    diagnostics_by_code = _diagnostics_by_code(diagnostics)
+    failed_count = int(summary.get("failedCount", 0))
+    skipped_count = int(summary.get("skippedCount", 0))
+    status = "passed" if failed_count == 0 and skipped_count == 0 else "failed"
+    if status == "failed" and RUNTIME_READINESS_TRACKED_ISSUES:
+        status = "blocked-by-tracked-issues"
+    return {
+        "name": f"{name}-runtime-fixture-execution",
+        "status": status,
+        "fixtureMetadata": _relpath(metadata_path, mlx_root),
+        "runtimeTestManifest": _relpath(manifest_path, mlx_root),
+        "projectTestRunnerPlan": _relpath(plan_path, mlx_root),
+        "projectTestRunnerReport": _relpath(report_path, mlx_root),
+        "targets": list(targets),
+        "summary": summary,
+        "projectRunnerSummary": project_runner_summary,
+        "diagnosticsByCode": diagnostics_by_code,
+        "runtimeFixtureExecutionIncluded": True,
+        "runtimeIntegrationIncluded": False,
+        "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
+    }
 
 
 def _plan_runtime_readiness_for_report(
@@ -778,6 +964,13 @@ def _plan_runtime_readiness_for_report(
         project_root=mlx_root,
     )
     _write_json(plan_path, plan)
+    runtime_fixture_execution = _execute_runtime_fixtures_for_report(
+        mlx_root=mlx_root,
+        report_dir=report_dir,
+        name=name,
+        runtime_artifact_manifest_path=runtime_artifact_manifest_path,
+        targets=targets,
+    )
 
     runtime_artifact_diagnostics_by_code = _diagnostics_by_code(
         runtime_artifact_manifest.get("runtimeDiagnostics", [])
@@ -851,6 +1044,8 @@ def _plan_runtime_readiness_for_report(
         "planBlockerCodes": plan_blocker_codes,
         "shaderArtifactsOnly": True,
         "runtimeIntegrationIncluded": False,
+        "runtimeFixtureExecutionIncluded": True,
+        "runtimeFixtureExecution": runtime_fixture_execution,
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
     }
 
@@ -883,6 +1078,8 @@ def _plan_reduced_runtime_readiness(
     diagnostics_by_code: Counter[str] = Counter()
     runtime_artifact_diagnostics_by_code: Counter[str] = Counter()
     runtime_plan_diagnostics_by_code: Counter[str] = Counter()
+    runtime_fixture_execution_by_status: Counter[str] = Counter()
+    runtime_fixture_execution_summary: Counter[str] = Counter()
     for report in reports:
         diagnostics_by_code.update(report.get("diagnosticsByCode", {}))
         runtime_artifact_diagnostics_by_code.update(
@@ -891,6 +1088,28 @@ def _plan_reduced_runtime_readiness(
         runtime_plan_diagnostics_by_code.update(
             report.get("runtimePlanDiagnosticsByCode", {})
         )
+        runtime_fixture_execution = report.get("runtimeFixtureExecution", {})
+        if isinstance(runtime_fixture_execution, Mapping):
+            runtime_fixture_execution_by_status.update(
+                [str(runtime_fixture_execution.get("status", "unknown"))]
+            )
+            execution_summary = runtime_fixture_execution.get("summary", {})
+            if isinstance(execution_summary, Mapping):
+                for key in (
+                    "fixtureCount",
+                    "resultCount",
+                    "passedCount",
+                    "skippedCount",
+                    "unavailableCount",
+                    "translationFailedCount",
+                    "runtimeFailedCount",
+                    "comparisonFailedCount",
+                    "failedCount",
+                ):
+                    if key in execution_summary:
+                        runtime_fixture_execution_summary[key] += int(
+                            execution_summary.get(key, 0)
+                        )
     return {
         "name": "runtime-readiness",
         "status": status,
@@ -906,6 +1125,13 @@ def _plan_reduced_runtime_readiness(
         ),
         "shaderArtifactsOnly": True,
         "runtimeIntegrationIncluded": False,
+        "runtimeFixtureExecutionIncluded": True,
+        "runtimeFixtureExecutionByStatus": dict(
+            sorted(runtime_fixture_execution_by_status.items())
+        ),
+        "runtimeFixtureExecutionSummary": dict(
+            sorted(runtime_fixture_execution_summary.items())
+        ),
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
     }
 
@@ -1163,6 +1389,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             "shaderArtifactsOnly": True,
             "runtimeIntegrationIncluded": False,
             "runtimeReadinessIncluded": args.mode == REDUCED_FRONTIER_MODE,
+            "runtimeFixtureExecutionIncluded": args.mode == REDUCED_FRONTIER_MODE,
         },
         "trackedIssues": list(FULL_CORPUS_TRACKED_ISSUES),
         "resolvedFrontierIssues": list(RESOLVED_FRONTIER_ISSUES),

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -536,6 +536,23 @@ map neutral fixture buffers and function constants to MLX runtime objects, but
 the fixture contract remains expressed in terms of entry points, bindings,
 constants, dispatch geometry, and validation hooks rather than MLX APIs.
 
+Saved project test-runner plans can execute deterministic runtime fixtures when
+callers supply adapter implementations explicitly:
+
+.. code-block:: bash
+
+   python -m crosstl execute-test-runner \
+     crosstl-out/project-test-runner-plan.json \
+     --runtime-executor native-vulkan=tools.runtime.vulkan:VulkanRuntimeAdapter \
+     --output crosstl-out/project-test-runner-report.json
+
+``--runtime-executor`` is repeatable and uses
+``EXECUTOR=MODULE:OBJECT``. ``MODULE`` may be a dotted Python module name or a
+``.py`` file path. ``OBJECT`` may be an adapter instance, adapter class, or
+factory returning an object with ``run(request)`` or the parity-adapter methods
+``prepare_buffers(state)``, ``dispatch(state, buffers)``, and
+``collect_outputs(state, result)``.
+
 The translator stops at this contract boundary. Full framework rewrites,
 non-kernel host API ports, application command scheduling, target SDK
 installation, build-system migration, memory lifetime policy, and production

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -161,6 +161,17 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
     assert (mlx_root / result["runtimeArtifactManifest"]).is_file()
     assert (mlx_root / result["runtimeTestManifest"]).is_file()
     assert (mlx_root / result["runtimeTestPlan"]).is_file()
+    assert result["runtimeFixtureExecutionIncluded"] is True
+    execution = result["runtimeFixtureExecution"]
+    assert execution["status"] == "passed"
+    assert execution["summary"]["fixtureCount"] == 1
+    assert execution["summary"]["passedCount"] == 1
+    assert execution["summary"]["failedCount"] == 0
+    assert execution["projectRunnerSummary"]["skippedCount"] == 1
+    assert (mlx_root / execution["fixtureMetadata"]).is_file()
+    assert (mlx_root / execution["runtimeTestManifest"]).is_file()
+    assert (mlx_root / execution["projectTestRunnerPlan"]).is_file()
+    assert (mlx_root / execution["projectTestRunnerReport"]).is_file()
 
     manifest = json.loads((mlx_root / result["runtimeTestManifest"]).read_text())
     assert manifest["success"] is True
@@ -180,6 +191,42 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
     assert plan["testCases"][0]["runtimeExecution"]["dispatch"]["entryPoint"] == (
         "CSMain"
     )
+
+    runner_report = json.loads(
+        (mlx_root / execution["projectTestRunnerReport"]).read_text()
+    )
+    runtime_result = runner_report["runtimeTestReport"]["results"][0]
+    assert runner_report["success"] is True
+    assert runtime_result["status"] == "passed"
+    assert (
+        runtime_result["executor"]["details"]["runtimeParityAdapter"]["runtimeAdapter"]
+        == "mlx-arange-reference-runtime"
+    )
+
+
+def test_runtime_fixture_execution_metadata_uses_toolchain_free_adapters():
+    module = _load_harness()
+
+    metadata = module._runtime_fixture_execution_metadata(
+        ("directx", "opengl", "vulkan")
+    )
+
+    assert metadata["metadata"]["runtimeFixtureExecutionIncluded"] is True
+    assert {adapter["id"] for adapter in metadata["adapters"]} == {
+        "mlx-arange-reference-directx",
+        "mlx-arange-reference-opengl",
+        "mlx-arange-reference-vulkan",
+    }
+    assert all(
+        adapter["platformRequirements"]["requiredTools"] == []
+        for adapter in metadata["adapters"]
+    )
+    assert all("target" not in adapter for adapter in metadata["adapters"])
+    assert {fixture["adapter"] for fixture in metadata["fixtures"]} == {
+        "mlx-arange-reference-directx",
+        "mlx-arange-reference-opengl",
+        "mlx-arange-reference-vulkan",
+    }
 
 
 @pytest.mark.parametrize(
@@ -252,6 +299,84 @@ def test_runtime_readiness_reports_tracked_plan_resource_blockers(
         "https://github.com/CrossGL/crosstl/issues/1392"
         in result["trackedRuntimeIssues"]
     )
+    assert result["runtimeFixtureExecution"]["status"] == "blocked-by-tracked-issues"
+
+
+def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
+    module = _load_harness()
+    reports = [
+        {
+            "name": "directx-vulkan-runtime-readiness",
+            "status": "planned",
+            "testCount": 2,
+            "diagnosticsByCode": {},
+            "runtimeArtifactDiagnosticsByCode": {},
+            "runtimePlanDiagnosticsByCode": {},
+            "runtimeFixtureExecution": {
+                "status": "passed",
+                "summary": {
+                    "fixtureCount": 2,
+                    "passedCount": 2,
+                    "skippedCount": 0,
+                    "unavailableCount": 0,
+                    "translationFailedCount": 0,
+                    "runtimeFailedCount": 0,
+                    "comparisonFailedCount": 0,
+                    "failedCount": 0,
+                },
+            },
+        },
+        {
+            "name": "opengl-runtime-readiness",
+            "status": "blocked-by-tracked-issues",
+            "testCount": 1,
+            "diagnosticsByCode": {},
+            "runtimeArtifactDiagnosticsByCode": {},
+            "runtimePlanDiagnosticsByCode": {
+                "project.runtime-verification.resource-unbound": 1
+            },
+            "runtimeFixtureExecution": {
+                "status": "blocked-by-tracked-issues",
+                "summary": {
+                    "fixtureCount": 1,
+                    "passedCount": 0,
+                    "skippedCount": 1,
+                    "unavailableCount": 0,
+                    "translationFailedCount": 0,
+                    "runtimeFailedCount": 0,
+                    "comparisonFailedCount": 0,
+                    "failedCount": 0,
+                },
+            },
+        },
+    ]
+
+    monkeypatch.setattr(
+        module,
+        "_plan_runtime_readiness_for_report",
+        lambda **kwargs: reports.pop(0),
+    )
+
+    result = module._plan_reduced_runtime_readiness(
+        Path("/tmp/mlx"), Path("/tmp/reports")
+    )
+
+    assert result["status"] == "blocked-by-tracked-issues"
+    assert result["runtimeFixtureExecutionIncluded"] is True
+    assert result["runtimeFixtureExecutionByStatus"] == {
+        "blocked-by-tracked-issues": 1,
+        "passed": 1,
+    }
+    assert result["runtimeFixtureExecutionSummary"] == {
+        "comparisonFailedCount": 0,
+        "failedCount": 0,
+        "fixtureCount": 3,
+        "passedCount": 2,
+        "runtimeFailedCount": 0,
+        "skippedCount": 1,
+        "translationFailedCount": 0,
+        "unavailableCount": 0,
+    }
 
 
 def test_full_corpus_mode_writes_bounded_config_and_checks_counts(
@@ -642,3 +767,4 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
         "runtime-readiness",
     ]
     assert result["scope"]["runtimeReadinessIncluded"] is True
+    assert result["scope"]["runtimeFixtureExecutionIncluded"] is True

--- a/tests/test_project_test_runner.py
+++ b/tests/test_project_test_runner.py
@@ -305,6 +305,131 @@ def test_project_test_runner_executes_runtime_tests_with_supplied_executor(tmp_p
     assert report["summary"]["passedCount"] == 1
 
 
+def test_project_cli_execute_test_runner_loads_runtime_executor(tmp_path):
+    artifact_path = tmp_path / "out" / "opengl" / "add.glsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("#version 450\nvoid main() {}\n", encoding="utf-8")
+    artifact_report_path = tmp_path / "artifact-report.json"
+    artifact_report_path.write_text(
+        json.dumps(
+            _artifact_report(
+                tmp_path,
+                [
+                    _artifact(
+                        path="out/opengl/add.glsl",
+                        dispatch={
+                            "entryPoint": "main",
+                            "globalSize": [1, 1, 1],
+                            "workgroupSize": [1, 1, 1],
+                        },
+                    )
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
+    manifest = {
+        "kind": "crosstl-project-runtime-test-manifest",
+        "adapters": [
+            {
+                "id": "fixture-runtime",
+                "executor": "fixture-runtime",
+                "adapterKind": "fixture-runtime-parity",
+                "platformRequirements": {"requiredTools": []},
+            }
+        ],
+        "tests": [
+            {
+                "id": "increment-fixture",
+                "selector": {
+                    "source": "kernels/add.cgl",
+                    "target": "opengl",
+                    "variant": "debug",
+                },
+                "adapter": "fixture-runtime",
+                "inputs": [
+                    {
+                        "name": "lhs",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [1.0],
+                    }
+                ],
+                "expectedOutputs": [
+                    {
+                        "name": "out",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [2.0],
+                    }
+                ],
+            }
+        ],
+    }
+    plan = build_project_test_runner_plan(
+        artifact_report_path,
+        manifest,
+        project_root=tmp_path,
+    )
+    plan_path = tmp_path / "test-runner-plan.json"
+    report_path = tmp_path / "test-runner-report.json"
+    executor_path = tmp_path / "fixture_runtime.py"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    executor_path.write_text(
+        """
+class IncrementRuntime:
+    name = "increment-runtime"
+
+    def prepare_buffers(self, state):
+        return dict(state.resource_values)
+
+    def dispatch(self, state, prepared_buffers):
+        return {"out": [value + 1.0 for value in prepared_buffers["lhs"]]}
+
+    def collect_outputs(self, state, dispatch_result):
+        return {
+            name: {
+                "dtype": "float32",
+                "shape": [len(values)],
+                "values": values,
+            }
+            for name, values in dispatch_result.items()
+        }
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "execute-test-runner",
+            str(plan_path),
+            "--project-root",
+            str(tmp_path),
+            "--runtime-executor",
+            f"fixture-runtime={executor_path}:IncrementRuntime",
+            "--output",
+            str(report_path),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    runtime_result = report["runtimeTestReport"]["results"][0]
+    assert report["success"] is True
+    assert runtime_result["status"] == "passed"
+    assert (
+        runtime_result["executor"]["details"]["runtimeParityAdapter"]["runtimeAdapter"]
+        == "increment-runtime"
+    )
+
+
 def test_project_test_runner_inspection_summarizes_unavailable_adapters(tmp_path):
     plan = build_project_test_runner_plan(
         _artifact_report(tmp_path, [_artifact()]),

--- a/tests/test_tool_cli.py
+++ b/tests/test_tool_cli.py
@@ -169,6 +169,7 @@ TOOLS = [
                 "usage:",
                 "--project-root",
                 "--no-runtime-tests",
+                "--runtime-executor",
                 "--format",
                 "--output",
             ),

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -350,6 +350,29 @@ def test_runtime_fixture_round_trips_independent_entry_point():
     assert parsed.to_json()["entryPoint"] == "reduce_sum"
 
 
+def test_runtime_fixture_accepts_scalar_value_alias():
+    parsed = parse_runtime_verification_fixtures(
+        {
+            "fixtures": [
+                _runtime_fixture(
+                    id="scalar-input-fixture",
+                    inputs=[
+                        {
+                            "name": "start",
+                            "kind": "scalar",
+                            "dtype": "uint32",
+                            "value": 3,
+                        }
+                    ],
+                )
+            ]
+        }
+    )[0]
+
+    assert parsed.inputs[0].values == 3
+    assert parsed.to_json()["inputs"][0]["values"] == 3
+
+
 def test_parse_runtime_verification_fixtures_rejects_missing_selector():
     with pytest.raises(RuntimeVerificationError, match="selector must identify"):
         parse_runtime_verification_fixtures({"fixtures": [{"id": "missing"}]})


### PR DESCRIPTION
## Summary
- add `execute-test-runner --runtime-executor EXECUTOR=MODULE:OBJECT` so project runtime fixture plans can load supplied adapters from dotted modules or Python files
- preserve scalar `value` aliases in runtime fixture metadata while normalizing reports to `values`
- extend the MLX reduced readiness harness to generate and execute reference runtime fixture reports for DirectX, OpenGL, and Vulkan arange probes through the project test runner
- document the supplied-adapter execution contract and the MLX harness scope without claiming native backend runtime parity

## Validation
- `.venv/bin/python -m pytest -q -n auto tests/test_project_test_runner.py tests/test_tool_cli.py tests/test_translator/test_runtime_verification.py::test_runtime_fixture_accepts_scalar_value_alias tests/test_mlx_porting_harness.py`
- `.venv/bin/python demos/integrations/mlx/run_mlx_porting.py --mode reduced-frontier --mlx-root /tmp/crosstl-mlx-entrypoint-next --work-dir /tmp/crosstl-mlx-entrypoint-next/.crosstl-mlx-runtime-fixture-execution`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n auto`

Refs #1462
Support issue traceability: no issue closed
