### PR TITLE
Account Metal template work by reachable specialization

### DIFF
--- a/crosstl/backend/Metal/preprocessor.py
+++ b/crosstl/backend/Metal/preprocessor.py
@@ -54,7 +54,6 @@ MLX_HOST_NAME_DECL_RE = re.compile(
     re.DOTALL,
 )
 DEFAULT_EXPLICIT_TEMPLATE_SPECIALIZATION_LIMIT = 512
-TEMPLATE_MATERIALIZATION_SCAN_CHARS_PER_WORK_ITEM = 8
 
 
 class MetalStructMethodError(ValueError):
@@ -592,9 +591,15 @@ class MetalPreprocessor(HLSLPreprocessor):
         return self._apply_text_replacements(code, replacements)
 
     def _materialize_explicit_template_function_calls(
-        self, code: str, *, work_budget: Optional[object] = None
+        self,
+        code: str,
+        *,
+        work_budget: Optional[object] = None,
+        materialized_names: Optional[Dict[Tuple[str, Tuple[str, ...]], str]] = None,
     ) -> str:
-        materialized_names: Dict[Tuple[str, Tuple[str, ...]], str] = {}
+        materialized_names = (
+            materialized_names if materialized_names is not None else {}
+        )
         working = code
 
         while True:
@@ -604,19 +609,6 @@ class MetalPreprocessor(HLSLPreprocessor):
 
             templates_by_name = {template.name: template for template in templates}
             template_spans = self._find_template_declaration_spans(working)
-            if work_budget is not None:
-                work_budget.consume(
-                    self._template_materialization_scan_work_items(working),
-                    offset=templates[0].span[0],
-                    length=max(templates[0].span[1] - templates[0].span[0], 0),
-                    context="explicit template source scan",
-                )
-                work_budget.consume(
-                    len(templates) * max(1, len(template_spans)),
-                    offset=templates[0].span[0],
-                    length=max(templates[0].span[1] - templates[0].span[0], 0),
-                    context="explicit template reachability scan",
-                )
             reachable_function_spans = self._reachable_function_spans(
                 working, template_spans
             )
@@ -630,13 +622,6 @@ class MetalPreprocessor(HLSLPreprocessor):
                 explicit_specialization_keys,
                 reachable_function_spans,
             )
-            if work_budget is not None:
-                first_call_offset = calls[0][2][0] if calls else templates[0].span[0]
-                work_budget.consume(
-                    len(calls) * max(1, len(templates_by_name)),
-                    offset=first_call_offset,
-                    context="explicit template call matching",
-                )
             if not calls:
                 return working
 
@@ -685,6 +670,27 @@ class MetalPreprocessor(HLSLPreprocessor):
                         requested_signature=requested_signature,
                         suggested_action=suggested_action,
                     )
+                if work_budget is not None:
+                    consume_unique = getattr(work_budget, "consume_unique", None)
+                    work_key = ("function", key[0], *key[1])
+                    context = (
+                        "reachable concrete helper "
+                        f"'{self._template_specialization_signature(function_name, template_arguments)}'"
+                    )
+                    if callable(consume_unique):
+                        consume_unique(
+                            work_key,
+                            offset=spans[0][0],
+                            length=max(spans[0][1] - spans[0][0], 0),
+                            context=context,
+                        )
+                    else:
+                        work_budget.consume(
+                            1,
+                            offset=spans[0][0],
+                            length=max(spans[0][1] - spans[0][0], 0),
+                            context=context,
+                        )
                 specialized_name = self._template_specialization_identifier(
                     function_name, list(key[1])
                 )
@@ -709,14 +715,6 @@ class MetalPreprocessor(HLSLPreprocessor):
                 working = working.rstrip() + "\n\n" + "\n\n".join(new_materializations)
                 if not working.endswith("\n"):
                     working += "\n"
