### PR TITLE
Expose native runtime adapters in project runner

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -911,8 +911,16 @@ def _load_project_test_runner_config(path):
     return dict(payload)
 
 
-def _load_project_runtime_executors(specs):
-    executors = {}
+def _load_project_runtime_executors(
+    specs,
+    *,
+    native_adapter_specs=(),
+    validate_native_runtime=True,
+):
+    executors = _load_project_native_runtime_adapters(
+        native_adapter_specs,
+        validate=validate_native_runtime,
+    )
     for spec in specs or ():
         key, separator, reference = spec.partition("=")
         key = key.strip()
@@ -921,6 +929,38 @@ def _load_project_runtime_executors(specs):
             raise ValueError("Runtime executor specs must use EXECUTOR=MODULE:OBJECT.")
         executor = _load_project_runtime_executor(reference)
         executors[key] = executor
+    return executors
+
+
+def _load_project_native_runtime_adapters(specs, *, validate):
+    if not specs:
+        return {}
+    from .project import native_runtime_parity_adapter
+
+    executors = {}
+    for spec in specs:
+        target, separator, runtime_reference = spec.partition("=")
+        target = target.strip()
+        runtime_reference = runtime_reference.strip()
+        if not target:
+            raise ValueError(
+                "Native runtime adapter specs must use TARGET or TARGET=MODULE:OBJECT."
+            )
+        if separator and not runtime_reference:
+            raise ValueError(
+                "Native runtime adapter specs must use TARGET or TARGET=MODULE:OBJECT."
+            )
+        normalized_target = normalize_backend_name(target) or target.lower()
+        runtime = (
+            _load_project_runtime_object(runtime_reference)
+            if runtime_reference
+            else None
+        )
+        executors[normalized_target] = native_runtime_parity_adapter(
+            normalized_target,
+            runtime=runtime,
+            validate=validate,
+        )
     return executors
 
 
@@ -969,6 +1009,24 @@ def _project_runtime_executor_instance(value):
     if _project_runtime_executor_like(value):
         return value
     if callable(value):
+        return value()
+    return value
+
+
+def _load_project_runtime_object(reference):
+    module_ref, separator, object_name = reference.rpartition(":")
+    module_ref = module_ref.strip()
+    object_name = object_name.strip()
+    if not separator or not module_ref or not object_name:
+        raise ValueError("Runtime object references must use MODULE:OBJECT.")
+    module = _load_project_runtime_executor_module(module_ref)
+    try:
+        value = getattr(module, object_name)
+    except AttributeError as exc:
+        raise ValueError(
+            f"Runtime object {object_name!r} was not found in {module_ref!r}."
+        ) from exc
+    if inspect.isclass(value):
         return value()
     return value
 
@@ -1175,7 +1233,11 @@ def _run_execute_project_test_runner(args):
         project_root=args.project_root,
         output_path=args.output if args.format == "json" else None,
         run_runtime_tests=not args.no_runtime_tests,
-        runtime_executors=_load_project_runtime_executors(args.runtime_executor),
+        runtime_executors=_load_project_runtime_executors(
+            args.runtime_executor,
+            native_adapter_specs=args.native_runtime_adapter,
+            validate_native_runtime=not args.no_native_runtime_validation,
+        ),
     )
     if args.format == "sarif":
         _write_json_payload(
@@ -6695,6 +6757,21 @@ def _build_parser():
             "Runtime executor implementation to load for fixture execution; "
             "repeatable. MODULE may be a dotted module name or a Python file path."
         ),
