### PR TITLE
Run MLX-generated Vulkan fixture natively

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -63,11 +63,16 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y spirv-tools
+          sudo apt-get install -y libvulkan1 mesa-vulkan-drivers spirv-tools vulkan-tools
 
       - name: Install Linux DXC
         if: runner.os == 'Linux'
         uses: ./.github/actions/install-linux-dxc
+
+      - name: Install Linux Vulkan runtime dependency
+        if: runner.os == 'Linux'
+        run: |
+          python -m pip install vulkan==1.3.275.1
 
       - name: Checkout pinned MLX
         shell: bash
@@ -84,10 +89,12 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$RUNNER_OS" = "Linux" ]; then
+            vulkaninfo --summary || true
             python demos/integrations/mlx/run_mlx_porting.py \
               --mode reduced-frontier \
               --mlx-root mlx-upstream \
-              --require-vulkan-toolchain
+              --require-vulkan-toolchain \
+              --require-vulkan-native-runtime
           else
             python demos/integrations/mlx/run_mlx_porting.py \
               --mode reduced-frontier \

--- a/crosstl/project/host_reflection.py
+++ b/crosstl/project/host_reflection.py
@@ -250,7 +250,7 @@ def _binding_diagnostics(
     resources: Sequence[Mapping[str, Any]],
 ) -> list[ReflectionDiagnostic]:
     diagnostics = []
-    seen: dict[tuple[Any, Any], str] = {}
+    seen: dict[tuple[Any, Any], tuple[str, tuple[str, ...]]] = {}
     for resource in resources:
         resource_name = str(resource.get("name") or "<unnamed>")
         binding = resource.get("binding")
@@ -265,22 +265,50 @@ def _binding_diagnostics(
             )
             continue
         coordinate = (0 if set_number is None else set_number, binding)
+        owners = _resource_entry_points(resource)
         if coordinate in seen:
+            conflicting_resource, conflicting_owners = seen[coordinate]
+            if (
+                owners
+                and conflicting_owners
+                and set(owners).isdisjoint(conflicting_owners)
+            ):
+                continue
             diagnostics.append(
                 ReflectionDiagnostic(
                     REFLECTION_AMBIGUOUS_BINDING,
                     "Multiple reflected resources use the same binding coordinate.",
                     details={
                         "resource": resource_name,
-                        "conflictingResource": seen[coordinate],
+                        "conflictingResource": conflicting_resource,
                         "set": coordinate[0],
                         "binding": coordinate[1],
                     },
                 )
             )
         else:
-            seen[coordinate] = resource_name
+            seen[coordinate] = (resource_name, owners)
     return diagnostics
+
+
+def _resource_entry_points(resource: Mapping[str, Any]) -> tuple[str, ...]:
+    metadata = resource.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return ()
+    names: list[str] = []
+    for key in ("entryPoint", "entry_point"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            names.append(value.strip())
+    for key in ("entryPoints", "entry_points"):
+        value = metadata.get(key)
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            names.extend(
+                item.strip() for item in value if isinstance(item, str) and item.strip()
+            )
+    return tuple(dict.fromkeys(names))
 
 
 def _read_text(path: Path) -> str:
@@ -801,9 +829,10 @@ def _reflect_spirv_assembly(source: str, *, artifact_format: str) -> dict[str, A
             continue
         if opcode == "OpName" and len(tokens) >= 3:
             names[tokens[1]] = tokens[2]
-        elif opcode == "OpDecorate" and len(tokens) >= 4:
+        elif opcode == "OpDecorate" and len(tokens) >= 3:
             target = tokens[1]
-            decorations.setdefault(target, {})[tokens[2]] = _literal_value(tokens[3])
+            value = _literal_value(tokens[3]) if len(tokens) >= 4 else True
+            decorations.setdefault(target, {})[tokens[2]] = value
         elif opcode == "OpEntryPoint" and len(tokens) >= 4:
             model = tokens[1]
             function_id = tokens[2]
@@ -876,6 +905,7 @@ def _reflect_spirv_assembly(source: str, *, artifact_format: str) -> dict[str, A
                 },
             }
         )
