### PR TITLE
Unify Metal template materialization across translation entry points

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -134,6 +134,8 @@ def translate(
     register_default_sources()
     discover_backend_plugins()
     backend = (backend or "cgl").strip().lower()
+    requested_backend = backend
+    normalized_backend = normalize_backend_name(requested_backend) or requested_backend
 
     source_spec = (
         SOURCE_REGISTRY.get(source_backend)
@@ -153,6 +155,26 @@ def translate(
 
     shader_code = _read_shader_source(file_path, source_spec.name)
 
+    if source_spec.name == "metal" and normalized_backend not in {
+        "cgl",
+        "crossgl",
+        "metal",
+    }:
+        from .project.pipeline import materialize_metal_source_for_target
+
+        materialized_source = materialize_metal_source_for_target(
+            source=shader_code,
+            file_path=file_path,
+            target=normalized_backend,
+            include_paths=include_paths or (),
+            defines=defines,
+            source_options=source_options,
+        )
+        if materialized_source is not None:
+            shader_code = materialized_source.text
+            defines = materialized_source.defines
+            source_options = materialized_source.source_options
+
     ast = source_spec.parse(
         shader_code,
         file_path=file_path,
@@ -160,9 +182,6 @@ def translate(
         defines=defines,
         source_options=source_options,
     )
-
-    requested_backend = backend
-    normalized_backend = normalize_backend_name(requested_backend) or requested_backend
 
     if source_spec.name == "cgl":
         if normalized_backend in ["cgl", "crossgl"]:

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -7124,6 +7124,30 @@ class ProjectTemplateMaterializedSource:
     error: str | None = None
 
 
+class MetalSourceMaterializationError(ValueError):
+    """A direct Metal translation blocked by template materialization."""
+
+    project_diagnostic_code = "project.translate.template-materialization-unsupported"
+    missing_capabilities = ("template.specialization",)
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        metadata: Mapping[str, Any],
+        diagnostics: Sequence[ProjectDiagnostic],
+    ) -> None:
+        super().__init__(message)
+        self.metadata = dict(metadata)
+        self.diagnostics = tuple(diagnostics)
+        if self.diagnostics:
+            diagnostic = self.diagnostics[0]
+            self.project_diagnostic_code = diagnostic.code
+            self.missing_capabilities = tuple(diagnostic.missing_capabilities)
+            self.source_location = diagnostic.location
+            self.details = dict(diagnostic.details)
+
+
 def _configuration_diagnostics(config: ProjectConfig) -> list[ProjectDiagnostic]:
     diagnostics: list[ProjectDiagnostic] = []
     location = _config_location(config)
@@ -15612,14 +15636,19 @@ def _project_template_materialization_for_artifact(
     include_paths: Sequence[str],
     source_options: Mapping[str, Any],
     target_artifact: str | None = None,
+    source: str | None = None,
+    fail_closed: bool = False,
 ) -> ProjectTemplateMaterializedSource | None:
     if unit.source_backend != "metal" or not _is_template_hostile_target(target):
         return None
 
-    try:
-        source = unit.path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
+    if source is None:
+        try:
+            source = unit.path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            if fail_closed:
+                raise
+            return None
     if "template" not in source and "#include" not in source:
         return None
 
@@ -15664,6 +15693,8 @@ def _project_template_materialization_for_artifact(
             discovery_source,
         )
     except Exception:  # noqa: BLE001
+        if fail_closed:
+            raise
         return None
 
     source_template_parameters = _metal_template_parameter_names(discovery_source)
@@ -15721,6 +15752,8 @@ def _project_template_materialization_for_artifact(
         )
         templates = preprocessor._find_template_functions(preprocessed)
     except Exception:  # noqa: BLE001
+        if fail_closed:
+            raise
         return None
     source_instantiations = preprocessor._find_project_template_instantiations(
         preprocessed
@@ -16536,6 +16569,59 @@ def _project_template_materialization_for_artifact(
             "preprocess": False,
         },
     )
+
+
+def materialize_metal_source_for_target(
+    *,
+    source: str,
+    file_path: str | os.PathLike[str],
+    target: str,
+    include_paths: Sequence[str] = (),
+    defines: Mapping[str, str] | None = None,
+    source_options: Mapping[str, Any] | None = None,
+) -> ProjectTemplateMaterializedSource | None:
+    """Materialize reachable Metal specializations for a direct translation."""
+
+    normalized_target = normalize_backend_name(target) or target.strip().lower()
+    if normalized_target in {"cgl", "crossgl", "metal"}:
+        return None
+
+    options = dict(source_options or {})
+    if options.get("preprocess") is False:
+        return None
+
+    path = Path(file_path)
+    relative_path = path.as_posix() if not path.is_absolute() else path.name
+    encoded_source = source.encode("utf-8")
+    unit = ProjectTranslationUnit(
+        path=path,
+        relative_path=relative_path,
+        source_backend="metal",
+        extension=path.suffix.lower(),
+        source_hash={
+            "algorithm": "sha256",
+            "value": hashlib.sha256(encoded_source).hexdigest(),
+        },
+        source_size_bytes=len(encoded_source),
+    )
+    materialized = _project_template_materialization_for_artifact(
+        unit=unit,
+        target=normalized_target,
+        variant=None,
+        defines=dict(defines or {}),
+        include_paths=tuple(include_paths),
+        source_options=options,
+        source=source,
+        fail_closed=True,
+    )
+    if materialized is not None and materialized.blocked:
+        detail = materialized.error or "required specializations remain unresolved."
+        raise MetalSourceMaterializationError(
+            f"Metal template materialization failed: {detail}",
+            metadata=materialized.metadata,
+            diagnostics=materialized.diagnostics,
+        )
+    return materialized
 
 
 def _translation_failure_diagnostic_code(exc: Exception) -> str:

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -912,6 +912,19 @@ whole-source ``source instantiations x template declarations`` Cartesian
 estimate, and repeated scans of progressively expanded source text are not work
 items merely because the text was scanned again.
 
+Direct ``translate()`` calls from Metal to template-hostile targets use the
+same reachable-specialization preparation as one-unit project translation.
+Explicit instantiations, ``host_name`` attributes, template defaults, include
+paths, defines, and materialization budgets are therefore applied before
+DirectX or OpenGL code generation. If a reachable declaration still requires
+template arguments, direct translation raises a ``ValueError`` carrying the
+``project.translate.template-materialization-unsupported`` diagnostic code,
+missing-capability list, materialization metadata, and source location instead
+of returning an artifact with unresolved target resource types. Metal,
+CrossGL, and already-preprocessed source paths retain their existing behavior.
+This contract does not infer variants for which the source supplies no concrete
+evidence, and it is not a full-corpus or runtime-parity claim.
+
 During project translation, Metal template-member inference preserves a
 generic pointer template parameter as a pointer rather than reducing it to its
 pointee type. For a parameter such as ``Pointer src``, a bare tracked pointer,

--- a/tests/test_translator/test_codegen/test_SPIRV_codegen.py
+++ b/tests/test_translator/test_codegen/test_SPIRV_codegen.py
@@ -34076,7 +34076,9 @@ class TestSpirvShaderValidation:
         assert_spirv_stores_use_matching_value_types(spv_code)
         assert_spirv_module_validates(spv_code, tmp_path)
 
-    def test_metal_symbolic_local_array_reports_structured_extent_error(self, tmp_path):
+    def test_metal_symbolic_local_array_fails_during_template_materialization(
+        self, tmp_path
+    ):
         source_path = tmp_path / "symbolic_local_array.metal"
         source_path.write_text(
             """
@@ -34096,10 +34098,10 @@ class TestSpirvShaderValidation:
         )
 
         with pytest.raises(
-            UnsupportedSPIRVFeatureError,
+            ValueError,
             match=(
-                "SPIR-V requires a concrete fixed-array extent for local variable "
-                "values; could not resolve 'extent'"
+                "Template-hostile target 'vulkan' requires concrete template "
+                "arguments.*symbolic_local_array missing extent"
             ),
         ) as exc_info:
             crosstl.translate(
@@ -34108,8 +34110,21 @@ class TestSpirvShaderValidation:
                 format_output=False,
             )
 
-        assert exc_info.value.feature == "unresolved fixed array extent"
-        assert exc_info.value.missing_capabilities == ("spirv.fixed_array_extent",)
+        assert exc_info.value.project_diagnostic_code == (
+            "project.translate.template-materialization-unsupported"
+        )
+        assert exc_info.value.missing_capabilities == ("template.specialization",)
+        assert exc_info.value.metadata["status"] == "unsupported"
+        unresolved_entries = [
+            record
+            for record in exc_info.value.metadata["unsupported"]
+            if record["name"] == "symbolic_local_array"
+        ]
+        assert len(unresolved_entries) == 1
+        assert unresolved_entries[0]["missingParameters"] == ["extent"]
+        assert unresolved_entries[0]["requiredSignature"] == (
+            "symbolic_local_array<extent>"
+        )
 
     def test_metal_simdgroup_matrix_reports_structured_spirv_error(self, tmp_path):
         source_path = tmp_path / "simdgroup_matrix.metal"

--- a/tests/test_translator/test_codegen/test_shader_validation.py
+++ b/tests/test_translator/test_codegen/test_shader_validation.py
@@ -1,4 +1,5 @@
 import ast
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -6734,6 +6735,32 @@ kernel void read_alias(
 """
 
 
+METAL_MATERIALIZED_TYPED_RESOURCE_TEMPLATE_SOURCE = """\
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T, int Width = 4>
+T add_bias(T value, uint bias = 1u) {
+    return value + T(Width) + T(bias);
+}
+
+template <typename T, int Width = 4>
+[[kernel]] void copy_values(
+    const device T* values [[buffer(0)]],
+    device T* results [[buffer(1)]],
+    uint gid [[thread_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]]) {
+    threadgroup T scratch[Width];
+    scratch[lid] = add_bias<T, Width>(values[gid]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    results[gid] = scratch[lid];
+}
+
+template [[host_name("copy_float")]] [[kernel]]
+decltype(copy_values<float>) copy_values<float>;
+"""
+
+
 def run_validator(command):
     result = subprocess.run(command, capture_output=True, text=True)
     diagnostics = f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
@@ -11919,6 +11946,49 @@ def test_translated_metal_conditional_typed_resource_pointer_alias_validates_wit
     run_validator([glslang, "-S", "comp", str(source)])
 
 
+def test_translated_metal_materialized_template_validates_with_glslang(tmp_path):
+    glslang = shutil.which("glslangValidator")
+    if glslang is None:
+        pytest.skip("glslangValidator is not installed")
+
+    metal_source = tmp_path / "materialized_typed_resource_template.metal"
+    source = tmp_path / "materialized_typed_resource_template.comp"
+    output = tmp_path / "materialized_typed_resource_template.spv"
+    metal_source.write_text(
+        METAL_MATERIALIZED_TYPED_RESOURCE_TEMPLATE_SOURCE,
+        encoding="utf-8",
+    )
+    code = crosstl.translate(
+        str(metal_source),
+        backend="opengl",
+        format_output=False,
+        source_backend="metal",
+    )
+
+    assert "float add_bias_float_4(float value, uint bias)" in code
+    assert "shared float copy_float_scratch[4];" in code
+    assert re.search(r"\b(?:T|Width)\b", code) is None
+    assert "template <" not in code
+    source.write_text(code, encoding="utf-8")
+
+    run_validator(
+        [
+            glslang,
+            "-G",
+            "--target-env",
+            "opengl",
+            "-S",
+            "comp",
+            str(source),
+            "-o",
+            str(output),
+        ]
+    )
+    spirv_val = shutil.which("spirv-val")
+    if spirv_val is not None:
+        run_validator([spirv_val, "--target-env", "spv1.0", str(output)])
+
+
 def test_generated_glsl_wave_intrinsics_compute_validates_with_glslang(tmp_path):
     glslang = shutil.which("glslangValidator")
     if glslang is None:
@@ -12728,6 +12798,36 @@ def test_translated_metal_conditional_typed_resource_pointer_alias_validates_wit
     assert "int*" not in code
     assert "int *" not in code
     assert "(values + flag) ?" not in code
+    source.write_text(code, encoding="utf-8")
+
+    run_validator(
+        [dxc, "-T", "cs_6_0", "-E", "CSMain", str(source), "-Fo", str(output)]
+    )
+
+
+def test_translated_metal_materialized_template_validates_with_dxc(tmp_path):
+    dxc = shutil.which("dxc")
+    if dxc is None:
+        pytest.skip("dxc is not installed")
+
+    metal_source = tmp_path / "materialized_typed_resource_template.metal"
+    source = tmp_path / "materialized_typed_resource_template.hlsl"
+    output = tmp_path / "materialized_typed_resource_template.dxil"
+    metal_source.write_text(
+        METAL_MATERIALIZED_TYPED_RESOURCE_TEMPLATE_SOURCE,
+        encoding="utf-8",
+    )
+    code = crosstl.translate(
+        str(metal_source),
+        backend="directx",
+        format_output=False,
+        source_backend="metal",
+    )
+
+    assert "float add_bias_float_4(float value, uint bias)" in code
+    assert "groupshared float copy_float_scratch[4];" in code
+    assert re.search(r"\b(?:T|Width)\b", code) is None
+    assert "template <" not in code
     source.write_text(code, encoding="utf-8")
 
     run_validator(

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -12459,6 +12459,226 @@ def test_translate_project_opengl_validates_implicit_metal_matmul_resources(
     assert output == validator_inputs[0]
 
 
+@pytest.mark.parametrize("target", ["directx", "opengl"])
+def test_translate_project_matches_direct_metal_materialized_signatures(
+    tmp_path,
+    target,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "materialized-copy.metal"
+    source_path.write_text(
+        textwrap.dedent("""
+            #include <metal_stdlib>
+            using namespace metal;
+
+            template <typename T, int Width = 4>
+            T add_bias(T value, uint bias = 1u) {
+                return value + T(Width) + T(bias);
+            }
+
+            template <typename T, int Width = 4>
+            [[kernel]] void copy_values(
+                const device T* values [[buffer(0)]],
+                device T* results [[buffer(1)]],
+                uint gid [[thread_position_in_grid]],
+                uint lid [[thread_position_in_threadgroup]]) {
+                threadgroup T scratch[Width];
+                scratch[lid] = add_bias<T, Width>(values[gid]);
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                results[gid] = scratch[lid];
+            }
+
+            template [[host_name("copy_float")]] [[kernel]]
+            decltype(copy_values<float>) copy_values<float>;
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+
+    direct_output = crosstl_cli.translate(
+        str(source_path), backend=target, format_output=False
+    )
+    payload = translate_project(
+        repo,
+        targets=[target],
+        output_dir="out",
+        format_output=False,
+    ).to_json()
+
+    assert payload["diagnostics"] == []
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 0
+    artifact = payload["artifacts"][0]
+    assert artifact["status"] == "translated"
+    assert artifact["templateMaterialization"]["status"] == "materialized"
+    assert artifact["templateMaterialization"]["unsupported"] == []
+    project_output = (repo / artifact["path"]).read_text(encoding="utf-8")
+
+    def signature_contract(output):
+        normalized = re.sub(r"\s+", " ", output)
+        helper_signatures = sorted(
+            set(
+                re.findall(
+                    r"\bfloat add_bias_float_4\(float value, uint bias\)",
+                    normalized,
+                )
+            )
+        )
+        if target == "directx":
+            resources = sorted(
+                re.findall(
+                    r"\b((?:RW)?StructuredBuffer)<(float)>\s+\w+\s*"
+                    r":\s*register\(([tu]\d+)\);",
+                    normalized,
+                )
+            )
+            shared_storage = re.findall(
+                r"\bgroupshared (float) copy_float_scratch\[(\d+)\];",
+                normalized,
+            )
+            entry_signatures = re.findall(
+                r"\[numthreads\(([^)]+)\)\]\s*void\s+(\w+)\(([^)]*)\)",
+                normalized,
+            )
+        else:
+            resources = sorted(
+                re.findall(
+                    r"layout\(std430, binding = (\d+)\) (readonly )?buffer "
+                    r"\w+ \{ (float) \w+\[\]; \};",
+                    normalized,
+                )
+            )
+            shared_storage = re.findall(
+                r"\bshared (float) copy_float_scratch\[(\d+)\];", normalized
+            )
+            entry_signatures = re.findall(
+                r"layout\(local_size_x = ([^,]+), local_size_y = ([^,]+), "
+                r"local_size_z = ([^)]+)\) in;\s*void\s+(main)\(([^)]*)\)",
+                normalized,
+            )
+        return {
+            "resources": resources,
+            "sharedStorage": shared_storage,
+            "helpers": helper_signatures,
+            "entries": entry_signatures,
+        }
+
+    direct_contract = signature_contract(direct_output)
+    project_contract = signature_contract(project_output)
+    assert direct_contract == project_contract
+    assert direct_contract["helpers"] == [
+        "float add_bias_float_4(float value, uint bias)"
+    ]
+    assert direct_contract["sharedStorage"] == [("float", "4")]
+    assert direct_contract["entries"]
+    if target == "directx":
+        assert direct_contract["resources"] == [
+            ("RWStructuredBuffer", "float", "u1"),
+            ("StructuredBuffer", "float", "t0"),
+        ]
+    else:
+        assert direct_contract["resources"] == [
+            ("0", "readonly ", "float"),
+            ("1", "", "float"),
+        ]
+
+    for output in (direct_output, project_output):
+        assert "add_bias_float_4" in output
+        assert "copy_float_scratch[4]" in output
+        assert not re.search(r"\b(?:T|Width)\b", output)
+        assert "template <" not in output
+
+
+def test_translate_project_unresolved_metal_resources_fail_before_target_codegen(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "unresolved-copy.metal"
+    source_path.write_text(
+        textwrap.dedent("""
+            #include <metal_stdlib>
+            using namespace metal;
+
+            template <typename T, int Width>
+            T add_bias(T value) {
+                return value + T(Width);
+            }
+
+            template <typename T, int Width>
+            [[kernel]] void unresolved_copy(
+                const device T* values [[buffer(0)]],
+                device T* results [[buffer(1)]],
+                uint gid [[thread_position_in_grid]],
+                uint lid [[thread_position_in_threadgroup]]) {
+                threadgroup T scratch[Width];
+                scratch[lid] = add_bias<T, Width>(values[gid]);
+                results[gid] = scratch[lid];
+            }
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+
+    direct_failures = {}
+    for target in ("directx", "opengl"):
+        with pytest.raises(ValueError) as exc_info:
+            crosstl_cli.translate(str(source_path), backend=target, format_output=False)
+        direct_failures[target] = exc_info.value
+
+    payload = translate_project(
+        repo,
+        targets=["directx", "opengl"],
+        output_dir="out",
+        format_output=False,
+    ).to_json()
+
+    assert payload["summary"]["translatedCount"] == 0
+    assert payload["summary"]["failedCount"] == 2
+    assert payload["summary"]["diagnosticsByCode"] == {
+        "project.translate.template-materialization-unsupported": 2
+    }
+    assert len(payload["artifacts"]) == 2
+    assert len(payload["diagnostics"]) == 2
+
+    diagnostics_by_target = {
+        diagnostic["target"]: diagnostic for diagnostic in payload["diagnostics"]
+    }
+    for artifact in payload["artifacts"]:
+        target = artifact["target"]
+        direct_failure = direct_failures[target]
+        diagnostic = diagnostics_by_target[target]
+
+        assert artifact["status"] == "failed"
+        assert not (repo / artifact["path"]).exists()
+        assert artifact["templateMaterialization"]["status"] == "unsupported"
+        assert diagnostic["code"] == direct_failure.project_diagnostic_code
+        assert diagnostic["missingCapabilities"] == list(
+            direct_failure.missing_capabilities
+        )
+        assert diagnostic["code"] == (
+            "project.translate.template-materialization-unsupported"
+        )
+        assert diagnostic["sourceBackend"] == "metal"
+        assert "requires concrete template arguments" in diagnostic["message"]
+        assert "unresolved_copy" in diagnostic["message"]
+        assert "T" in diagnostic["message"]
+        assert "Width" in diagnostic["message"]
+        assert "codegen cannot emit" not in diagnostic["message"]
+        assert "StructuredBuffer<T>" not in artifact["error"]
+        assert "buffer T[]" not in artifact["error"]
+
+        unresolved_entries = [
+            record
+            for record in artifact["templateMaterialization"]["unsupported"]
+            if record["name"] == "unresolved_copy"
+        ]
+        assert len(unresolved_entries) == 1
+        assert unresolved_entries[0]["missingParameters"] == ["T", "Width"]
+        assert unresolved_entries[0]["requiredSignature"] == (
+            "unresolved_copy<T, Width>"
+        )
+
+
 def test_translate_project_materializes_metal_rope_template_defaults_to_targets(
     tmp_path,
 ):

--- a/tests/test_translator/test_translation_pipeline.py
+++ b/tests/test_translator/test_translation_pipeline.py
@@ -619,6 +619,125 @@ def test_metal_explicit_template_helper_specializes_to_concrete_opengl(tmp_path)
     assert not re.search(r"\b(?:T|IdxT|Offset)\b", generated)
 
 
+@pytest.mark.parametrize("backend", ["directx", "opengl"])
+def test_metal_reachable_template_resources_materialize_before_target_codegen(
+    tmp_path,
+    backend,
+):
+    source_path = _write_source(
+        tmp_path,
+        "materialized-copy.metal",
+        """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        template <typename T, int Width = 4>
+        T add_bias(T value, uint bias = 1u) {
+            return value + T(Width) + T(bias);
+        }
+
+        template <typename T, int Width = 4>
+        [[kernel]] void copy_values(
+            const device T* values [[buffer(0)]],
+            device T* results [[buffer(1)]],
+            uint gid [[thread_position_in_grid]],
+            uint lid [[thread_position_in_threadgroup]]) {
+            threadgroup T scratch[Width];
+            scratch[lid] = add_bias<T, Width>(values[gid]);
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            results[gid] = scratch[lid];
+        }
+
+        template [[host_name("copy_float")]] [[kernel]]
+        decltype(copy_values<float>) copy_values<float>;
+        """,
+    )
+
+    generated = crosstl.translate(
+        str(source_path), backend=backend, format_output=False
+    )
+
+    _assert_generated_output_is_usable(generated)
+    assert "add_bias_float_4" in generated
+    assert not re.search(r"\b(?:T|Width)\b", generated)
+    assert "template <" not in generated
+    if backend == "directx":
+        assert "StructuredBuffer<float> values : register(t0);" in generated
+        assert "RWStructuredBuffer<float> results : register(u1);" in generated
+        assert "groupshared float copy_float_scratch[4];" in generated
+        assert re.search(r"float add_bias_float_4\(float value, uint bias\)", generated)
+        assert "add_bias_float_4(values.Load(gid), 1u)" in generated
+    else:
+        assert re.search(
+            r"readonly buffer valuesBuffer\s*\{\s*float values\[\];\s*\};",
+            generated,
+        )
+        assert re.search(
+            r"buffer resultsBuffer\s*\{\s*float results\[\];\s*\};",
+            generated,
+        )
+        assert "shared float copy_float_scratch[4];" in generated
+        assert re.search(r"float add_bias_float_4\(float value, uint bias\)", generated)
+        assert "add_bias_float_4(values[gid], 1u)" in generated
+
+
+def test_metal_unresolved_reachable_template_resources_fail_before_target_codegen(
+    tmp_path,
+):
+    source_path = _write_source(
+        tmp_path,
+        "unresolved-copy.metal",
+        """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        template <typename T, int Width>
+        T add_bias(T value) {
+            return value + T(Width);
+        }
+
+        template <typename T, int Width>
+        [[kernel]] void unresolved_copy(
+            const device T* values [[buffer(0)]],
+            device T* results [[buffer(1)]],
+            uint gid [[thread_position_in_grid]],
+            uint lid [[thread_position_in_threadgroup]]) {
+            threadgroup T scratch[Width];
+            scratch[lid] = add_bias<T, Width>(values[gid]);
+            results[gid] = scratch[lid];
+        }
+        """,
+    )
+
+    for backend in ("directx", "opengl"):
+        with pytest.raises(ValueError) as exc_info:
+            crosstl.translate(str(source_path), backend=backend, format_output=False)
+
+        message = str(exc_info.value)
+        assert exc_info.value.project_diagnostic_code == (
+            "project.translate.template-materialization-unsupported"
+        )
+        assert exc_info.value.missing_capabilities == ("template.specialization",)
+        assert exc_info.value.metadata["status"] == "unsupported"
+        unresolved_entries = [
+            record
+            for record in exc_info.value.metadata["unsupported"]
+            if record["name"] == "unresolved_copy"
+        ]
+        assert len(unresolved_entries) == 1
+        assert unresolved_entries[0]["missingParameters"] == ["T", "Width"]
+        assert unresolved_entries[0]["requiredSignature"] == (
+            "unresolved_copy<T, Width>"
+        )
+        assert "requires concrete template arguments" in message
+        assert "unresolved_copy" in message
+        assert "T" in message
+        assert "Width" in message
+        assert "codegen cannot emit" not in message
+        assert "StructuredBuffer<T>" not in message
+        assert "buffer T[]" not in message
+
+
 def test_metal_uint2_dispatch_id_promotes_to_directx_uint3(tmp_path):
     source_path = _write_source(
         tmp_path,


### PR DESCRIPTION
## Summary

- run direct Metal translation to template-hostile targets through the same reachable-specialization preparation used by project translation
- preserve include paths, defines, source options, explicit instantiations, `host_name` attributes, defaults, and finite materialization budgets
- fail before target code generation with structured materialization metadata when reachable template arguments remain unresolved
- prove concrete DirectX/OpenGL resource, helper, and shared-memory signatures across direct and one-unit project translation
- compile reduced artifacts with native Metal and OpenGL toolchains locally and gate HLSL with DXC when available in CI

## MLX evidence

At MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`, direct translation of `mlx/backend/metal/kernels/arange.metal` now completes through the shared specialization path for both targets:

- DirectX: 17,276-byte concrete HLSL artifact in 2.8 seconds
- OpenGL: 15,146-byte concrete GLSL artifact in 4.5 seconds
- neither artifact retains the surveyed unresolved template markers
- the OpenGL artifact compiles with `glslangValidator` for OpenGL/SPIR-V 1.3 and passes `spirv-val`

This change does not claim full pinned-corpus compilation or MLX runtime parity. Larger generic kernels still require bounded full-source replays and target-specific follow-up work, and host dispatch/resource integration remains separate.

## Validation

- `.venv/bin/python -m pytest -q -n auto tests/test_translator/test_translation_pipeline.py` (`311 passed`)
- `.venv/bin/python -m pytest -q -n auto tests/test_translator/test_project_translation.py -k 'metal and materializ'` (`38 passed`)
- focused direct/project/native materialization regressions (`7 passed, 1 skipped`; DXC unavailable locally)
- `.venv/bin/python -m pytest -q -n auto` (`14899 passed, 186 skipped`)
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python tools/support_matrix.py check`
- `.venv/bin/python tools/sync_support_issues.py --repo CrossGL/crosstl --dry-run` (`0` desired issues)
- `xcrun -sdk macosx metal` on the concrete template fixture
- `glslangValidator --target-env opengl --target-env spirv1.3` and `spirv-val --target-env spv1.3` on the reduced fixture and pinned MLX `arange.metal`

Closes #1685