+    )
+    execute_test_runner_parser.add_argument(
+        "--native-runtime-adapter",
+        action="append",
+        default=[],
+        metavar="TARGET[=MODULE:OBJECT]",
+        help=(
+            "Use a built-in native runtime parity adapter for TARGET; repeatable. "
+            "MODULE:OBJECT may provide the backend runtime driver."
+        ),
+    )
+    execute_test_runner_parser.add_argument(
+        "--no-native-runtime-validation",
+        action="store_true",
+        help="Skip built-in native runtime adapter toolchain validation before dispatch",
     )
     execute_test_runner_parser.add_argument(
         "--format",

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -1048,7 +1048,9 @@ class NativeRuntimeParityAdapter(RuntimeParityAdapter):
                 details=platform_details,
             )
         missing_tools = [
-            tool for tool in self.required_tools if self._resolve_tool(tool) is None
+            tool
+            for tool in self.required_tools
+            if self.validate and self._resolve_tool(tool) is None
         ]
         if missing_tools:
             return RuntimeExecutorAvailability(

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -22,7 +22,10 @@ The current harness verifies:
   Vulkan;
 - reference runtime fixture execution reports for the reduced `arange`
   readiness probes, using supplied project test-runner adapters and
-  deterministic expected-output checks.
+  deterministic expected-output checks;
+- native runtime execution-readiness reports for the same reduced probes,
+  using the built-in DirectX, OpenGL, and Vulkan native adapter contracts with
+  missing runtime drivers reported as structured blockers.
 
 Pull requests run the reduced frontier above. Scheduled and manually triggered
 CI also run the full-corpus artifact scout with finite Metal template
@@ -58,6 +61,9 @@ layout, and entry-point ownership warnings. These plans are still metadata
 readiness artifacts. The reduced fixture execution report exercises the
 project runner and adapter contract with reference buffers; it does not execute
 the upstream MLX runtime or native Direct3D, OpenGL, or Vulkan device code.
+The native execution-readiness report attempts the built-in native adapter
+contract separately and records missing runtime drivers as blockers until
+backend runtime drivers are supplied by integration code.
 
 ## Running Locally
 

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -17,6 +17,7 @@ from crosstl.project import (
     build_project_test_runner_plan,
     build_runtime_artifact_manifest,
     execute_project_test_runner_plan,
+    native_runtime_parity_adapters,
 )
 from crosstl.project.runtime_verification import (
     RuntimeParityAdapter,
@@ -60,6 +61,7 @@ RUNTIME_READINESS_ENTRY_POINTS = {
     "vulkan": "arangeuint8",
 }
 RUNTIME_FIXTURE_EXECUTION_ADAPTER_KIND = "mlx-arange-reference-runtime"
+NATIVE_RUNTIME_EXECUTION_SCOPE = "native-runtime-execution-readiness"
 RUNTIME_READINESS_DIAGNOSTIC_CODES = frozenset(
     (
         "project.runtime-test-manifest.entry-points-unavailable",
@@ -755,6 +757,43 @@ def _runtime_fixture_execution_metadata(targets: Sequence[str]) -> dict[str, Any
     return metadata
 
 
+def _native_runtime_execution_adapter_id(target: str) -> str:
+    return f"mlx-arange-native-{target}"
+
+
+def _native_runtime_execution_metadata(targets: Sequence[str]) -> dict[str, Any]:
+    metadata = _runtime_readiness_fixture_metadata(targets)
+    metadata["metadata"] = {
+        **metadata["metadata"],
+        "scope": NATIVE_RUNTIME_EXECUTION_SCOPE,
+        "nativeRuntimeExecutionIncluded": True,
+    }
+    metadata["adapters"] = [
+        {
+            "id": _native_runtime_execution_adapter_id(target),
+            "executor": target,
+            "adapterKind": f"{target}-native-runtime",
+            "platformRequirements": {"requiredTools": []},
+            "metadata": {
+                "target": target,
+                "scope": NATIVE_RUNTIME_EXECUTION_SCOPE,
+            },
+        }
+        for target in targets
+    ]
+    metadata["fixtures"] = [
+        {
+            **fixture,
+            "adapter": _native_runtime_execution_adapter_id(
+                str(fixture["selector"]["target"])
+            ),
+        }
+        for fixture in metadata["fixtures"]
+        if isinstance(fixture.get("selector"), Mapping)
+    ]
+    return metadata
+
+
 class MlxArangeReferenceRuntime(RuntimeParityAdapter):
     """Reference executor for MLX reduced arange runtime fixtures."""
 
@@ -930,6 +969,78 @@ def _execute_runtime_fixtures_for_report(
     }
 
 
+def _execute_native_runtime_fixtures_for_report(
+    *,
+    mlx_root: Path,
+    report_dir: Path,
+    name: str,
+    runtime_artifact_manifest_path: Path,
+    targets: Sequence[str],
+) -> dict[str, Any]:
+    metadata_path = report_dir / f"{name}.native-runtime-execution-metadata.json"
+    manifest_path = report_dir / f"{name}.native-runtime-execution-manifest.json"
+    plan_path = report_dir / f"{name}.native-runtime-execution-plan.json"
+    report_path = report_dir / f"{name}.native-runtime-execution-report.json"
+    metadata = _native_runtime_execution_metadata(targets)
+    _write_json(metadata_path, metadata)
+    manifest = build_runtime_test_manifest(
+        runtime_artifact_manifest_path,
+        metadata_path,
+        project_root=mlx_root,
+    )
+    _write_json(manifest_path, manifest)
+    plan = build_project_test_runner_plan(
+        runtime_artifact_manifest_path,
+        manifest,
+        selected_targets=targets,
+        project_root=mlx_root,
+    )
+    _write_json(plan_path, plan)
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=mlx_root,
+        runtime_executors=native_runtime_parity_adapters(validate=False),
+    )
+    _write_json(report_path, report)
+    project_runner_summary = report.get("summary", {})
+    _require(
+        isinstance(project_runner_summary, dict),
+        "native runtime execution project-runner summary missing",
+    )
+    runtime_report = report.get("runtimeTestReport", {})
+    _require(
+        isinstance(runtime_report, Mapping),
+        "native runtime execution runtime report missing",
+    )
+    summary = runtime_report.get("summary", {})
+    _require(isinstance(summary, dict), "native runtime execution summary missing")
+    diagnostics = _runtime_report_diagnostics(report)
+    diagnostics_by_code = _diagnostics_by_code(diagnostics)
+    failed_count = int(summary.get("failedCount", 0))
+    unavailable_count = int(summary.get("unavailableCount", 0))
+    skipped_count = int(summary.get("skippedCount", 0))
+    status = "passed"
+    if failed_count:
+        status = "blocked-by-tracked-issues"
+    elif unavailable_count or skipped_count:
+        status = "blocked-by-runtime-driver"
+    return {
+        "name": f"{name}-native-runtime-execution",
+        "status": status,
+        "fixtureMetadata": _relpath(metadata_path, mlx_root),
+        "runtimeTestManifest": _relpath(manifest_path, mlx_root),
+        "projectTestRunnerPlan": _relpath(plan_path, mlx_root),
+        "projectTestRunnerReport": _relpath(report_path, mlx_root),
+        "targets": list(targets),
+        "summary": summary,
+        "projectRunnerSummary": project_runner_summary,
+        "diagnosticsByCode": diagnostics_by_code,
+        "nativeRuntimeExecutionIncluded": True,
+        "runtimeIntegrationIncluded": False,
+        "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
+    }
+
+
 def _plan_runtime_readiness_for_report(
     *,
     mlx_root: Path,
@@ -965,6 +1076,13 @@ def _plan_runtime_readiness_for_report(
     )
     _write_json(plan_path, plan)
     runtime_fixture_execution = _execute_runtime_fixtures_for_report(
+        mlx_root=mlx_root,
+        report_dir=report_dir,
+        name=name,
+        runtime_artifact_manifest_path=runtime_artifact_manifest_path,
+        targets=targets,
+    )
+    native_runtime_execution = _execute_native_runtime_fixtures_for_report(
         mlx_root=mlx_root,
         report_dir=report_dir,
         name=name,
@@ -1046,6 +1164,8 @@ def _plan_runtime_readiness_for_report(
         "runtimeIntegrationIncluded": False,
         "runtimeFixtureExecutionIncluded": True,
         "runtimeFixtureExecution": runtime_fixture_execution,
+        "nativeRuntimeExecutionIncluded": True,
+        "nativeRuntimeExecution": native_runtime_execution,
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
     }
 
@@ -1080,6 +1200,8 @@ def _plan_reduced_runtime_readiness(
     runtime_plan_diagnostics_by_code: Counter[str] = Counter()
     runtime_fixture_execution_by_status: Counter[str] = Counter()
     runtime_fixture_execution_summary: Counter[str] = Counter()
+    native_runtime_execution_by_status: Counter[str] = Counter()
+    native_runtime_execution_summary: Counter[str] = Counter()
     for report in reports:
         diagnostics_by_code.update(report.get("diagnosticsByCode", {}))
         runtime_artifact_diagnostics_by_code.update(
@@ -1110,6 +1232,27 @@ def _plan_reduced_runtime_readiness(
                         runtime_fixture_execution_summary[key] += int(
                             execution_summary.get(key, 0)
                         )
+        native_runtime_execution = report.get("nativeRuntimeExecution", {})
+        if isinstance(native_runtime_execution, Mapping):
+            native_runtime_execution_by_status.update(
+                [str(native_runtime_execution.get("status", "unknown"))]
+            )
+            execution_summary = native_runtime_execution.get("summary", {})
+            if isinstance(execution_summary, Mapping):
+                for key in (
+                    "fixtureCount",
+                    "passedCount",
+                    "skippedCount",
+                    "unavailableCount",
+                    "translationFailedCount",
+                    "runtimeFailedCount",
+                    "comparisonFailedCount",
+                    "failedCount",
+                ):
+                    if key in execution_summary:
+                        native_runtime_execution_summary[key] += int(
+                            execution_summary.get(key, 0)
+                        )
     return {
         "name": "runtime-readiness",
         "status": status,
@@ -1131,6 +1274,13 @@ def _plan_reduced_runtime_readiness(
         ),
         "runtimeFixtureExecutionSummary": dict(
             sorted(runtime_fixture_execution_summary.items())
+        ),
+        "nativeRuntimeExecutionIncluded": True,
+        "nativeRuntimeExecutionByStatus": dict(
+            sorted(native_runtime_execution_by_status.items())
+        ),
+        "nativeRuntimeExecutionSummary": dict(
+            sorted(native_runtime_execution_summary.items())
         ),
         "trackedRuntimeIssues": list(RUNTIME_READINESS_TRACKED_ISSUES),
     }
@@ -1390,6 +1540,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             "runtimeIntegrationIncluded": False,
             "runtimeReadinessIncluded": args.mode == REDUCED_FRONTIER_MODE,
             "runtimeFixtureExecutionIncluded": args.mode == REDUCED_FRONTIER_MODE,
+            "nativeRuntimeExecutionIncluded": args.mode == REDUCED_FRONTIER_MODE,
         },
         "trackedIssues": list(FULL_CORPUS_TRACKED_ISSUES),
         "resolvedFrontierIssues": list(RESOLVED_FRONTIER_ISSUES),

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -553,6 +553,13 @@ factory returning an object with ``run(request)`` or the parity-adapter methods
 ``prepare_buffers(state)``, ``dispatch(state, buffers)``, and
 ``collect_outputs(state, result)``.
 
+For the built-in DirectX, OpenGL, and Vulkan native parity adapters, callers can
+also pass ``--native-runtime-adapter TARGET`` or
+``--native-runtime-adapter TARGET=MODULE:OBJECT``. The optional object is the
+backend runtime driver consumed by the native adapter after artifact validation.
+Use ``--no-native-runtime-validation`` only when the caller has already handled
+toolchain validation or is running a controlled test fixture.
+
 The translator stops at this contract boundary. Full framework rewrites,
 non-kernel host API ports, application command scheduling, target SDK
 installation, build-system migration, memory lifetime policy, and production

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -172,6 +172,15 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
     assert (mlx_root / execution["runtimeTestManifest"]).is_file()
     assert (mlx_root / execution["projectTestRunnerPlan"]).is_file()
     assert (mlx_root / execution["projectTestRunnerReport"]).is_file()
+    native_execution = result["nativeRuntimeExecution"]
+    assert result["nativeRuntimeExecutionIncluded"] is True
+    assert native_execution["status"] == "blocked-by-runtime-driver"
+    assert native_execution["summary"]["fixtureCount"] == 1
+    assert native_execution["summary"]["unavailableCount"] == 1
+    assert (mlx_root / native_execution["fixtureMetadata"]).is_file()
+    assert (mlx_root / native_execution["runtimeTestManifest"]).is_file()
+    assert (mlx_root / native_execution["projectTestRunnerPlan"]).is_file()
+    assert (mlx_root / native_execution["projectTestRunnerReport"]).is_file()
 
     manifest = json.loads((mlx_root / result["runtimeTestManifest"]).read_text())
     assert manifest["success"] is True
@@ -226,6 +235,33 @@ def test_runtime_fixture_execution_metadata_uses_toolchain_free_adapters():
         "mlx-arange-reference-directx",
         "mlx-arange-reference-opengl",
         "mlx-arange-reference-vulkan",
+    }
+
+
+def test_native_runtime_execution_metadata_uses_target_executors():
+    module = _load_harness()
+
+    metadata = module._native_runtime_execution_metadata(
+        ("directx", "opengl", "vulkan")
+    )
+
+    assert metadata["metadata"]["nativeRuntimeExecutionIncluded"] is True
+    assert {
+        (adapter["id"], adapter["executor"], adapter["adapterKind"])
+        for adapter in metadata["adapters"]
+    } == {
+        ("mlx-arange-native-directx", "directx", "directx-native-runtime"),
+        ("mlx-arange-native-opengl", "opengl", "opengl-native-runtime"),
+        ("mlx-arange-native-vulkan", "vulkan", "vulkan-native-runtime"),
+    }
+    assert all(
+        adapter["platformRequirements"]["requiredTools"] == []
+        for adapter in metadata["adapters"]
+    )
+    assert {fixture["adapter"] for fixture in metadata["fixtures"]} == {
+        "mlx-arange-native-directx",
+        "mlx-arange-native-opengl",
+        "mlx-arange-native-vulkan",
     }
 
 
@@ -300,6 +336,10 @@ def test_runtime_readiness_reports_tracked_plan_resource_blockers(
         in result["trackedRuntimeIssues"]
     )
     assert result["runtimeFixtureExecution"]["status"] == "blocked-by-tracked-issues"
+    assert result["nativeRuntimeExecution"]["status"] in {
+        "blocked-by-runtime-driver",
+        "blocked-by-tracked-issues",
+    }
 
 
 def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
@@ -325,6 +365,19 @@ def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
                     "failedCount": 0,
                 },
             },
+            "nativeRuntimeExecution": {
+                "status": "blocked-by-runtime-driver",
+                "summary": {
+                    "fixtureCount": 2,
+                    "passedCount": 0,
+                    "skippedCount": 0,
+                    "unavailableCount": 2,
+                    "translationFailedCount": 0,
+                    "runtimeFailedCount": 0,
+                    "comparisonFailedCount": 0,
+                    "failedCount": 0,
+                },
+            },
         },
         {
             "name": "opengl-runtime-readiness",
@@ -342,6 +395,19 @@ def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
                     "passedCount": 0,
                     "skippedCount": 1,
                     "unavailableCount": 0,
+                    "translationFailedCount": 0,
+                    "runtimeFailedCount": 0,
+                    "comparisonFailedCount": 0,
+                    "failedCount": 0,
+                },
+            },
+            "nativeRuntimeExecution": {
+                "status": "blocked-by-runtime-driver",
+                "summary": {
+                    "fixtureCount": 1,
+                    "passedCount": 0,
+                    "skippedCount": 0,
+                    "unavailableCount": 1,
                     "translationFailedCount": 0,
                     "runtimeFailedCount": 0,
                     "comparisonFailedCount": 0,
@@ -376,6 +442,20 @@ def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
         "skippedCount": 1,
         "translationFailedCount": 0,
         "unavailableCount": 0,
+    }
+    assert result["nativeRuntimeExecutionIncluded"] is True
+    assert result["nativeRuntimeExecutionByStatus"] == {
+        "blocked-by-runtime-driver": 2,
+    }
+    assert result["nativeRuntimeExecutionSummary"] == {
+        "comparisonFailedCount": 0,
+        "failedCount": 0,
+        "fixtureCount": 3,
+        "passedCount": 0,
+        "runtimeFailedCount": 0,
+        "skippedCount": 0,
+        "translationFailedCount": 0,
+        "unavailableCount": 3,
     }
 
 
@@ -768,3 +848,4 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
     ]
     assert result["scope"]["runtimeReadinessIncluded"] is True
     assert result["scope"]["runtimeFixtureExecutionIncluded"] is True
+    assert result["scope"]["nativeRuntimeExecutionIncluded"] is True

--- a/tests/test_project_test_runner.py
+++ b/tests/test_project_test_runner.py
@@ -430,6 +430,121 @@ class IncrementRuntime:
     )
 
 
+def test_project_cli_execute_test_runner_loads_native_runtime_driver(tmp_path):
+    artifact_path = tmp_path / "out" / "opengl" / "add.glsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("#version 450\nvoid main() {}\n", encoding="utf-8")
+    artifact_report_path = tmp_path / "artifact-report.json"
+    artifact_report_path.write_text(
+        json.dumps(
+            _artifact_report(
+                tmp_path,
+                [
+                    _artifact(
+                        path="out/opengl/add.glsl",
+                        dispatch={
+                            "entryPoint": "main",
+                            "globalSize": [1, 1, 1],
+                            "workgroupSize": [1, 1, 1],
+                        },
+                    )
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
+    manifest = {
+        "kind": "crosstl-project-runtime-test-manifest",
+        "adapters": [
+            {
+                "id": "native-opengl",
+                "executor": "opengl",
+                "adapterKind": "opengl-native-runtime",
+                "platformRequirements": {"requiredTools": []},
+            }
+        ],
+        "tests": [
+            {
+                "id": "native-increment-fixture",
+                "selector": {
+                    "source": "kernels/add.cgl",
+                    "target": "opengl",
+                    "variant": "debug",
+                },
+                "adapter": "native-opengl",
+                "inputs": [
+                    {
+                        "name": "lhs",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [1.0],
+                    }
+                ],
+                "expectedOutputs": [
+                    {
+                        "name": "out",
+                        "dtype": "float32",
+                        "shape": [1],
+                        "values": [2.0],
+                    }
+                ],
+            }
+        ],
+    }
+    plan = build_project_test_runner_plan(
+        artifact_report_path,
+        manifest,
+        project_root=tmp_path,
+    )
+    plan_path = tmp_path / "test-runner-plan.json"
+    report_path = tmp_path / "test-runner-report.json"
+    runtime_path = tmp_path / "native_runtime.py"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    runtime_path.write_text(
+        """
+class OpenGLFixtureRuntime:
+    name = "fixture-opengl-driver"
+
+    def dispatch(self, adapter, state, request):
+        assert adapter.target == "opengl"
+        assert request.entry_point == "main"
+        assert request.buffers["out"].source == "expectedOutput"
+        return {"out": [value + 1.0 for value in request.buffers["lhs"].value]}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "execute-test-runner",
+            str(plan_path),
+            "--project-root",
+            str(tmp_path),
+            "--native-runtime-adapter",
+            f"opengl={runtime_path}:OpenGLFixtureRuntime",
+            "--no-native-runtime-validation",
+            "--output",
+            str(report_path),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    runtime_result = report["runtimeTestReport"]["results"][0]
+    details = runtime_result["executor"]["details"]
+    assert report["success"] is True
+    assert runtime_result["status"] == "passed"
+    assert details["runtimeParityAdapter"]["runtimeAdapter"] == "opengl-native-runtime"
+    assert details["nativeRuntimeDispatch"]["target"] == "opengl"
+
+
 def test_project_test_runner_inspection_summarizes_unavailable_adapters(tmp_path):
     plan = build_project_test_runner_plan(
         _artifact_report(tmp_path, [_artifact()]),

--- a/tests/test_tool_cli.py
+++ b/tests/test_tool_cli.py
@@ -170,6 +170,8 @@ TOOLS = [
                 "--project-root",
                 "--no-runtime-tests",
                 "--runtime-executor",
+                "--native-runtime-adapter",
+                "--no-native-runtime-validation",
                 "--format",
                 "--output",
             ),

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -1885,6 +1885,38 @@ def test_runtime_parity_native_adapter_reports_unavailable_tooling(tmp_path):
     assert result["executor"]["details"]["missingTools"] == [missing_tool]
 
 
+def test_runtime_parity_native_adapter_skips_validation_tooling_when_disabled(
+    tmp_path,
+):
+    artifact_path = tmp_path / "out" / "opengl" / "debug" / "add.glsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("#version 450\nvoid main() {}\n", encoding="utf-8")
+    adapter = OpenGLRuntimeParityAdapter(
+        runtime=FakeNativeRuntime(),
+        required_tools=("crosstl-runtime-tool-that-does-not-exist-1302",),
+        tool_resolver=lambda _tool: None,
+        validate=False,
+    )
+
+    report = verify_runtime_test_manifest(
+        _artifact_report(tmp_path, [_native_runtime_artifact()]),
+        _native_runtime_manifest(),
+        executors={"opengl": adapter},
+    )
+
+    result = report["results"][0]
+    assert report["success"] is True
+    assert result["status"] == PASSED
+    validation_steps = [
+        step
+        for step in result["executor"]["details"]["adapterSteps"]
+        if step["action"] == "validate-native-runtime-artifact"
+    ]
+    assert len(validation_steps) == 1
+    assert validation_steps[0]["status"] == SKIPPED
+    assert validation_steps[0]["details"]["reason"] == "validation-disabled"
+
+
 def test_runtime_parity_native_adapter_reports_unavailable_platform(tmp_path):
     adapter = OpenGLRuntimeParityAdapter(
         runtime=FakeNativeRuntime(),


### PR DESCRIPTION
## Summary
- add `execute-test-runner --native-runtime-adapter` for built-in DirectX, OpenGL, and Vulkan native parity adapters, with optional backend runtime driver loading
- add MLX reduced-frontier native runtime execution-readiness reports that surface missing runtime drivers as structured blockers
- document the native adapter CLI contract and clarify that the MLX harness still stops at shader/kernel and runtime-adapter boundaries

## Validation
- `.venv/bin/python -m pytest -q -n auto tests/test_project_test_runner.py tests/test_tool_cli.py tests/test_mlx_porting_harness.py`
- `.venv/bin/python demos/integrations/mlx/run_mlx_porting.py --mode reduced-frontier --mlx-root /tmp/crosstl-mlx-entrypoint-next --work-dir /tmp/crosstl-mlx-entrypoint-next/.crosstl-mlx-native-runtime-execution`
- `git diff --check`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n auto`

Refs #1462.

Support issue traceability: no issue closed
