### PR TITLE
Run Vulkan compute runtime proof in CI

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -234,7 +234,7 @@ jobs:
           - os: ubuntu-latest
             adapter: vulkan
             required_tools: spirv-val,spirv-as
-            install_command: sudo apt-get update && sudo apt-get install -y spirv-tools
+            install_command: sudo apt-get update && sudo apt-get install -y glslang-tools libvulkan1 mesa-vulkan-drivers spirv-tools vulkan-tools
           - os: macOS-latest
             adapter: metal
             required_tools: xcrun
@@ -312,13 +312,25 @@ jobs:
           python -m pip install -e .
           python -m pip install -r requirements.txt
 
+      - name: Install optional Vulkan runtime dependency
+        if: matrix.adapter == 'vulkan' && steps.probe_runtime_parity.outputs.available == 'true'
+        run: |
+          python -m pip install vulkan==1.3.275.1
+
       - name: Run runtime parity tests
         if: steps.probe_runtime_parity.outputs.available == 'true'
         shell: bash
+        env:
+          RUNTIME_PARITY_ADAPTER: ${{ matrix.adapter }}
         run: |
           mkdir -p support/generated
+          if [ "$RUNTIME_PARITY_ADAPTER" = "vulkan" ]; then
+            export CROSTL_RUN_VULKAN_DEVICE_TEST=1
+            vulkaninfo --summary || true
+          fi
           python -m pytest -q \
             tests/test_translator/test_runtime_verification.py \
+            tests/test_translator/test_native_runtime_drivers.py \
             -k "runtime_parity" \
             --junitxml support/generated/runtime-parity-${{ matrix.adapter }}-${{ matrix.os }}.xml
 

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -338,14 +338,14 @@ class _VulkanDispatchContext:
             return
         pointer = self.vk.vkMapMemory(self.device, memory, 0, len(payload), 0)
         try:
-            ctypes.memmove(pointer, payload, len(payload))
+            _write_mapped_memory(pointer, payload)
         finally:
             self.vk.vkUnmapMemory(self.device, memory)
 
     def _read_memory(self, memory: Any, size: int) -> bytes:
         pointer = self.vk.vkMapMemory(self.device, memory, 0, size, 0)
         try:
-            return ctypes.string_at(pointer, size)
+            return _read_mapped_memory(pointer, size)
         finally:
             self.vk.vkUnmapMemory(self.device, memory)
 
@@ -436,7 +436,7 @@ class _VulkanDispatchContext:
             [pipeline_info],
             None,
         )
-        self.pipeline = pipelines[0] if isinstance(pipelines, Sequence) else pipelines
+        self.pipeline = _first_vulkan_handle(pipelines)
 
     def _record_and_submit(self) -> None:
         vk = self.vk
@@ -543,6 +543,42 @@ def _vk_destroy(vk: Any, name: str, owner: Any, handle: Any) -> None:
         destroy(handle, None)
     else:
         destroy(owner, handle, None)