-
-    @staticmethod
-    def _template_materialization_scan_work_items(code: str) -> int:
-        return max(
-            1,
-            (len(code) + TEMPLATE_MATERIALIZATION_SCAN_CHARS_PER_WORK_ITEM - 1)
-            // TEMPLATE_MATERIALIZATION_SCAN_CHARS_PER_WORK_ITEM,
-        )
 
     def _materialize_explicit_template_struct_instantiations(
         self, code: str, *, work_budget: Optional[object] = None
@@ -751,13 +749,6 @@ class MetalPreprocessor(HLSLPreprocessor):
             templates = self._find_template_structs(working)
             if not templates:
                 return working
-            if work_budget is not None:
-                work_budget.consume(
-                    self._template_materialization_scan_work_items(working),
-                    offset=templates[0].span[0],
-                    length=max(templates[0].span[1] - templates[0].span[0], 0),
-                    context="explicit template struct source scan",
-                )
             primary_templates = [
                 template
                 for template in templates
@@ -787,12 +778,6 @@ class MetalPreprocessor(HLSLPreprocessor):
                     (template, specialization_arguments)
                 )
             excluded_spans = self._find_template_declaration_spans(working)
-            if work_budget is not None:
-                work_budget.consume(
-                    len(templates_by_name) * max(1, len(excluded_spans)),
-                    offset=templates[0].span[0],
-                    context="explicit template struct declaration matching",
-                )
             (
                 instantiations,
                 selected_partial_specializations,
@@ -803,15 +788,6 @@ class MetalPreprocessor(HLSLPreprocessor):
                 explicit_specialization_keys,
                 partial_specializations,
             )
-            if work_budget is not None:
-                first_offset = (
-                    instantiations[0][2][0] if instantiations else templates[0].span[0]
-                )
-                work_budget.consume(
-                    len(instantiations) * max(1, len(templates_by_name)),
-                    offset=first_offset,
-                    context="explicit template struct instantiation matching",
-                )
             if not instantiations:
                 return working
 
@@ -881,6 +857,28 @@ class MetalPreprocessor(HLSLPreprocessor):
                     # `Name<...>` so the existing template-materialization
                     # diagnostic fires exactly as it does today.
                     return code
+                if work_budget is not None:
+                    consume_unique = getattr(work_budget, "consume_unique", None)
+                    work_key = ("struct", key[0], *key[1])
+                    context = (
+                        "reachable concrete struct "
+                        f"'{self._template_specialization_signature(struct_name, template_arguments)}'"
+                    )
+                    first_span = materialization_spans[0]
+                    if callable(consume_unique):
+                        consume_unique(
+                            work_key,
+                            offset=first_span[0],
+                            length=max(first_span[1] - first_span[0], 0),
+                            context=context,
+                        )
+                    else:
+                        work_budget.consume(
+                            1,
+                            offset=first_span[0],
+                            length=max(first_span[1] - first_span[0], 0),
+                            context=context,
+                        )
                 specialized_name = self._template_specialization_identifier(
                     struct_name, list(key[1])
                 )

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -1289,7 +1289,6 @@ METAL_TEMPLATE_MATERIALIZATION_WORK_LIMIT_SOURCE_OPTION = (
     "template_materialization_work_limit_source"
 )
 METAL_TEMPLATE_MATERIALIZATION_WORK_LIMIT_MULTIPLIER = 64
-METAL_LARGE_TEMPLATE_SOURCE_MIN_CHARS = 96 * 1024
 METAL_DIAGNOSTIC_TEMPLATE_HELPER_RE = re.compile(
     r"(^|_)(?:debug|dbg|log|trace|diagnostic|diag|assert)($|_)"
 )
@@ -9722,6 +9721,18 @@ def _metal_find_implicit_template_function_calls(
             and preprocessor._containing_span(function.span[0], included) is None
         ):
             continue
+        candidate_calls = _plain_template_helper_call_sites(
+            preprocessor,
+            source,
+            templates_by_name,
+            excluded_spans,
+            [function.body_span],
+        )
+        if not any(
+            not explicit_template_arguments
+            for _name, _arguments, _span, explicit_template_arguments in candidate_calls
+        ):
+            continue
         type_environment = _metal_function_type_environment(
             preprocessor,
             source,
@@ -9834,6 +9845,7 @@ class _MetalTemplateMaterializationWorkBudget:
     target: str
     pass_name: str = "implicit-template-materialization/type-environment"
     used: int = 0
+    unique_items: set[tuple[Any, ...]] = field(default_factory=set)
 
     def consume(
         self,
@@ -9859,8 +9871,8 @@ class _MetalTemplateMaterializationWorkBudget:
         requested_signature = f"{self.pass_name}: {self.used} work items for {context}"
         suggested_action = (
             "raise max_template_materialization_work for this source pattern "
-            "or backend, reduce implicit Metal template helper fan-out, or add "
-            "explicit template arguments"
+            "or backend, reduce the reachable concrete template graph or "
+            "type-resolution fan-out, or provide explicit template arguments"
         )
         location_text = (
             f" Source context: {location.file}:{location.line}:{location.column}."
@@ -9870,7 +9882,8 @@ class _MetalTemplateMaterializationWorkBudget:
         raise MetalTemplateSpecializationError(
             "Metal template materialization work budget exceeded while "
             f"running {self.pass_name} for target '{self.target}'; "
-            f"{self.used} work items requested, limit {self.limit} from "
+            f"{self.used} work items requested for {context}, "
+            f"limit {self.limit} from "
             f"{self.limit_source}.{location_text} "
             f"Suggested action: {suggested_action}.",
             limit=self.limit,
@@ -9881,6 +9894,25 @@ class _MetalTemplateMaterializationWorkBudget:
             suggested_action=suggested_action,
             source_location=location,
         )
+
+    def consume_unique(
+        self,
+        key: tuple[Any, ...],
+        *,
+        offset: int = 0,
+        length: int = 0,
+        context: str,
+    ) -> bool:
+        if key in self.unique_items:
+            return False
+        self.unique_items.add(key)
+        self.consume(
+            1,
+            offset=offset,
+            length=length,
+            context=context,
+        )
+        return True
 
 
 def _metal_template_materialization_work_limit(
@@ -11661,9 +11693,7 @@ def _metal_struct_field_type_environments(
     structs = preprocessor._find_concrete_struct_definitions(source)
     if work_budget is not None and structs:
         work_budget.consume(
-            preprocessor._template_materialization_scan_work_items(source)
-            + len(structs)
-            + sum(len(struct.data_member_types) for struct in structs),
+            len(structs) + sum(len(struct.data_member_types) for struct in structs),
             offset=int(structs[0].span[0]),
             length=max(int(structs[0].span[1]) - int(structs[0].span[0]), 0),
             context="concrete struct field type scan",
@@ -12524,19 +12554,6 @@ def _materialize_plain_template_helper_calls(
         for template in templates:
             templates_by_name.setdefault(template.name, []).append(template)
         template_spans = preprocessor._find_template_declaration_spans(working)
-        if work_budget is not None:
-            work_budget.consume(
-                preprocessor._template_materialization_scan_work_items(working),
-                offset=templates[0].span[0],
-                length=max(templates[0].span[1] - templates[0].span[0], 0),
-                context="plain template helper source scan",
-            )
-            work_budget.consume(
-                len(templates) * max(1, len(template_spans)),
-                offset=templates[0].span[0],
-                length=max(templates[0].span[1] - templates[0].span[0], 0),
-                context="plain template helper reachability scan",
-            )
         reachable_function_spans = preprocessor._reachable_function_spans(
             working,
             template_spans,
@@ -12600,6 +12617,17 @@ def _materialize_plain_template_helper_calls(
             materialized_name = materialized_names.get(key)
             if materialized_name is not None:
                 return materialized_name
+
+            if work_budget is not None:
+                work_budget.consume_unique(
+                    ("function", *key),
+                    offset=int(template.span[0]),
+                    length=max(int(template.span[1]) - int(template.span[0]), 0),
+                    context=(
+                        "reachable concrete helper "
+                        f"'{preprocessor._template_specialization_signature(function_name, arguments)}'"
+                    ),
+                )
 
             unique_count = len(materialized_names) + 1
             if len(materialized_names) >= preprocessor.max_template_specializations:
@@ -15718,7 +15746,6 @@ def _project_template_materialization_for_artifact(
             pass_name="explicit-template-materialization",
         )
         if materialization_work_limit > 0
-        and len(preprocessed) >= METAL_LARGE_TEMPLATE_SOURCE_MIN_CHARS
         else None
     )
 
@@ -15726,59 +15753,6 @@ def _project_template_materialization_for_artifact(
     source_instantiation_unsupported: list[dict[str, Any]] = []
     source_instantiation_partial_templates: set[str] = set()
     template_lookup = {template.name: template for template in templates}
-    if target == "opengl" and source_instantiations:
-        materialization_work_items = len(source_instantiations) * max(
-            1,
-            len(templates),
-        )
-        if materialization_work_items > materialization_work_limit:
-            first_instantiation = source_instantiations[0]
-            first_template = template_lookup.get(first_instantiation.function_name)
-            if first_template is not None:
-                location = _source_location_at_offset(
-                    unit,
-                    preprocessed,
-                    int(first_template.span[0]),
-                    max(int(first_template.span[1]) - int(first_template.span[0]), 0),
-                )
-                location_kind = "source declaration"
-            else:
-                location = _source_location_at_offset(
-                    unit,
-                    preprocessed,
-                    int(first_instantiation.span[0]),
-                    max(
-                        int(first_instantiation.span[1])
-                        - int(first_instantiation.span[0]),
-                        0,
-                    ),
-                )
-                location_kind = "source instantiation"
-            requested_signature = (
-                f"{len(source_instantiations)} source instantiations x "
-                f"{len(templates)} templates"
-            )
-            suggested_action = (
-                "raise max_template_materialization_work for this source pattern "
-                "or OpenGL target, or reduce source template instantiations"
-            )
-            raise MetalTemplateSpecializationError(
-                "OpenGL Metal template materialization work limit exceeded before "
-                f"GLSL codegen for '{unit.relative_path}'; "
-                f"{materialization_work_items} source-instantiation/template work "
-                f"items requested ({requested_signature}), limit "
-                f"{materialization_work_limit} from "
-                f"{materialization_work_limit_source}. "
-                f"First {location_kind}: "
-                f"{location.file}:{location.line}:{location.column}. "
-                f"Suggested action: {suggested_action}.",
-                limit=materialization_work_limit,
-                limit_source=materialization_work_limit_source,
-                required_work_items=materialization_work_items,
-                requested_signature=requested_signature,
-                suggested_action=suggested_action,
-                source_location=location,
-            )
     source_instantiation_contexts: list[_SourceInstantiationTemplateContext] = []
     source_instantiation_materialized_names: dict[tuple[str, tuple[str, ...]], str] = {}
     seen_source_instantiations: set[tuple[str, tuple[str, ...], str]] = set()
@@ -15847,6 +15821,16 @@ def _project_template_materialization_for_artifact(
         if key in seen_source_instantiations:
             continue
         seen_source_instantiations.add(key)
+        if explicit_work_budget is not None:
+            explicit_work_budget.consume_unique(
+                ("entry", *key),
+                offset=int(instantiation.span[0]),
+                length=max(
+                    int(instantiation.span[1]) - int(instantiation.span[0]),
+                    0,
+                ),
+                context=f"reachable source entry '{instantiation.host_name}'",
+            )
         materialized_name = preprocessor._materialized_function_identifier(
             instantiation.host_name,
             template.name,
@@ -15902,19 +15886,6 @@ def _project_template_materialization_for_artifact(
     templates = preprocessor._find_template_functions(preprocessed)
     templates_by_name = {template.name: template for template in templates}
     template_spans = preprocessor._find_template_declaration_spans(preprocessed)
-    if templates and explicit_work_budget is not None:
-        explicit_work_budget.consume(
-            preprocessor._template_materialization_scan_work_items(preprocessed),
-            offset=templates[0].span[0],
-            length=max(templates[0].span[1] - templates[0].span[0], 0),
-            context="project explicit template source scan",
-        )
-        explicit_work_budget.consume(
-            len(templates) * max(1, len(template_spans)),
-            offset=templates[0].span[0],
-            length=max(templates[0].span[1] - templates[0].span[0], 0),
-            context="project explicit template reachability scan",
-        )
     reachable_function_spans = preprocessor._reachable_function_spans(
         preprocessed, template_spans
     )
@@ -15928,13 +15899,6 @@ def _project_template_materialization_for_artifact(
         explicit_specialization_keys,
         reachable_function_spans,
     )
-    if calls and explicit_work_budget is not None:
-        explicit_work_budget.consume(
-            len(calls) * max(1, len(templates_by_name)),
-            offset=calls[0][2][0],
-            context="project explicit template call matching",
-        )
-
     explicit_template_names: set[str] = set()
     seen_call_specializations: set[tuple[str, tuple[str, ...]]] = set()
     call_site_materialized_names: dict[tuple[str, tuple[str, ...]], str] = {}
@@ -15972,15 +15936,47 @@ def _project_template_materialization_for_artifact(
             )
         )
 
+    explicit_materialized_names: dict[tuple[str, tuple[str, ...]], str] = {}
     try:
         materialized = preprocessor._materialize_explicit_template_function_calls(
             preprocessed,
             work_budget=explicit_work_budget,
+            materialized_names=explicit_materialized_names,
         )
     except MetalTemplateSpecializationError:
         raise
     except Exception:  # noqa: BLE001
         return None
+
+    recorded_specializations = {
+        (record.get("name"), record.get("materializedName"))
+        for record in specializations
+    }
+    for key, materialized_name in explicit_materialized_names.items():
+        function_name, normalized_arguments = key
+        template = templates_by_name.get(function_name)
+        if template is None:
+            continue
+        explicit_template_names.add(function_name)
+        call_site_materialized_names[key] = materialized_name
+        record_key = (function_name, materialized_name)
+        if record_key in recorded_specializations:
+            continue
+        parameters = _template_parameter_values_from_arguments(
+            preprocessor,
+            template,
+            list(normalized_arguments),
+        )
+        specializations.append(
+            _materialized_template_specialization_record(
+                name=function_name,
+                materialized_name=materialized_name,
+                parameters=parameters,
+                parameter_sources={parameter: "call-site" for parameter in parameters},
+                source="call-site",
+            )
+        )
+        recorded_specializations.add(record_key)
 
     implicit_materialization = _materialize_implicit_template_function_calls(
         preprocessor=preprocessor,

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -1535,11 +1535,19 @@ REPORT_ARTIFACT_TEMPLATE_MATERIALIZATION_FIELDS = frozenset(
     (
         "status",
         "specializationCount",
+        "accounting",
         "configuredParameterCount",
         "configuredParameters",
         "configuredParameterSources",
         "specializations",
         "unsupported",
+    )
+)
+REPORT_ARTIFACT_TEMPLATE_MATERIALIZATION_ACCOUNTING_FIELDS = frozenset(
+    (
+        "reachableSpecializationCount",
+        "dependencyDiscoveryWorkCount",
+        "prunedCandidateCount",
     )
 )
 REPORT_ARTIFACT_TEMPLATE_SPECIALIZATION_FIELDS = frozenset(
@@ -9818,6 +9826,7 @@ class _ImplicitTemplateMaterialization:
     materialized_names: dict[tuple[str, tuple[str, ...], tuple[str, ...]], str] = field(
         default_factory=dict
     )
+    dependency_discovery_work_count: int = 0
 
 
 @dataclass
@@ -9846,6 +9855,12 @@ class _MetalTemplateMaterializationWorkBudget:
     pass_name: str = "implicit-template-materialization/type-environment"
     used: int = 0
     unique_items: set[tuple[Any, ...]] = field(default_factory=set)
+    dependency_discovery_work_count: int = 0
+    pruned_candidate_count: int = 0
+
+    @property
+    def reachable_specialization_count(self) -> int:
+        return len(self.unique_items)
 
     def consume(
         self,
@@ -9857,6 +9872,22 @@ class _MetalTemplateMaterializationWorkBudget:
     ) -> None:
         if amount <= 0:
             return
+        self.dependency_discovery_work_count += amount
+        self._consume(
+            amount,
+            offset=offset,
+            length=length,
+            context=context,
+        )
+
+    def _consume(
+        self,
+        amount: int,
+        *,
+        offset: int,
+        length: int,
+        context: str,
+    ) -> None:
         self.used += amount
         if self.used <= self.limit:
             return
@@ -9879,7 +9910,7 @@ class _MetalTemplateMaterializationWorkBudget:
             if location is not None
             else ""
         )
-        raise MetalTemplateSpecializationError(
+        error = MetalTemplateSpecializationError(
             "Metal template materialization work budget exceeded while "
             f"running {self.pass_name} for target '{self.target}'; "
             f"{self.used} work items requested for {context}, "
@@ -9888,12 +9919,16 @@ class _MetalTemplateMaterializationWorkBudget:
             f"Suggested action: {suggested_action}.",
             limit=self.limit,
             limit_source=self.limit_source,
-            unique_specialization_count=self.used,
+            unique_specialization_count=self.reachable_specialization_count,
             required_work_items=self.used,
             requested_signature=requested_signature,
             suggested_action=suggested_action,
             source_location=location,
         )
+        error.reachable_specialization_count = self.reachable_specialization_count
+        error.dependency_discovery_work_count = self.dependency_discovery_work_count
+        error.pruned_candidate_count = self.pruned_candidate_count
+        raise error
 
     def consume_unique(
         self,
@@ -9906,7 +9941,7 @@ class _MetalTemplateMaterializationWorkBudget:
         if key in self.unique_items:
             return False
         self.unique_items.add(key)
-        self.consume(
+        self._consume(
             1,
             offset=offset,
             length=length,
@@ -10141,6 +10176,11 @@ def _materialize_implicit_template_function_calls(
         text=materialized,
         specializations=specializations,
         materialized_names=implicit_materialized_names,
+        dependency_discovery_work_count=(
+            work_budget.dependency_discovery_work_count
+            if work_budget is not None
+            else 0
+        ),
     )
 
 
@@ -14473,8 +14513,9 @@ def _template_materialization_metadata(
     configured_parameters: Mapping[str, str],
     configured_parameter_sources: Mapping[str, str],
     unsupported: Sequence[Mapping[str, Any]],
+    accounting: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
-    return {
+    metadata = {
         "status": "unsupported" if unsupported else "materialized",
         "specializationCount": len(specializations),
         "configuredParameterCount": len(configured_parameters),
@@ -14485,6 +14526,9 @@ def _template_materialization_metadata(
         "specializations": [dict(specialization) for specialization in specializations],
         "unsupported": [dict(record) for record in unsupported],
     }
+    if accounting is not None:
+        metadata["accounting"] = dict(accounting)
+    return metadata
 
 
 def _template_specialization_source(
@@ -15736,6 +15780,13 @@ def _project_template_materialization_for_artifact(
     if stripped_diagnostic_helpers:
         templates = preprocessor._find_template_functions(preprocessed)
 
+    # Candidate accounting mirrors the retired eager planner: every parsed source
+    # instantiation was paired with every remaining template-function declaration.
+    # Exactly one pair is retained for each unique, concrete host entry; duplicate,
+    # unmatched, unsupported, and nonmatching declaration pairs are pruned.
+    source_instantiation_candidate_count = len(source_instantiations) * len(templates)
+    selected_source_instantiation_candidate_count = 0
+
     explicit_work_budget = (
         _MetalTemplateMaterializationWorkBudget(
             limit=materialization_work_limit,
@@ -15748,6 +15799,10 @@ def _project_template_materialization_for_artifact(
         if materialization_work_limit > 0
         else None
     )
+    if explicit_work_budget is not None:
+        explicit_work_budget.pruned_candidate_count = (
+            source_instantiation_candidate_count
+        )
 
     specializations: list[dict[str, Any]] = []
     source_instantiation_unsupported: list[dict[str, Any]] = []
@@ -15821,7 +15876,13 @@ def _project_template_materialization_for_artifact(
         if key in seen_source_instantiations:
             continue
         seen_source_instantiations.add(key)
+        selected_source_instantiation_candidate_count += 1
         if explicit_work_budget is not None:
+            explicit_work_budget.pruned_candidate_count = max(
+                0,
+                source_instantiation_candidate_count
+                - selected_source_instantiation_candidate_count,
+            )
             explicit_work_budget.consume_unique(
                 ("entry", *key),
                 offset=int(instantiation.span[0]),
@@ -15943,7 +16004,15 @@ def _project_template_materialization_for_artifact(
             work_budget=explicit_work_budget,
             materialized_names=explicit_materialized_names,
         )
-    except MetalTemplateSpecializationError:
+    except MetalTemplateSpecializationError as exc:
+        if explicit_work_budget is not None:
+            exc.reachable_specialization_count = (
+                explicit_work_budget.reachable_specialization_count
+            )
+            exc.dependency_discovery_work_count = (
+                explicit_work_budget.dependency_discovery_work_count
+            )
+            exc.pruned_candidate_count = explicit_work_budget.pruned_candidate_count
         raise
     except Exception:  # noqa: BLE001
         return None
@@ -15978,15 +16047,29 @@ def _project_template_materialization_for_artifact(
         )
         recorded_specializations.add(record_key)
 
-    implicit_materialization = _materialize_implicit_template_function_calls(
-        preprocessor=preprocessor,
-        materialized=materialized,
-        source_contexts=source_instantiation_contexts,
-        unit=unit,
-        target=target,
-        work_limit=materialization_work_limit,
-        work_limit_source=materialization_work_limit_source,
-    )
+    try:
+        implicit_materialization = _materialize_implicit_template_function_calls(
+            preprocessor=preprocessor,
+            materialized=materialized,
+            source_contexts=source_instantiation_contexts,
+            unit=unit,
+            target=target,
+            work_limit=materialization_work_limit,
+            work_limit_source=materialization_work_limit_source,
+        )
+    except MetalTemplateSpecializationError as exc:
+        if explicit_work_budget is not None and hasattr(
+            exc, "reachable_specialization_count"
+        ):
+            exc.reachable_specialization_count += (
+                explicit_work_budget.reachable_specialization_count
+            )
+            exc.dependency_discovery_work_count += (
+                explicit_work_budget.dependency_discovery_work_count
+            )
+            exc.pruned_candidate_count += explicit_work_budget.pruned_candidate_count
+            exc.unique_specialization_count = exc.reachable_specialization_count
+        raise
     materialized = implicit_materialization.text
     specializations.extend(implicit_materialization.specializations)
 
@@ -16360,11 +16443,48 @@ def _project_template_materialization_for_artifact(
         name: used_configured_parameter_sources[name]
         for name in sorted(used_configured_parameter_sources)
     }
+    accounting = None
+    if source_instantiations:
+        reachable_function_specializations = {
+            (record.get("name"), record.get("materializedName"))
+            for record in specializations
+            if _is_non_empty_string(record.get("name"))
+            and _is_non_empty_string(record.get("materializedName"))
+        }
+        reachable_struct_specialization_count = (
+            sum(
+                1
+                for key in explicit_work_budget.unique_items
+                if key and key[0] == "struct"
+            )
+            if explicit_work_budget is not None
+            else len(preprocessor._materialized_struct_specializations)
+        )
+        accounting = {
+            "reachableSpecializationCount": (
+                len(reachable_function_specializations)
+                + reachable_struct_specialization_count
+            ),
+            "dependencyDiscoveryWorkCount": (
+                (
+                    explicit_work_budget.dependency_discovery_work_count
+                    if explicit_work_budget is not None
+                    else 0
+                )
+                + implicit_materialization.dependency_discovery_work_count
+            ),
+            "prunedCandidateCount": max(
+                0,
+                source_instantiation_candidate_count
+                - selected_source_instantiation_candidate_count,
+            ),
+        }
     metadata = _template_materialization_metadata(
         specializations=specializations,
         configured_parameters=configured_payload,
         configured_parameter_sources=configured_source_payload,
         unsupported=unsupported,
+        accounting=accounting,
     )
     if not specializations and not unsupported and not stripped_diagnostic_helpers:
         return None
@@ -16488,6 +16608,13 @@ def _template_materialization_failure_details(exc: Exception) -> dict[str, Any]:
     unique_specialization_count = getattr(exc, "unique_specialization_count", None)
     requested_signature = getattr(exc, "requested_signature", None)
     suggested_action = getattr(exc, "suggested_action", None)
+    reachable_specialization_count = getattr(
+        exc, "reachable_specialization_count", None
+    )
+    dependency_discovery_work_count = getattr(
+        exc, "dependency_discovery_work_count", None
+    )
+    pruned_candidate_count = getattr(exc, "pruned_candidate_count", None)
     owner_struct_name = getattr(exc, "owner_struct_name", None)
     owner_aliases = getattr(exc, "owner_aliases", None)
     nested_struct_name = getattr(exc, "nested_struct_name", None)
@@ -16512,6 +16639,20 @@ def _template_materialization_failure_details(exc: Exception) -> dict[str, Any]:
         template_materialization["requestedSignature"] = requested_signature
     if _is_non_empty_string(suggested_action):
         template_materialization["suggestedAction"] = suggested_action
+    accounting_counts = (
+        reachable_specialization_count,
+        dependency_discovery_work_count,
+        pruned_candidate_count,
+    )
+    if all(
+        isinstance(count, int) and not isinstance(count, bool) and count >= 0
+        for count in accounting_counts
+    ):
+        template_materialization["accounting"] = {
+            "reachableSpecializationCount": reachable_specialization_count,
+            "dependencyDiscoveryWorkCount": dependency_discovery_work_count,
+            "prunedCandidateCount": pruned_candidate_count,
+        }
     if (
         _is_non_empty_string(owner_struct_name)
         and _is_non_empty_string(nested_struct_name)
@@ -38341,6 +38482,28 @@ def _artifact_template_materialization_contract_reasons(
         specializations
     ):
         reasons.append(f"{prefix}.specializationCount must match specializations")
+
+    if "accounting" in materialization:
+        accounting_prefix = f"{prefix}.accounting"
+        accounting = materialization.get("accounting")
+        if not isinstance(accounting, Mapping):
+            reasons.append(f"{accounting_prefix} must be an object")
+        else:
+            reasons.extend(
+                _unsupported_mapping_field_reasons(
+                    accounting_prefix,
+                    accounting,
+                    REPORT_ARTIFACT_TEMPLATE_MATERIALIZATION_ACCOUNTING_FIELDS,
+                )
+            )
+            for field_name in sorted(
+                REPORT_ARTIFACT_TEMPLATE_MATERIALIZATION_ACCOUNTING_FIELDS
+            ):
+                if not _is_non_negative_int(accounting.get(field_name)):
+                    reasons.append(
+                        f"{accounting_prefix}.{field_name} must be a "
+                        "non-negative integer"
+                    )
 
     unsupported = materialization.get("unsupported")
     if not isinstance(unsupported, list):

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -222,10 +222,12 @@ verification target for MLX commit
 configured work budgets to unique reachable concrete entries, helpers, and
 struct specializations plus actual type-environment resolution, rather than an
 eager whole-source instantiation-by-template Cartesian estimate or repeated
-expanded-text scans. Focused tests establish the accounting behavior. An
-isolated project replay of `quantized.metal` at the pinned revision now advances
-both DirectX and OpenGL past the former 522,068-item eager planning failure
-without raising the 131,072 work limit. Both targets then fail closed with
+expanded-text scans. Artifact metadata and budget diagnostics report reachable
+specializations, dependency-discovery work, and pruned eager candidate pairs as
+separate counts. Focused tests establish the accounting behavior. An isolated
+project replay of `quantized.metal` at the pinned revision now advances both
+DirectX and OpenGL past the former 522,068-item eager planning failure without
+raising the 131,072 work limit. Both targets then fail closed with
 `project.translate.metal-struct-method` while lowering the reference-returning
 `MMATile::frag_at(i, j)` accessor tracked by CrossGL/crosstl#1557; neither target
 emits an artifact, so no validator acceptance or runtime parity is claimed. A

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -3,7 +3,10 @@
 This directory contains the project-level MLX porting checks used by CrossTL.
 The checks are pinned to MLX commit
 `4367c73b60541ddd5a266ce4644fd93d20223b6e` and exercise the Metal kernel tree
-as a source repository, not as isolated parser snippets.
+as a source repository, not as isolated parser snippets. This pinned revision is
+an active repository-level verification target: configured coverage and expected
+baselines are not, by themselves, evidence that every kernel translates or
+passes a target validator.
 
 ## Scope
 
@@ -92,13 +95,15 @@ the pinned MLX source count. Scheduled and manually triggered CI also run the
 full-corpus artifact scout with finite Metal template materialization budgets.
 The generated full-corpus project config caps
 `max_template_specializations` at 4096 and
-`max_template_materialization_work` at 131072. The full scout translates all 40
-pinned MLX Metal kernel units to DirectX, OpenGL, and Vulkan and records 120
-target attempts. Its fence-aware baseline is 117 translated artifacts and three
-expected failed `fence.metal` records, one per target, with no fence target files
-emitted. Additional failures remain issue-backed scout results. CI uploads
-generated portability reports, validation summaries embedded in those reports,
-generated logs, available generated artifacts, and a concise JSON summary.
+`max_template_materialization_work` at 131072. The scout discovers all 40 pinned
+MLX Metal kernel units and attempts 120 DirectX, OpenGL, and Vulkan artifacts.
+Its fence-aware success condition is 117 translated artifacts and three expected
+failed `fence.metal` records, one per target, with no fence target files emitted.
+That condition is a gate expectation, not a claim that the pinned full corpus
+currently satisfies it. Additional failures remain issue-backed scout results.
+CI uploads generated portability reports, validation summaries embedded in
+those reports, generated logs, available generated artifacts, and a concise JSON
+summary.
 Because `binary_two.metal` was already in the DirectX/Vulkan frontier, its OpenGL
 promotion does not change either reduced source count.
 
@@ -211,9 +216,25 @@ The harness writes reports, generated artifacts, and command logs under
 ## Current Translator Gaps
 
 CrossGL/crosstl#1376 tracks bounded runtime for the scheduled full-corpus scout.
-CrossGL/crosstl#1676 tracks demand-driven materialization so repository
-translation charges configured work budgets to reachable concrete template
-graphs instead of eager whole-source cross products.
+[#1676](https://github.com/CrossGL/crosstl/issues/1676) remains an active
+verification target for MLX commit
+`4367c73b60541ddd5a266ce4644fd93d20223b6e`. The materialization change charges
+configured work budgets to unique reachable concrete entries, helpers, and
+struct specializations plus actual type-environment resolution, rather than an
+eager whole-source instantiation-by-template Cartesian estimate or repeated
+expanded-text scans. Focused tests establish the accounting behavior. An
+isolated project replay of `quantized.metal` at the pinned revision now advances
+both DirectX and OpenGL past the former 522,068-item eager planning failure
+without raising the 131,072 work limit. Both targets then fail closed with
+`project.translate.metal-struct-method` while lowering the reference-returning
+`MMATile::frag_at(i, j)` accessor tracked by CrossGL/crosstl#1557; neither target
+emits an artifact, so no validator acceptance or runtime parity is claimed. A
+fresh pinned full-corpus report is still required to identify every kernel that
+advances past the former budget failure and to satisfy the repository-level
+acceptance criteria for CrossGL/crosstl#1676. The checked-in evidence also
+records full-kernel Vulkan replays of `fp_quantized.metal` and
+`quantized_nax.metal` as failed after selected materialization contracts; only
+the explicitly documented reduced quantized fixtures carry validator evidence.
 CrossGL/crosstl#1659 tracks quadratic DirectX resource-register relocation for
 large aggregate artifacts; a high-budget `binary.metal` DirectX translation
 reaches that allocator after template materialization.

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -899,20 +899,32 @@ Include directories, defines, and named
 variants are recorded in project reports. Source frontend options can also be
 set under ``[project.source_options.<source-backend>]`` and are forwarded only
 to source lexers that expose matching keyword options. Metal source imports
-support ``max_template_specializations`` for project-specific explicit helper
-materialization budgets and ``max_template_materialization_work`` for project
-template materialization work budgets. The default materialization work budget
-is derived from the active template specialization limit, so larger finite
-source-instantiated kernels can complete without raising the unique helper
-specialization cap. Use
+support ``max_template_specializations`` as the project-specific unique concrete
+helper specialization cap and ``max_template_materialization_work`` as the
+project template materialization work budget. Materialization work is charged
+to the reachable concrete graph and the type information actually resolved. It
+counts each unique reachable source entry, concrete helper specialization, and
+concrete struct specialization once, together with uncached function and type-
+environment resolution and concrete struct-field type resolution performed for
+that graph. Shared transitive helpers and repeated occurrences of the same
+concrete signature are therefore deduplicated. The budget does not precharge a
+whole-source ``source instantiations x template declarations`` Cartesian
+estimate, and repeated scans of progressively expanded source text are not work
+items merely because the text was scanned again.
+
+The default materialization work budget is derived from the active template
+specialization limit, so larger finite source-instantiated kernels can complete
+without raising the unique helper specialization cap. Use
 ``[project.source_options.metal.source_patterns."<repo-relative-glob>"]`` to
 raise or lower Metal budgets for matching sources. Use
 ``[project.source_options.metal.target_options.<target>]`` and its nested
 ``source_patterns`` table to override budgets only for one target, such as
-OpenGL. When a Metal helper or materialization-work budget is exceeded,
-project diagnostics report the concrete signature count or work item count,
-the active limit, the configuration field that set the limit, and a suggested
-remediation. Project reports include
+OpenGL. Both limits remain fail-closed. If the next unique entry, helper, struct
+specialization, or required type-environment resolution would cross a configured
+limit, translation fails without emitting the target artifact. The structured
+diagnostic identifies the concrete item or resolution that crossed the limit
+and reports the requested count, active limit, configuration field that set it,
+source location, and suggested remediation. Project reports include
 order-preserving include-directory status records and status counts so missing,
 non-directory, outside-project, and frontend-visible active include directories
 can be triaged without re-running discovery. Missing include directories,

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -1204,7 +1204,16 @@ Project reports are JSON documents with:
   templates with missing parameter names, and concrete specializations with the
   original template name, materialized function name, parameter map,
   specialization source, and optional ``hostName`` for source-instantiated
-  kernels.
+  kernels. Source-instantiated Metal artifacts can also include an ``accounting``
+  object. ``reachableSpecializationCount`` counts unique concrete function and
+  struct specializations selected for the artifact,
+  ``dependencyDiscoveryWorkCount`` counts uncached type-environment and type
+  resolution charged separately from those specializations, and
+  ``prunedCandidateCount`` records source-instantiation/template-declaration
+  pairs from the former eager candidate space that were not selected. The same
+  accounting object is included in a materialization-work budget diagnostic
+  when all three counts are available. Report validation rejects missing,
+  negative, boolean, or unknown accounting fields.
   Full reports require failed artifacts to carry an actionable error string and
   reject failed artifacts that claim
   generated hashes or source-map records. Full reports also reject translated

--- a/tests/test_backend/test_metal/test_preprocessor.py
+++ b/tests/test_backend/test_metal/test_preprocessor.py
@@ -1500,8 +1500,11 @@ def test_preprocessor_bounds_owner_alias_materialization_work():
 
     assert output.count("struct Tile_BaseFrag_float_") == 32
     assert "struct Tile_frag_t" not in output
-    assert work_budget.contexts.count("explicit template struct source scan") == 3
-    assert work_budget.used <= 2200
+    assert work_budget.used == 96
+    assert all(
+        context.startswith("reachable concrete struct '")
+        for context in work_budget.contexts
+    )
 
 
 def test_preprocessor_reports_dependent_owner_alias_at_nested_instantiation():

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -45320,6 +45320,126 @@ def test_translate_project_metal_call_site_template_limit_blocks_opengl_material
     )
 
 
+def test_translate_project_metal_materialization_budget_tracks_reachable_graph(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    unrelated_instantiations = "\n".join(
+        f'instantiate_kernel("independent_{index}", independent, float, {index})'
+        for index in range(24)
+    )
+    (repo / "reachable_graph.metal").write_text(
+        textwrap.dedent("""
+            #include <metal_stdlib>
+            using namespace metal;
+
+            template <typename T, int Slot>
+            [[kernel]] void independent(
+                device T* out [[buffer(0)]],
+                uint gid [[thread_position_in_grid]]
+            ) {
+                out[gid] = T(Slot);
+            }
+
+            template <typename T>
+            T shared_leaf(T value) {
+                return value + T(1);
+            }
+
+            template <typename T>
+            T shared_stage(T value) {
+                return shared_leaf<T>(value);
+            }
+
+            template <typename T>
+            [[kernel]] void entry_left(
+                device T* out [[buffer(0)]],
+                uint gid [[thread_position_in_grid]]
+            ) {
+                out[gid] = shared_stage<T>(T(gid));
+            }
+
+            template <typename T>
+            [[kernel]] void entry_right(
+                device T* out [[buffer(0)]],
+                uint gid [[thread_position_in_grid]]
+            ) {
+                out[gid] = shared_stage<T>(T(gid + 1));
+            }
+
+            template <typename T, int Bias>
+            T unreachable_helper(T value) {
+                return value + T(Bias);
+            }
+
+            template <typename T>
+            [[kernel]] void unreachable_entry(
+                device T* out [[buffer(0)]],
+                uint gid [[thread_position_in_grid]]
+            ) {
+                out[gid] = unreachable_helper<T, 99>(T(gid));
+            }
+            """).strip()
+        + "\n\n"
+        + unrelated_instantiations
+        + "\n"
+        + 'instantiate_kernel("entry_left_float", entry_left, float)\n'
+        + 'instantiate_kernel("entry_right_float", entry_right, float)\n',
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            targets = ["opengl"]
+            output_dir = "out"
+
+            [project.source_options.metal]
+            max_template_specializations = 32
+            max_template_materialization_work = 48
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    payload = translate_project(load_project_config(repo)).to_json()
+
+    assert payload["diagnostics"] == []
+    artifact = payload["artifacts"][0]
+    assert artifact["status"] == "translated"
+    materialization = artifact["templateMaterialization"]
+    assert materialization["status"] == "materialized"
+    assert materialization["specializationCount"] == 28
+    specializations = materialization["specializations"]
+    expected_entries = {f"independent_{index}" for index in range(24)} | {
+        "entry_left_float",
+        "entry_right_float",
+    }
+    assert {
+        record["hostName"]
+        for record in specializations
+        if record["source"] == "source-instantiation"
+    } == expected_entries
+    expected_materializations = {
+        ("independent", entry_name)
+        for entry_name in expected_entries
+        if entry_name.startswith("independent_")
+    } | {
+        ("entry_left", "entry_left_float"),
+        ("entry_right", "entry_right_float"),
+        ("shared_leaf", "shared_leaf_float"),
+        ("shared_stage", "shared_stage_float"),
+    }
+    assert {
+        (record["name"], record["materializedName"]) for record in specializations
+    } == expected_materializations
+
+    output = (repo / artifact["path"]).read_text(encoding="utf-8")
+    assert len(re.findall(r"float shared_leaf_float\(float value\)\s*\{", output)) == 1
+    assert len(re.findall(r"float shared_stage_float\(float value\)\s*\{", output)) == 1
+    assert "unreachable_helper" not in output
+    assert "unreachable_entry" not in output
+
+
 def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_materialization(
     tmp_path,
 ):
@@ -45332,7 +45452,7 @@ def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_m
             output_dir = "out"
 
             [project.source_options.metal]
-            max_template_materialization_work = 4
+            max_template_materialization_work = 2
             """).strip(),
         encoding="utf-8",
     )
@@ -45368,14 +45488,11 @@ def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_m
     assert artifact["status"] == "failed"
     assert "templateMaterialization" not in artifact
     assert not (repo / artifact["path"]).exists()
-    assert "work limit exceeded before GLSL codegen" in artifact["error"]
-    assert "6 source-instantiation/template work items requested" in artifact["error"]
+    assert "3 work items requested" in artifact["error"]
+    assert "reachable source entry 'launch_f32_c'" in artifact["error"]
     assert (
-        "limit 4 from project.source_options.metal.max_template_materialization_work"
+        "limit 2 from project.source_options.metal.max_template_materialization_work"
         in artifact["error"]
-    )
-    assert "First source declaration: bounded_source_instantiations.metal:9:1" in (
-        artifact["error"]
     )
 
     assert payload["summary"]["translatedCount"] == 0
@@ -45389,17 +45506,22 @@ def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_m
     assert diagnostic["sourceBackend"] == "metal"
     assert diagnostic["missingCapabilities"] == ["template.specialization"]
     assert diagnostic["location"]["file"] == "bounded_source_instantiations.metal"
-    assert diagnostic["location"]["line"] == 9
+    assert diagnostic["location"]["line"] == 19
     assert diagnostic["location"]["column"] == 1
-    assert "work limit exceeded before GLSL codegen" in diagnostic["message"]
+    assert "reachable source entry 'launch_f32_c'" in diagnostic["message"]
     assert diagnostic["details"]["templateMaterialization"] == {
-        "limit": 4,
+        "limit": 2,
         "limitSource": "project.source_options.metal.max_template_materialization_work",
-        "requiredWorkItems": 6,
-        "requestedSignature": "3 source instantiations x 2 templates",
+        "requiredWorkItems": 3,
+        "requestedSpecializationCount": 3,
+        "requestedSignature": (
+            "explicit-template-materialization: 3 work items for reachable "
+            "source entry 'launch_f32_c'"
+        ),
         "suggestedAction": (
             "raise max_template_materialization_work for this source pattern or "
-            "OpenGL target, or reduce source template instantiations"
+            "backend, reduce the reachable concrete template graph or "
+            "type-resolution fan-out, or provide explicit template arguments"
         ),
     }
 
@@ -45513,7 +45635,7 @@ def test_translate_project_applies_metal_target_source_pattern_materialization_w
             output_dir = "out"
 
             [project.source_options.metal]
-            max_template_materialization_work = 4
+            max_template_materialization_work = 2
 
             [project.source_options.metal.target_options.opengl.source_patterns."shaders/p.metal"]
             max_template_materialization_work = 8
@@ -45531,7 +45653,7 @@ def test_translate_project_applies_metal_target_source_pattern_materialization_w
     assert "project.validate.invalid-report" not in validation["diagnosticsByCode"]
     assert payload["project"]["sourceOptions"] == {
         "metal": {
-            "max_template_materialization_work": 4,
+            "max_template_materialization_work": 2,
             "target_options": {
                 "opengl": {
                     "source_patterns": {
@@ -45553,7 +45675,7 @@ def test_translate_project_applies_metal_target_source_pattern_materialization_w
     assert diagnostic["sourceBackend"] == "metal"
     assert diagnostic["missingCapabilities"] == ["template.specialization"]
     assert (
-        "limit 4 from project.source_options.metal.max_template_materialization_work"
+        "limit 2 from project.source_options.metal.max_template_materialization_work"
         in diagnostic["message"]
     )
 
@@ -45586,11 +45708,9 @@ def test_translate_project_metal_explicit_materialization_work_budget_diagnostic
 
             kernel void launch(device float* out [[buffer(0)]]) {
                 out[0] = cast_value<float>(1.0);
+                out[1] = cast_value<half>(2.0);
             }
             """).strip()
-    source += (
-        "\n/*" + ("x" * project_pipeline.METAL_LARGE_TEMPLATE_SOURCE_MIN_CHARS) + "*/\n"
-    )
     (repo / "explicit_budget.metal").write_text(source, encoding="utf-8")
 
     payload = translate_project(load_project_config(repo)).to_json()
@@ -45606,7 +45726,7 @@ def test_translate_project_metal_explicit_materialization_work_budget_diagnostic
     }
     diagnostic = payload["diagnostics"][0]
     assert diagnostic["location"]["file"] == "explicit_budget.metal"
-    assert diagnostic["location"]["line"] == 4
+    assert diagnostic["location"]["line"] == 11
     detail = diagnostic["details"]["templateMaterialization"]
     assert detail["limit"] == 1
     assert (

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -16361,6 +16361,11 @@ def test_translate_project_opengl_rejects_post_materialization_template_type_lea
     assert artifact["templateMaterialization"] == {
         "status": "unsupported",
         "specializationCount": 1,
+        "accounting": {
+            "reachableSpecializationCount": 2,
+            "dependencyDiscoveryWorkCount": 0,
+            "prunedCandidateCount": 0,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},
@@ -45401,7 +45406,8 @@ def test_translate_project_metal_materialization_budget_tracks_reachable_graph(
         encoding="utf-8",
     )
 
-    payload = translate_project(load_project_config(repo)).to_json()
+    report = translate_project(load_project_config(repo))
+    payload = report.to_json()
 
     assert payload["diagnostics"] == []
     artifact = payload["artifacts"][0]
@@ -45409,6 +45415,13 @@ def test_translate_project_metal_materialization_budget_tracks_reachable_graph(
     materialization = artifact["templateMaterialization"]
     assert materialization["status"] == "materialized"
     assert materialization["specializationCount"] == 28
+    assert materialization["accounting"] == {
+        "reachableSpecializationCount": 28,
+        "dependencyDiscoveryWorkCount": 0,
+        # The retired eager planner considered 26 instantiations x 7 declarations;
+        # one declaration pair is retained for each concrete host entry.
+        "prunedCandidateCount": (26 * 7) - 26,
+    }
     specializations = materialization["specializations"]
     expected_entries = {f"independent_{index}" for index in range(24)} | {
         "entry_left_float",
@@ -45438,6 +45451,71 @@ def test_translate_project_metal_materialization_budget_tracks_reachable_graph(
     assert len(re.findall(r"float shared_stage_float\(float value\)\s*\{", output)) == 1
     assert "unreachable_helper" not in output
     assert "unreachable_entry" not in output
+
+    report_path = repo / "out" / "report.json"
+    report.write_json(report_path)
+    validation = validate_project_report(report_path)
+    assert "project.validate.invalid-report" not in validation["diagnosticsByCode"]
+
+
+def test_validate_project_report_template_materialization_accounting_is_optional_and_closed(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "accounting.metal").write_text(
+        textwrap.dedent("""
+            template <typename T>
+            T unrelated(T value) {
+                return value;
+            }
+
+            template <typename T>
+            [[kernel]] void launch(device T* out [[buffer(0)]]) {
+                out[0] = T(1);
+            }
+
+            instantiate_kernel("launch_float", launch, float)
+            """).strip(),
+        encoding="utf-8",
+    )
+    payload = translate_project(
+        repo,
+        targets=["opengl"],
+        output_dir="out",
+        format_output=False,
+    ).to_json()
+    accounting = payload["artifacts"][0]["templateMaterialization"]["accounting"]
+    assert accounting == {
+        "reachableSpecializationCount": 1,
+        "dependencyDiscoveryWorkCount": 0,
+        "prunedCandidateCount": 1,
+    }
+    legacy_payload = copy.deepcopy(payload)
+    legacy_payload["artifacts"][0]["templateMaterialization"].pop("accounting")
+    legacy_report_path = repo / "out" / "legacy-accounting-report.json"
+    legacy_report_path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+    legacy_validation = validate_project_report(legacy_report_path)
+    assert legacy_validation["success"] is True
+
+    accounting.pop("dependencyDiscoveryWorkCount")
+    accounting["sourceScanCount"] = 7
+    report_path = repo / "out" / "malformed-accounting-report.json"
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    validation = validate_project_report(report_path)
+
+    assert validation["success"] is False
+    diagnostic = validation["diagnostics"][0]
+    assert diagnostic["code"] == "project.validate.invalid-report"
+    assert (
+        "artifacts[0].templateMaterialization.accounting.sourceScanCount "
+        "is not allowed"
+    ) in diagnostic["message"]
+    assert (
+        "artifacts[0].templateMaterialization.accounting."
+        "dependencyDiscoveryWorkCount must be a non-negative integer"
+    ) in diagnostic["message"]
 
 
 def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_materialization(
@@ -45510,6 +45588,11 @@ def test_translate_project_metal_source_instantiation_work_limit_blocks_opengl_m
     assert diagnostic["location"]["column"] == 1
     assert "reachable source entry 'launch_f32_c'" in diagnostic["message"]
     assert diagnostic["details"]["templateMaterialization"] == {
+        "accounting": {
+            "reachableSpecializationCount": 3,
+            "dependencyDiscoveryWorkCount": 0,
+            "prunedCandidateCount": 3,
+        },
         "limit": 2,
         "limitSource": "project.source_options.metal.max_template_materialization_work",
         "requiredWorkItems": 3,
@@ -46058,6 +46141,11 @@ def test_translate_project_metal_implicit_type_environment_budget_diagnostic(
     assert "implicit-template-materialization/type-environment" in diagnostic["message"]
     assert "templates=1" in diagnostic["message"]
     detail = diagnostic["details"]["templateMaterialization"]
+    assert detail["accounting"] == {
+        "reachableSpecializationCount": 0,
+        "dependencyDiscoveryWorkCount": 4,
+        "prunedCandidateCount": 0,
+    }
     assert detail["limit"] == 3
     assert (
         detail["limitSource"]
@@ -46519,6 +46607,11 @@ def test_translate_project_signature_instantiation_materializes_convolution_help
     expected_materialization = {
         "status": "materialized",
         "specializationCount": 2,
+        "accounting": {
+            "reachableSpecializationCount": 2,
+            "dependencyDiscoveryWorkCount": 0,
+            "prunedCandidateCount": 1,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},
@@ -46804,6 +46897,11 @@ def test_translate_project_metal_reduction_source_instantiation_records_nontype_
     expected_materialization = {
         "status": "materialized",
         "specializationCount": 1,
+        "accounting": {
+            "reachableSpecializationCount": 1,
+            "dependencyDiscoveryWorkCount": 0,
+            "prunedCandidateCount": 0,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},
@@ -46892,6 +46990,11 @@ def test_translate_project_metal_reduction_materializes_shared_helper_templates(
     expected_materialization = {
         "status": "materialized",
         "specializationCount": 3,
+        "accounting": {
+            "reachableSpecializationCount": 3,
+            "dependencyDiscoveryWorkCount": 4,
+            "prunedCandidateCount": 2,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},
@@ -46983,6 +47086,11 @@ def test_translate_project_metal_const_for_loop_partial_template_materializes_to
     expected_materialization = {
         "status": "materialized",
         "specializationCount": 2,
+        "accounting": {
+            "reachableSpecializationCount": 2,
+            "dependencyDiscoveryWorkCount": 3,
+            "prunedCandidateCount": 1,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},
@@ -48224,6 +48332,11 @@ def test_translate_project_metal_norm_materializes_variadic_shared_helper(
     assert artifact["templateMaterialization"] == {
         "status": "materialized",
         "specializationCount": 2,
+        "accounting": {
+            "reachableSpecializationCount": 2,
+            "dependencyDiscoveryWorkCount": 4,
+            "prunedCandidateCount": 1,
+        },
         "configuredParameterCount": 0,
         "configuredParameters": {},
         "configuredParameterSources": {},


### PR DESCRIPTION
## Summary

- account Metal project materialization work by unique reachable entries,
  concrete helpers, concrete structs, and actual type-resolution work
- deduplicate shared transitive helper specializations and retain their
  provenance in project reports
- report reachable specializations, dependency-discovery work, and pruned
  eager candidate pairs through a validated optional accounting object
- add bounded reachable-graph regressions and document the pinned MLX
  `quantized.metal` translation frontier

The isolated MLX replay at commit
`4367c73b60541ddd5a266ce4644fd93d20223b6e` advances DirectX and OpenGL past
the former 522,068-item eager planning failure at the unchanged 131,072 work
limit. Both targets then fail closed on the reference-returning
`MMATile::frag_at` contract tracked by #1557, so this PR does not claim emitted
artifacts, validator acceptance, or runtime parity.

This advances #1676. The issue remains open for its pinned full-corpus evidence
and remaining high-scale acceptance criteria.

Support issue traceability: no issue closed

## Validation

- `.venv/bin/python -m pytest -n auto tests/test_backend/test_metal -q`
- `.venv/bin/python -m pytest -n auto tests/test_translator tests/test_backend -q`
- `.venv/bin/python -m pytest -n auto -q`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python tools/support_matrix.py check`
- `.venv/bin/python tools/sync_support_issues.py --repo CrossGL/crosstl --dry-run`