+    resources = _annotate_spirv_resource_entry_points(resources, entry_points)
 
     constants = []
     for constant_id, constant in constants_by_id.items():
@@ -906,6 +936,80 @@ def _reflect_spirv_assembly(source: str, *, artifact_format: str) -> dict[str, A
         resources=resources,
         constants=constants,
         diagnostics=[],
+    )
+
+
+def _annotate_spirv_resource_entry_points(
+    resources: Sequence[Mapping[str, Any]],
+    entry_points: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    annotated = [dict(resource) for resource in resources]
+    entry_names = [
+        str(entry_point.get("name"))
+        for entry_point in entry_points
+        if isinstance(entry_point.get("name"), str)
+    ]
+    if not entry_names:
+        return annotated
+
+    for resource in annotated:
+        owner = _spirv_resource_entry_point_by_name(resource, entry_names)
+        if owner is not None:
+            metadata = dict(resource.get("metadata") or {})
+            metadata.setdefault("entryPoint", owner)
+            resource["metadata"] = metadata
+
+    if len(entry_names) <= 1 or len(annotated) % len(entry_names):
+        return annotated
+
+    group_size = len(annotated) // len(entry_names)
+    if group_size == 0:
+        return annotated
+    groups = [
+        annotated[index : index + group_size]
+        for index in range(0, len(annotated), group_size)
+    ]
+    first_signature = [
+        _spirv_resource_layout_signature(resource) for resource in groups[0]
+    ]
+    if not all(
+        [_spirv_resource_layout_signature(resource) for resource in group]
+        == first_signature
+        for group in groups[1:]
+    ):
+        return annotated
+
+    for entry_name, group in zip(entry_names, groups):
+        for resource in group:
+            metadata = dict(resource.get("metadata") or {})
+            metadata.setdefault("entryPoint", entry_name)
+            resource["metadata"] = metadata
+    return annotated
+
+
+def _spirv_resource_entry_point_by_name(
+    resource: Mapping[str, Any], entry_names: Sequence[str]
+) -> str | None:
+    metadata = resource.get("metadata")
+    metadata_id = metadata.get("id") if isinstance(metadata, Mapping) else ""
+    candidates = (
+        str(resource.get("type") or ""),
+        str(resource.get("name") or ""),
+        str(metadata_id or ""),
+    )
+    for entry_name in entry_names:
+        prefixes = (f"{entry_name}_", f"{entry_name}.", f"{entry_name}$")
+        if any(candidate.startswith(prefixes) for candidate in candidates):
+            return entry_name
+    return None
+
+
+def _spirv_resource_layout_signature(resource: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        resource.get("set", 0),
+        resource.get("binding"),
+        resource.get("kind"),
+        resource.get("name"),
     )
 
 

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -26,9 +26,11 @@ class _PreparedVulkanBuffer:
     name: str
     set_index: int
     binding_index: int
+    resource_kind: str | None
     dtype: str
     shape: tuple[int, ...]
     source: str | None
+    output_name: str | None
     payload: bytes
 
     @property
@@ -299,7 +301,7 @@ class _VulkanDispatchContext:
         create_info = vk.VkBufferCreateInfo(
             sType=vk.VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
             size=max(prepared.size, 1),
-            usage=vk.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+            usage=_vulkan_buffer_usage(vk, prepared.resource_kind),
             sharingMode=vk.VK_SHARING_MODE_EXCLUSIVE,
         )
         buffer_handle = vk.vkCreateBuffer(self.device, create_info, None)
@@ -359,7 +361,7 @@ class _VulkanDispatchContext:
         bindings = [
             vk.VkDescriptorSetLayoutBinding(
                 binding=buffer.binding_index,
-                descriptorType=vk.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                descriptorType=_vulkan_descriptor_type(vk, buffer.resource_kind),
                 descriptorCount=1,
                 stageFlags=vk.VK_SHADER_STAGE_COMPUTE_BIT,
             )
@@ -373,15 +375,21 @@ class _VulkanDispatchContext:
         self.descriptor_set_layout = vk.vkCreateDescriptorSetLayout(
             self.device, layout_info, None
         )
-        pool_size = vk.VkDescriptorPoolSize(
-            type=vk.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            descriptorCount=len(bindings),
-        )
+        descriptor_counts: dict[Any, int] = {}
+        for buffer in self.buffers:
+            descriptor_type = _vulkan_descriptor_type(vk, buffer.resource_kind)
+            descriptor_counts[descriptor_type] = (
+                descriptor_counts.get(descriptor_type, 0) + 1
+            )
+        pool_sizes = [
+            vk.VkDescriptorPoolSize(type=descriptor_type, descriptorCount=count)
+            for descriptor_type, count in descriptor_counts.items()
+        ]
         pool_info = vk.VkDescriptorPoolCreateInfo(
             sType=vk.VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
             maxSets=1,
-            poolSizeCount=1,
-            pPoolSizes=[pool_size],
+            poolSizeCount=len(pool_sizes),
+            pPoolSizes=pool_sizes,
         )
         self.descriptor_pool = vk.vkCreateDescriptorPool(self.device, pool_info, None)
         allocate_info = vk.VkDescriptorSetAllocateInfo(
@@ -404,7 +412,9 @@ class _VulkanDispatchContext:
                     dstSet=self.descriptor_set,
                     dstBinding=resource.prepared.binding_index,
                     descriptorCount=1,
-                    descriptorType=vk.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                    descriptorType=_vulkan_descriptor_type(
+                        vk, resource.prepared.resource_kind
+                    ),
                     pBufferInfo=[buffer_info],
                 )
             )
@@ -490,7 +500,7 @@ class _VulkanDispatchContext:
             if prepared.source != "expectedOutput":
                 continue
             payload = self._read_memory(resource.memory, prepared.size)
-            outputs[prepared.name] = {
+            outputs[prepared.output_name or prepared.name] = {
                 "dtype": prepared.dtype,
                 "shape": list(prepared.shape),
                 "values": _unpack_values(payload, prepared.dtype),
@@ -581,6 +591,18 @@ def _read_mapped_memory(mapped: Any, size: int) -> bytes:
         view.release()
 
 
+def _vulkan_descriptor_type(vk: Any, resource_kind: str | None) -> Any:
+    if resource_kind in {"constant-buffer", "uniform"}:
+        return vk.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+    return vk.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+
+
+def _vulkan_buffer_usage(vk: Any, resource_kind: str | None) -> Any:
+    if resource_kind in {"constant-buffer", "uniform"}:
+        return vk.VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+    return vk.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+
+
 def _prepare_vulkan_buffers(
     bindings: Mapping[str, NativeRuntimeBufferBinding],
 ) -> tuple[_PreparedVulkanBuffer, ...]:
@@ -588,7 +610,13 @@ def _prepare_vulkan_buffers(
     seen_bindings: set[tuple[int, int]] = set()
     for name, binding in bindings.items():
         resource = binding.binding
-        if resource.kind not in (None, "buffer", "storage-buffer"):
+        if resource.kind not in (
+            None,
+            "buffer",
+            "storage-buffer",
+            "constant-buffer",
+            "uniform",
+        ):
             raise RuntimeExecutorUnavailable(
                 f"Vulkan compute runtime supports buffer resources only: {name}."
             )
@@ -618,15 +646,24 @@ def _prepare_vulkan_buffers(
                 name=name,
                 set_index=set_index,
                 binding_index=binding_index,
+                resource_kind=resource.kind,
                 dtype=dtype,
                 shape=shape,
                 source=binding.source,
+                output_name=_runtime_value_name(binding),
                 payload=payload,
             )
         )
     return tuple(
         sorted(prepared, key=lambda item: (item.set_index, item.binding_index))
     )
+
+
+def _runtime_value_name(binding: NativeRuntimeBufferBinding) -> str | None:
+    value_name = binding.metadata.get("runtimeValueName")
+    if isinstance(value_name, str) and value_name.strip():
+        return value_name.strip()
+    return None
 
 
 def _workgroup_count(request: NativeRuntimeDispatchRequest) -> tuple[int, int, int]:

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -17591,6 +17591,9 @@ def _runtime_manifest_resource_bindings(
             "status": _runtime_manifest_binding_status(resource),
             "source": "hostInterface.resources",
         }
+        metadata = resource.get("metadata")
+        if isinstance(metadata, Mapping) and metadata:
+            binding["metadata"] = dict(metadata)
         bindings.append(binding)
     return bindings
 

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -1414,7 +1414,14 @@ class NativeRuntimeParityAdapter(RuntimeParityAdapter):
                 source=resource.source,
                 dtype=runtime_value.dtype if runtime_value is not None else None,
                 shape=runtime_value.shape if runtime_value is not None else (),
-                metadata=runtime_value.metadata if runtime_value is not None else {},
+                metadata=(
+                    {
+                        **dict(runtime_value.metadata),
+                        "runtimeValueName": runtime_value.name,
+                    }
+                    if runtime_value is not None
+                    else {}
+                ),
             )
         return bindings
 

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -25,7 +25,10 @@ The current harness verifies:
   deterministic expected-output checks;
 - native runtime execution-readiness reports for the same reduced probes,
   using the built-in DirectX, OpenGL, and Vulkan native adapter contracts with
-  missing runtime drivers reported as structured blockers.
+  missing runtime drivers reported as structured blockers;
+- on Linux CI, native Vulkan execution for the generated MLX `arange.metal`
+  SPIR-V assembly through the optional Vulkan compute runtime and Mesa Vulkan
+  software driver.
 
 Pull requests run the reduced frontier above. Scheduled and manually triggered
 CI also run the full-corpus artifact scout with finite Metal template
@@ -55,15 +58,17 @@ manifests consume reflected runtime artifact metadata, including entry points,
 resource bindings, and dispatch geometry. Runtime-test plans now resolve
 source-level fixture names against common generated resource aliases. The
 reduced arange fixtures select the translated artifact by source and target,
-then select `CSMain`, `main`, or `arangeuint8` independently for DirectX,
+then select `CSMain`, `main`, or `arangeuint32` independently for DirectX,
 OpenGL, or Vulkan dispatch. Plans report remaining non-blocking platform,
-layout, and entry-point ownership warnings. These plans are still metadata
-readiness artifacts. The reduced fixture execution report exercises the
-project runner and adapter contract with reference buffers; it does not execute
-the upstream MLX runtime or native Direct3D, OpenGL, or Vulkan device code.
-The native execution-readiness report attempts the built-in native adapter
-contract separately and records missing runtime drivers as blockers until
-backend runtime drivers are supplied by integration code.
+layout, and entry-point ownership warnings. The reduced fixture execution
+report exercises the project runner and adapter contract with reference
+buffers. The native execution report attempts the built-in native adapter
+contract separately. On Linux CI it requires the generated Vulkan `arangeuint32`
+artifact to assemble, load, dispatch, and compare on the Vulkan compute runtime;
+other unavailable native backends remain structured blockers until backend
+runtime drivers are supplied by integration code. This still does not execute
+the upstream MLX host runtime or the upstream MLX Python/C++ unit test suite on
+non-Metal backends.
 
 ## Running Locally
 
@@ -89,14 +94,18 @@ python demos/integrations/mlx/run_mlx_porting.py \
   --summary /tmp/mlx/.crosstl-mlx-porting/full-corpus-summary.json
 ```
 
-On Linux, install SPIR-V tools and require the Vulkan smoke check:
+On Linux, install SPIR-V tools and the Vulkan runtime dependencies to require
+both Vulkan validation and native execution of the generated MLX `arange`
+artifact:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y spirv-tools
+sudo apt-get install -y libvulkan1 mesa-vulkan-drivers spirv-tools vulkan-tools
+python -m pip install vulkan==1.3.275.1
 python demos/integrations/mlx/run_mlx_porting.py \
   --mlx-root /tmp/mlx \
-  --require-vulkan-toolchain
+  --require-vulkan-toolchain \
+  --require-vulkan-native-runtime
 ```
 
 The harness writes reports, generated artifacts, and command logs under

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from crosstl.project import (
+    VulkanComputeRuntime,
     build_project_test_runner_plan,
     build_runtime_artifact_manifest,
     execute_project_test_runner_plan,
@@ -58,7 +59,7 @@ RUNTIME_READINESS_TRACKED_ISSUES = (
 RUNTIME_READINESS_ENTRY_POINTS = {
     "directx": "CSMain",
     "opengl": "main",
-    "vulkan": "arangeuint8",
+    "vulkan": "arangeuint32",
 }
 RUNTIME_FIXTURE_EXECUTION_ADAPTER_KIND = "mlx-arange-reference-runtime"
 NATIVE_RUNTIME_EXECUTION_SCOPE = "native-runtime-execution-readiness"
@@ -890,6 +891,23 @@ def _runtime_report_diagnostics(report: Mapping[str, Any]) -> list[Mapping[str, 
     return diagnostics
 
 
+def _runtime_report_result_for_target(
+    runtime_report: Mapping[str, Any], target: str
+) -> Mapping[str, Any] | None:
+    for result in runtime_report.get("results", []):
+        if not isinstance(result, Mapping):
+            continue
+        artifact = result.get("artifact")
+        if isinstance(artifact, Mapping) and artifact.get("target") == target:
+            return result
+        fixture = result.get("fixture")
+        if isinstance(fixture, Mapping):
+            selector = fixture.get("selector")
+            if isinstance(selector, Mapping) and selector.get("target") == target:
+                return result
+    return None
+
+
 def _error_diagnostics(
     diagnostics: Sequence[Mapping[str, Any]],
 ) -> list[Mapping[str, Any]]:
@@ -976,6 +994,7 @@ def _execute_native_runtime_fixtures_for_report(
     name: str,
     runtime_artifact_manifest_path: Path,
     targets: Sequence[str],
+    require_vulkan_native_runtime: bool,
 ) -> dict[str, Any]:
     metadata_path = report_dir / f"{name}.native-runtime-execution-metadata.json"
     manifest_path = report_dir / f"{name}.native-runtime-execution-manifest.json"
@@ -999,7 +1018,9 @@ def _execute_native_runtime_fixtures_for_report(
     report = execute_project_test_runner_plan(
         plan,
         project_root=mlx_root,
-        runtime_executors=native_runtime_parity_adapters(validate=False),
+        runtime_executors=native_runtime_parity_adapters(
+            runtimes={"vulkan": VulkanComputeRuntime()}
+        ),
     )
     _write_json(report_path, report)
     project_runner_summary = report.get("summary", {})
@@ -1017,8 +1038,16 @@ def _execute_native_runtime_fixtures_for_report(
     diagnostics = _runtime_report_diagnostics(report)
     diagnostics_by_code = _diagnostics_by_code(diagnostics)
     failed_count = int(summary.get("failedCount", 0))
+    passed_count = int(summary.get("passedCount", 0))
     unavailable_count = int(summary.get("unavailableCount", 0))
     skipped_count = int(summary.get("skippedCount", 0))
+    if require_vulkan_native_runtime:
+        vulkan_result = _runtime_report_result_for_target(runtime_report, "vulkan")
+        _require(
+            isinstance(vulkan_result, Mapping)
+            and vulkan_result.get("status") == "passed",
+            "Vulkan native runtime execution was required for the MLX arange fixture",
+        )
     status = "passed"
     if failed_count:
         status = "blocked-by-tracked-issues"
@@ -1033,6 +1062,7 @@ def _execute_native_runtime_fixtures_for_report(
         "projectTestRunnerReport": _relpath(report_path, mlx_root),
         "targets": list(targets),
         "summary": summary,
+        "passedCount": passed_count,
         "projectRunnerSummary": project_runner_summary,
         "diagnosticsByCode": diagnostics_by_code,
         "nativeRuntimeExecutionIncluded": True,
@@ -1048,6 +1078,7 @@ def _plan_runtime_readiness_for_report(
     name: str,
     artifact_report: Path,
     targets: Sequence[str],
+    require_vulkan_native_runtime: bool,
 ) -> dict[str, Any]:
     _require(
         artifact_report.is_file(),
@@ -1088,6 +1119,7 @@ def _plan_runtime_readiness_for_report(
         name=name,
         runtime_artifact_manifest_path=runtime_artifact_manifest_path,
         targets=targets,
+        require_vulkan_native_runtime=require_vulkan_native_runtime,
     )
 
     runtime_artifact_diagnostics_by_code = _diagnostics_by_code(
@@ -1173,6 +1205,8 @@ def _plan_runtime_readiness_for_report(
 def _plan_reduced_runtime_readiness(
     mlx_root: Path,
     report_dir: Path,
+    *,
+    require_vulkan_native_runtime: bool,
 ) -> dict[str, Any]:
     reports = [
         _plan_runtime_readiness_for_report(
@@ -1181,6 +1215,7 @@ def _plan_reduced_runtime_readiness(
             name="directx-vulkan-runtime-readiness",
             artifact_report=report_dir / "directx-vulkan-frontier.json",
             targets=("directx", "vulkan"),
+            require_vulkan_native_runtime=require_vulkan_native_runtime,
         ),
         _plan_runtime_readiness_for_report(
             mlx_root=mlx_root,
@@ -1188,6 +1223,7 @@ def _plan_reduced_runtime_readiness(
             name="opengl-runtime-readiness",
             artifact_report=report_dir / "arange-opengl.json",
             targets=("opengl",),
+            require_vulkan_native_runtime=False,
         ),
     ]
     status = (
@@ -1507,6 +1543,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             _plan_reduced_runtime_readiness(
                 mlx_root,
                 report_dir,
+                require_vulkan_native_runtime=args.require_vulkan_native_runtime,
             )
         )
     elif args.mode == FULL_CORPUS_MODE:
@@ -1580,6 +1617,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--require-vulkan-toolchain",
         action="store_true",
         help="Fail unless the Vulkan SPIR-V smoke check runs successfully.",
+    )
+    parser.add_argument(
+        "--require-vulkan-native-runtime",
+        action="store_true",
+        help="Fail unless the MLX-generated Vulkan arange fixture executes natively.",
     )
     parser.add_argument(
         "--no-clean",

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2120,6 +2120,10 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert 'cron: "31 4 * * 1"' in mlx_porting
     assert "github.event_name != 'schedule'" in mlx_porting
     assert "--mode reduced-frontier" in mlx_porting
+    assert "--require-vulkan-native-runtime" in mlx_porting
+    assert "mesa-vulkan-drivers" in mlx_porting
+    assert "python -m pip install vulkan==1.3.275.1" in mlx_porting
+    assert "vulkaninfo --summary" in mlx_porting
     assert "mlx-full-corpus-scout:" in mlx_porting
     assert "MLX full-corpus artifact scout" in mlx_porting
     assert (
@@ -2143,6 +2147,8 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "without tracked issue references" in harness
     assert "runtime-readiness" in harness
     assert "runtime-test-manifest" in harness
+    assert "VulkanComputeRuntime" in harness
+    assert "require_vulkan_native_runtime" in harness
     for tracked_issue_number in (
         1312,
         1376,

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -143,6 +143,7 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
         name="directx-runtime-readiness",
         artifact_report=artifact_report,
         targets=("directx",),
+        require_vulkan_native_runtime=False,
     )
 
     assert build_calls == [artifact_report]
@@ -267,7 +268,7 @@ def test_native_runtime_execution_metadata_uses_target_executors():
 
 @pytest.mark.parametrize(
     ("target", "entry_point"),
-    (("directx", "CSMain"), ("opengl", "main"), ("vulkan", "arangeuint8")),
+    (("directx", "CSMain"), ("opengl", "main"), ("vulkan", "arangeuint32")),
 )
 def test_runtime_readiness_selects_entry_point_independently(target, entry_point):
     module = _load_harness()
@@ -317,6 +318,7 @@ def test_runtime_readiness_reports_tracked_plan_resource_blockers(
         name="opengl-runtime-readiness",
         artifact_report=artifact_report,
         targets=("opengl",),
+        require_vulkan_native_runtime=False,
     )
 
     assert result["status"] == "blocked-by-tracked-issues"
@@ -424,7 +426,9 @@ def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
     )
 
     result = module._plan_reduced_runtime_readiness(
-        Path("/tmp/mlx"), Path("/tmp/reports")
+        Path("/tmp/mlx"),
+        Path("/tmp/reports"),
+        require_vulkan_native_runtime=False,
     )
 
     assert result["status"] == "blocked-by-tracked-issues"
@@ -817,7 +821,7 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
     monkeypatch.setattr(
         module,
         "_plan_reduced_runtime_readiness",
-        lambda *args: {
+        lambda *args, **kwargs: {
             "name": "runtime-readiness",
             "status": "blocked-by-tracked-issues",
         },
@@ -835,6 +839,7 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
             no_clean=False,
             python="python",
             require_vulkan_toolchain=False,
+            require_vulkan_native_runtime=False,
             mode=module.REDUCED_FRONTIER_MODE,
         )
     )

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -167,24 +167,41 @@ def test_prepare_vulkan_buffers_packs_inputs_and_zeroes_outputs():
                 dtype="float32",
                 shape=(2,),
             ),
-            "out": NativeRuntimeBufferBinding(
-                name="out",
+            "scale": NativeRuntimeBufferBinding(
+                name="scaleUniform",
                 binding=RuntimeResourceBinding(
-                    name="out",
+                    name="scaleUniform",
+                    kind="constant-buffer",
+                    set=0,
+                    binding=2,
+                ),
+                value=3,
+                source="input",
+                dtype="uint32",
+                shape=(),
+            ),
+            "out": NativeRuntimeBufferBinding(
+                name="out_",
+                binding=RuntimeResourceBinding(
+                    name="out_",
                     kind="buffer",
                     set=0,
-                    binding=1,
+                    binding=3,
                 ),
                 source="expectedOutput",
                 dtype="float32",
                 shape=(2,),
+                metadata={"runtimeValueName": "out"},
             ),
         }
     )
 
-    assert [buffer.name for buffer in buffers] == ["lhs", "out"]
+    assert [buffer.name for buffer in buffers] == ["lhs", "scale", "out"]
     assert buffers[0].payload == b"\x00\x00\x80?\x00\x00\x00@"
-    assert buffers[1].payload == b"\x00" * 8
+    assert buffers[1].resource_kind == "constant-buffer"
+    assert buffers[1].payload == b"\x03\x00\x00\x00"
+    assert buffers[2].payload == b"\x00" * 8
+    assert buffers[2].output_name == "out"
 
 
 def test_vulkan_handle_array_unwraps_first_handle():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -33556,6 +33556,108 @@ def test_inspect_runtime_package_reflects_spirv_assembly_metadata(tmp_path):
     assert host_interface["diagnostics"] == []
 
 
+def test_reflect_spirv_assembly_preserves_flag_decorations(tmp_path):
+    artifact_path = tmp_path / "kernel.spvasm"
+    artifact_path.write_text(
+        textwrap.dedent("""
+            OpEntryPoint GLCompute %main "main" %out
+            OpExecutionMode %main LocalSize 1 1 1
+            OpName %out "out_"
+            OpName %OutBuffer "out_Buffer"
+            OpDecorate %runtimearr ArrayStride 4
+            OpDecorate %OutBuffer BufferBlock
+            OpMemberDecorate %OutBuffer 0 Offset 0
+            OpDecorate %out DescriptorSet 0
+            OpDecorate %out Binding 2
+            %uint = OpTypeInt 32 0
+            %runtimearr = OpTypeRuntimeArray %uint
+            %OutBuffer = OpTypeStruct %runtimearr
+            %ptr = OpTypePointer Uniform %OutBuffer
+            %out = OpVariable %ptr Uniform
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    host_interface = reflect_target_host_interface(artifact_path, target="vulkan")
+
+    assert host_interface is not None
+    assert host_interface["status"] == "ready"
+    assert host_interface["resources"] == [
+        {
+            "name": "out_",
+            "kind": "buffer",
+            "type": "out_Buffer",
+            "set": 0,
+            "binding": 2,
+            "access": "read",
+            "metadata": {
+                "id": "%out",
+                "storageClass": "Uniform",
+                "typeId": "%ptr",
+            },
+        }
+    ]
+
+
+def test_reflect_spirv_assembly_scopes_repeated_entry_point_layouts(tmp_path):
+    artifact_path = tmp_path / "kernel.spvasm"
+    artifact_path.write_text(
+        textwrap.dedent("""
+            OpEntryPoint GLCompute %ep_a "kernelA" %builtin
+            OpEntryPoint GLCompute %ep_b "kernelB" %builtin
+            OpName %a_start "start"
+            OpName %a_out "out_"
+            OpName %b_start "start"
+            OpName %b_out "out_"
+            OpName %kernelA_startUniformBlock "kernelA_startUniformBlock"
+            OpName %kernelB_startUniformBlock "kernelB_startUniformBlock"
+            OpName %OutBuffer "out_Buffer"
+            OpDecorate %kernelA_startUniformBlock Block
+            OpDecorate %a_start DescriptorSet 0
+            OpDecorate %a_start Binding 0
+            OpDecorate %OutBuffer BufferBlock
+            OpDecorate %a_out DescriptorSet 0
+            OpDecorate %a_out Binding 1
+            OpDecorate %kernelB_startUniformBlock Block
+            OpDecorate %b_start DescriptorSet 0
+            OpDecorate %b_start Binding 0
+            OpDecorate %b_out DescriptorSet 0
+            OpDecorate %b_out Binding 1
+            OpDecorate %builtin BuiltIn GlobalInvocationId
+            %uint = OpTypeInt 32 0
+            %runtimearr = OpTypeRuntimeArray %uint
+            %kernelA_startUniformBlock = OpTypeStruct %uint
+            %kernelB_startUniformBlock = OpTypeStruct %uint
+            %OutBuffer = OpTypeStruct %runtimearr
+            %ptr_a_start = OpTypePointer Uniform %kernelA_startUniformBlock
+            %ptr_b_start = OpTypePointer Uniform %kernelB_startUniformBlock
+            %ptr_out = OpTypePointer Uniform %OutBuffer
+            %ptr_builtin = OpTypePointer Input %uint
+            %a_start = OpVariable %ptr_a_start Uniform
+            %a_out = OpVariable %ptr_out Uniform
+            %b_start = OpVariable %ptr_b_start Uniform
+            %b_out = OpVariable %ptr_out Uniform
+            %builtin = OpVariable %ptr_builtin Input
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    host_interface = reflect_target_host_interface(artifact_path, target="vulkan")
+
+    assert host_interface is not None
+    assert host_interface["status"] == "ready"
+    assert host_interface["diagnostics"] == []
+    assert [
+        resource["metadata"]["entryPoint"] for resource in host_interface["resources"]
+    ] == ["kernelA", "kernelA", "kernelB", "kernelB"]
+    assert [resource["kind"] for resource in host_interface["resources"]] == [
+        "constant-buffer",
+        "buffer",
+        "constant-buffer",
+        "buffer",
+    ]
+
+
 def test_reflect_spirv_binary_reports_missing_disassembler(tmp_path):
     artifact_path = tmp_path / "kernel.spv"
     artifact_path.write_bytes(b"\x03\x02#\x07")


### PR DESCRIPTION
## Summary
- preserve SPIR-V flag decorations and entry-point resource ownership in host-interface reflection
- carry reflected resource metadata into runtime artifact manifests and bind MLX arange resources by selected entry point
- extend the optional Vulkan compute runtime for uniform-buffer inputs and mixed descriptor pools
- require Linux MLX CI to execute the generated Vulkan arange fixture through the native Vulkan runtime

## Validation
- .venv/bin/pre-commit run --all-files
- .venv/bin/python -m pytest -q -n auto
- .venv/bin/python demos/integrations/mlx/run_mlx_porting.py --mode reduced-frontier --mlx-root <pinned-mlx-checkout> --no-clean --summary <summary-local.json>

Refs #1462
Support issue traceability: no issue closed

This still does not claim the upstream MLX host runtime or full MLX test suite runs on non-Metal backends; it proves one generated MLX Vulkan artifact can be loaded and executed by the native runtime path in CI.