+
+
+def _first_vulkan_handle(handles: Any) -> Any:
+    if isinstance(handles, (str, bytes, bytearray)):
+        return handles
+    try:
+        return handles[0]
+    except (IndexError, TypeError, KeyError):
+        return handles
+
+
+def _write_mapped_memory(mapped: Any, payload: bytes) -> None:
+    try:
+        view = memoryview(mapped)
+    except TypeError:
+        ctypes.memmove(mapped, payload, len(payload))
+        return
+
+    try:
+        byte_view = view.cast("B") if view.format != "B" else view
+        byte_view[: len(payload)] = payload
+    finally:
+        view.release()
+
+
+def _read_mapped_memory(mapped: Any, size: int) -> bytes:
+    try:
+        view = memoryview(mapped)
+    except TypeError:
+        return ctypes.string_at(mapped, size)
+
+    try:
+        byte_view = view.cast("B") if view.format != "B" else view
+        return byte_view[:size].tobytes()
+    finally:
+        view.release()
 
 
 def _prepare_vulkan_buffers(

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -251,6 +251,11 @@ def test_full_suite_runs_runtime_parity_only_for_available_adapters():
     assert "steps.probe_runtime_parity.outputs.available == 'true'" in full_suite
     assert "Record unavailable runtime parity adapter" in full_suite
     assert "tests/test_translator/test_runtime_verification.py" in full_suite
+    assert "tests/test_translator/test_native_runtime_drivers.py" in full_suite
+    assert "mesa-vulkan-drivers" in full_suite
+    assert "python -m pip install vulkan==1.3.275.1" in full_suite
+    assert "CROSTL_RUN_VULKAN_DEVICE_TEST=1" in full_suite
+    assert "vulkaninfo --summary" in full_suite
     assert '-k "runtime_parity"' in full_suite
 
 

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -8,7 +9,10 @@ import pytest
 import crosstl.project as project_api
 from crosstl.project.native_runtime_drivers import (
     VulkanComputeRuntime,
+    _first_vulkan_handle,
     _prepare_vulkan_buffers,
+    _read_mapped_memory,
+    _write_mapped_memory,
 )
 from crosstl.project.runtime_verification import (
     UNAVAILABLE,
@@ -183,6 +187,26 @@ def test_prepare_vulkan_buffers_packs_inputs_and_zeroes_outputs():
     assert buffers[1].payload == b"\x00" * 8
 
 
+def test_vulkan_handle_array_unwraps_first_handle():
+    class HandleArray:
+        def __getitem__(self, index):
+            if index == 0:
+                return "pipeline-handle"
+            raise IndexError(index)
+
+    assert _first_vulkan_handle(HandleArray()) == "pipeline-handle"
+    assert _first_vulkan_handle("plain-handle") == "plain-handle"
+
+
+def test_mapped_memory_helpers_use_buffer_protocol():
+    mapped = bytearray(8)
+
+    _write_mapped_memory(mapped, b"abcd")
+
+    assert mapped == bytearray(b"abcd\x00\x00\x00\x00")
+    assert _read_mapped_memory(mapped, 6) == b"abcd\x00\x00"
+
+
 def test_runtime_parity_vulkan_compute_runtime_executes_vector_add_on_device(
     tmp_path,
 ):
@@ -292,6 +316,7 @@ void main() {
     )
 
     result = report["results"][0]
-    assert report["success"] is True
+    failure_context = json.dumps(report, indent=2, sort_keys=True)
+    assert report["success"] is True, failure_context
     assert result["status"] == "passed"
-    assert result["comparisons"][0]["status"] == "passed"
+    assert result["comparisons"][0]["status"] == "passed", failure_context

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -178,3 +181,117 @@ def test_prepare_vulkan_buffers_packs_inputs_and_zeroes_outputs():
     assert [buffer.name for buffer in buffers] == ["lhs", "out"]
     assert buffers[0].payload == b"\x00\x00\x80?\x00\x00\x00@"
     assert buffers[1].payload == b"\x00" * 8
+
+
+def test_runtime_parity_vulkan_compute_runtime_executes_vector_add_on_device(
+    tmp_path,
+):
+    if os.environ.get("CROSTL_RUN_VULKAN_DEVICE_TEST") != "1":
+        pytest.skip("set CROSTL_RUN_VULKAN_DEVICE_TEST=1 to run Vulkan device test")
+    pytest.importorskip("vulkan")
+    glslang = shutil.which("glslangValidator")
+    if glslang is None:
+        pytest.skip("glslangValidator is required to build the Vulkan fixture")
+
+    shader_path = tmp_path / "add.comp"
+    artifact_path = tmp_path / "out" / "vulkan" / "add.spv"
+    artifact_path.parent.mkdir(parents=True)
+    shader_path.write_text(
+        """
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) readonly buffer Lhs {
+    float values[];
+} lhs_buffer;
+layout(set = 0, binding = 1) readonly buffer Rhs {
+    float values[];
+} rhs_buffer;
+layout(set = 0, binding = 2) writeonly buffer Out {
+    float values[];
+} out_buffer;
+void main() {
+    uint index = gl_GlobalInvocationID.x;
+    out_buffer.values[index] = lhs_buffer.values[index] + rhs_buffer.values[index];
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [glslang, "-V", str(shader_path), "-o", str(artifact_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = verify_runtime_test_manifest(
+        {
+            "kind": "crosstl-project-portability-report",
+            "project": {"root": str(tmp_path), "targets": ["vulkan"]},
+            "artifacts": [
+                {
+                    "source": "kernels/add.comp",
+                    "path": "out/vulkan/add.spv",
+                    "target": "vulkan",
+                    "status": "translated",
+                    "entryPoints": [{"name": "main", "stage": "compute"}],
+                    "resourceBindings": [
+                        {"name": "lhs", "kind": "buffer", "set": 0, "binding": 0},
+                        {"name": "rhs", "kind": "buffer", "set": 0, "binding": 1},
+                        {"name": "out", "kind": "buffer", "set": 0, "binding": 2},
+                    ],
+                    "dispatch": {"entryPoint": "main", "workgroupCount": [2, 1, 1]},
+                }
+            ],
+        },
+        {
+            "kind": "crosstl-project-runtime-test-manifest",
+            "adapters": [
+                {
+                    "id": "native-vulkan",
+                    "executor": "vulkan",
+                    "adapterKind": "vulkan-native-runtime",
+                    "platformRequirements": {"requiredTools": []},
+                }
+            ],
+            "tests": [
+                {
+                    "id": "vulkan-add-device",
+                    "selector": {"source": "kernels/add.comp", "target": "vulkan"},
+                    "adapter": "native-vulkan",
+                    "inputs": [
+                        {
+                            "name": "lhs",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "values": [1.0, 2.0],
+                        },
+                        {
+                            "name": "rhs",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "values": [10.0, 20.0],
+                        },
+                    ],
+                    "expectedOutputs": [
+                        {
+                            "name": "out",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "values": [11.0, 22.0],
+                        }
+                    ],
+                }
+            ],
+        },
+        executors={
+            "vulkan": VulkanRuntimeParityAdapter(
+                runtime=VulkanComputeRuntime(),
+                required_tools=("spirv-val",),
+            )
+        },
+    )
+
+    result = report["results"][0]
+    assert report["success"] is True
+    assert result["status"] == "passed"
+    assert result["comparisons"][0]["status"] == "passed"


### PR DESCRIPTION
## Summary
- add a gated runtime parity test that compiles a small Vulkan compute shader and executes vector-add through `VulkanRuntimeParityAdapter` plus `VulkanComputeRuntime`
- enable that test only on the Ubuntu Vulkan runtime-parity CI row with Mesa Vulkan drivers, Vulkan tools, glslang, SPIR-V tools, and pinned Python `vulkan` bindings
- keep local/default runs safe: the device test skips unless `CROSTL_RUN_VULKAN_DEVICE_TEST=1` is set

## Validation
- `.venv/bin/python -m pytest -q -n auto tests/test_translator/test_native_runtime_drivers.py tests/test_ci_workflows.py::test_full_suite_runs_runtime_parity_only_for_available_adapters`
- `CROSTL_RUN_VULKAN_DEVICE_TEST=1 .venv/bin/python -m pytest -q tests/test_translator/test_native_runtime_drivers.py::test_runtime_parity_vulkan_compute_runtime_executes_vector_add_on_device` (local result: skipped after optional binding install because no local Vulkan runtime/device is available)
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n auto`

Refs #1462.

Support issue traceability: no issue closed
