### PR TITLE
Expand MLX DirectX compiler validation frontier

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -168,8 +168,19 @@ jobs:
           import os
           from pathlib import Path
 
+          from demos.integrations.mlx.run_mlx_porting import (
+              MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS,
+              MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES,
+          )
+
           fence_source = "mlx/backend/metal/kernels/fence.metal"
           fence_issue = "https://github.com/CrossGL/crosstl/issues/1537"
+          directx_frontier_sources = set(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
+          directx_entry_point_counts = dict(
+              MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+          )
+          directx_frontier_count = len(directx_frontier_sources)
+          directx_entry_point_count = sum(directx_entry_point_counts.values())
           opengl_frontier_sources = {
               "mlx/backend/metal/kernels/arg_reduce.metal",
               "mlx/backend/metal/kernels/binary_two.metal",
@@ -290,6 +301,36 @@ jobs:
                   raise SystemExit(
                       f"reference accessor {target} native validation must be "
                       f"{expected_status} on {os.environ['RUNNER_OS']}"
+                  )
+          directx = checks["directx-vulkan-frontier"]
+          if (
+              set(directx["directxToolchainSources"])
+              != directx_frontier_sources
+              or directx["directxToolchainArtifactCount"]
+              != directx_frontier_count
+              or directx["directxToolchainExpectedEntryPointCounts"]
+              != directx_entry_point_counts
+              or directx["directxToolchainExpectedEntryPointCount"]
+              != directx_entry_point_count
+          ):
+              raise SystemExit("DirectX frontier accounting is incomplete")
+          if os.environ["RUNNER_OS"] == "Windows":
+              if (
+                  directx["directxToolchainRequired"] is not True
+                  or directx["directxValidationStatus"] != "validated"
+                  or directx["directxToolchainValidatedArtifactCount"]
+                  != directx_frontier_count
+                  or set(directx["directxToolchainValidatedSources"])
+                  != directx_frontier_sources
+                  or directx["directxToolchainValidatedEntryPointCounts"]
+                  != directx_entry_point_counts
+                  or directx["directxToolchainValidatedEntryPointCount"]
+                  != directx_entry_point_count
+                  or directx["toolchainRuns"] != directx_entry_point_count
+              ):
+                  raise SystemExit(
+                      "DirectX frontier toolchain must validate every configured "
+                      "source artifact and compute entry"
                   )
           opengl = checks["opengl-frontier"]
           if set(opengl["sources"]) != opengl_frontier_sources:

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -57,15 +57,28 @@ The current harness verifies:
   clean artifact generation for DirectX, OpenGL, and Vulkan. OpenGL compilation
   and both OpenGL-derived and native SPIR-V validation run in the required Linux
   toolchain gate;
-- DirectX HLSL smoke checks with DXC on Windows CI for the verified subset
-  (`arange.metal`, `arg_reduce.metal`, and `rope.metal`). The pinned rope
-  translation supplies required function constant IDs through the quoted
-  `"1"`, `"2"`, and `"3"` selectors in `[project.specialization_constants]`,
-  materializes the concrete DirectX variant, and compiles every discovered
-  entry, including the unsuffixed `CSMain`. Other clean frontier kernels
-  translate to DirectX but are excluded for structural and semantic gaps
-  recorded in `expected-gaps.json`; `fence.metal` is excluded because its
-  DirectX translation intentionally fails before DXC;
+- DirectX HLSL smoke checks with official DXC v1.9.2602.24 on Windows CI for
+  the eight-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`,
+  `logsumexp.metal`, `rms_norm.metal`, `rope.metal`,
+  `scaled_dot_product_attention.metal`, and `softmax.metal` frontier. At the
+  pinned revision the gate compiles every generated compute entry: 11, 24, 12,
+  6, 12, 18, 42, and 10 entries respectively. The pinned rope translation
+  supplies required function constant IDs through the quoted `"1"`, `"2"`, and
+  `"3"` selectors in `[project.specialization_constants]` and materializes the
+  concrete DirectX variant before compilation. `binary_two.metal` remains
+  outside the gate under [#1694](https://github.com/CrossGL/crosstl/issues/1694)
+  and [#1695](https://github.com/CrossGL/crosstl/issues/1695), `random.metal`
+  under [#1696](https://github.com/CrossGL/crosstl/issues/1696) with runtime
+  dispatch metadata still tracked by
+  [#1542](https://github.com/CrossGL/crosstl/issues/1542), and `ternary.metal`
+  first under [#1695](https://github.com/CrossGL/crosstl/issues/1695), with later
+  entries still dependent on
+  [#1491](https://github.com/CrossGL/crosstl/issues/1491) and
+  [#1524](https://github.com/CrossGL/crosstl/issues/1524). `fence.metal` is
+  excluded because its DirectX translation intentionally fails under
+  [#1537](https://github.com/CrossGL/crosstl/issues/1537) before DXC. This gate
+  establishes compiler acceptance only; it does not dispatch these kernels or
+  establish numerical parity;
 - Vulkan assembly and validator checks for the existing non-fence regression
   frontier when SPIR-V tools are available. Vulkan atomic-fence feature work is
   deferred; the separate `fence.metal` contract check prevents generated
@@ -277,8 +290,8 @@ the fixed arrays of resource aliases introduced by the pinned revision's wide
 quantized matrix-vector helpers. CrossGL/crosstl#1671 tracks workgroup backing
 provenance through nested FFT helper parameters. CrossGL/crosstl#1672 tracks
 owner-dependent `constexpr` helper calls in quantized struct static members.
-CrossGL/crosstl#1491 tracks the current scaled-attention
-qualified-static-constant materialization blocker.
+CrossGL/crosstl#1491 tracks remaining qualified-static-constant materialization,
+including the current `ternary.metal` DirectX exclusion.
 Built-in overloads are resolved alongside user-defined wrappers by source
 signature.
 Before native validation, the harness verifies
@@ -296,8 +309,9 @@ constructors, casts, and generic static-member owners. For the pinned attention
 source this resolves 531 concrete uses across all 42 entries, including the
 float accumulation type used by the half and bfloat input families. The full
 source translates to DirectX, OpenGL, and Vulkan; local OpenGL and Vulkan native
-validation passes. DirectX remains outside the DXC gate for the independent
-resource-cursor issue listed in `expected-gaps.json`.
+validation passes, and official DXC v1.9.2602.24 compiles all 42 generated
+DirectX compute entries. This is compiler validation, not Direct3D runtime
+execution or numerical parity.
 The project Vulkan artifact is warning-free because project preparation removes
 unreachable generic declarations. Direct single-file translation still emits
 five such warnings under

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -337,7 +337,7 @@
       "static_members": 42
     },
     "native_validation": {
-      "directx": "translated-dxc-blocked-by-existing-issues",
+      "directx": "dxc-validated",
       "opengl": "validated",
       "vulkan": "validated"
     },
@@ -394,7 +394,11 @@
   },
   "directx_toolchain_status": {
     "status": "passing",
-    "note": "Windows CI compiles every discovered entry in the generated DirectX HLSL for the verified subset below. Other clean frontier kernels translate to DirectX but remain outside the compile gate for the listed structural or semantic defects. fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
+    "note": "Windows CI compiles every generated compute entry in the eight-source DirectX HLSL frontier below. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity. binary_two.metal, random.metal, and ternary.metal remain outside the clean-frontier DXC gate for the listed defects; fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
+    "compiler": {
+      "name": "dxc",
+      "version": "v1.9.2602.24"
+    },
     "specialization_constants": {
       "1": false,
       "2": false,
@@ -407,22 +411,34 @@
       "25": false,
       "26": 1
     },
+    "expected_entry_point_counts": {
+      "mlx/backend/metal/kernels/arange.metal": 11,
+      "mlx/backend/metal/kernels/arg_reduce.metal": 24,
+      "mlx/backend/metal/kernels/layer_norm.metal": 12,
+      "mlx/backend/metal/kernels/logsumexp.metal": 6,
+      "mlx/backend/metal/kernels/rms_norm.metal": 12,
+      "mlx/backend/metal/kernels/rope.metal": 18,
+      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": 42,
+      "mlx/backend/metal/kernels/softmax.metal": 10
+    },
     "dxc_validated_sources": [
       "mlx/backend/metal/kernels/arange.metal",
       "mlx/backend/metal/kernels/arg_reduce.metal",
-      "mlx/backend/metal/kernels/rope.metal"
+      "mlx/backend/metal/kernels/layer_norm.metal",
+      "mlx/backend/metal/kernels/logsumexp.metal",
+      "mlx/backend/metal/kernels/rms_norm.metal",
+      "mlx/backend/metal/kernels/rope.metal",
+      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
+      "mlx/backend/metal/kernels/softmax.metal"
     ],
     "directx_toolchain_gaps": {
-      "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)",
-      "mlx/backend/metal/kernels/random.metal": "the generated dispatch-info cbuffer still requires reflected runtime binding and dispatch-plan coverage before it enters the DXC/runtime gate (https://github.com/CrossGL/crosstl/issues/1542)",
-      "mlx/backend/metal/kernels/binary_two.metal": "operator-functor call lowering emits duplicated/temporary helper names and a conditional operator over a non-numeric result (https://github.com/CrossGL/crosstl/issues/1536)",
-      "mlx/backend/metal/kernels/layer_norm.metal": "pointer-style helpers and resource rebasing remain outside the DXC gate (https://github.com/CrossGL/crosstl/issues/1518)",
-      "mlx/backend/metal/kernels/logsumexp.metal": "storage-resource cursor arithmetic remains invalid HLSL (https://github.com/CrossGL/crosstl/issues/1518)",
-      "mlx/backend/metal/kernels/rms_norm.metal": "storage-resource cursor arithmetic remains invalid HLSL (https://github.com/CrossGL/crosstl/issues/1518)",
-      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": "storage-resource cursor arithmetic remains outside the DXC gate (https://github.com/CrossGL/crosstl/issues/1518)",
-      "mlx/backend/metal/kernels/softmax.metal": "storage-resource cursor arithmetic remains invalid HLSL (https://github.com/CrossGL/crosstl/issues/1518)",
-      "mlx/backend/metal/kernels/ternary.metal": "static template-trait member WorkPerThread<T>::n is emitted as an undeclared identifier and a conditional operator returns a non-numeric type (https://github.com/CrossGL/crosstl/issues/1491, https://github.com/CrossGL/crosstl/issues/1524)"
-    }
+      "mlx/backend/metal/kernels/binary_two.metal": "generated HLSL still has target-ABI signature collisions when distinct Metal scalar overloads collapse (https://github.com/CrossGL/crosstl/issues/1694) and structure-valued conditional expressions that require aggregate lowering instead of HLSL struct operators (https://github.com/CrossGL/crosstl/issues/1695)",
+      "mlx/backend/metal/kernels/random.metal": "union-backed aliases still require storage-preserving HLSL lowering (https://github.com/CrossGL/crosstl/issues/1696); reflected dispatch-grid cbuffer binding and dispatch-plan metadata also remain required before native execution (https://github.com/CrossGL/crosstl/issues/1542)",
+      "mlx/backend/metal/kernels/ternary.metal": "DXC first rejects a structure-valued conditional expression that requires aggregate lowering instead of HLSL struct operators (https://github.com/CrossGL/crosstl/issues/1695); later entries still depend on qualified static-constant and concrete type-trait value materialization (https://github.com/CrossGL/crosstl/issues/1491, https://github.com/CrossGL/crosstl/issues/1524)",
+      "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)"
+    },
+    "native_runtime_executed": false,
+    "runtime_parity_claimed": false
   },
   "opengl_smoke_status": {
     "status": "passing",
@@ -587,6 +603,9 @@
     "https://github.com/CrossGL/crosstl/issues/1670",
     "https://github.com/CrossGL/crosstl/issues/1671",
     "https://github.com/CrossGL/crosstl/issues/1672",
+    "https://github.com/CrossGL/crosstl/issues/1694",
+    "https://github.com/CrossGL/crosstl/issues/1695",
+    "https://github.com/CrossGL/crosstl/issues/1696",
     "https://github.com/CrossGL/crosstl/issues/1312",
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1676",

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -37,12 +37,15 @@ MLX_BINARY_TWO_SOURCE = "mlx/backend/metal/kernels/binary_two.metal"
 MLX_FENCE_SOURCE = "mlx/backend/metal/kernels/fence.metal"
 MLX_FENCE_EXPECTED_ATOMIC_FENCE_COUNT = 3
 MLX_GEMV_SOURCE = "mlx/backend/metal/kernels/gemv.metal"
+MLX_LAYER_NORM_SOURCE = "mlx/backend/metal/kernels/layer_norm.metal"
+MLX_LOGSUMEXP_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
 MLX_METAL_ROUNDTRIP_SOURCE = MLX_FENCE_SOURCE
 MLX_RMS_NORM_SOURCE = "mlx/backend/metal/kernels/rms_norm.metal"
 MLX_ROPE_SOURCE = "mlx/backend/metal/kernels/rope.metal"
 MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE = (
     "mlx/backend/metal/kernels/scaled_dot_product_attention.metal"
 )
+MLX_SOFTMAX_SOURCE = "mlx/backend/metal/kernels/softmax.metal"
 REFERENCE_ACCESSOR_FIXTURE_NAME = "reference_accessor_lvalue.metal"
 REFERENCE_ACCESSOR_FIXTURE_PATH = (
     Path(__file__).resolve().parent / "fixtures" / REFERENCE_ACCESSOR_FIXTURE_NAME
@@ -53,23 +56,23 @@ REFERENCE_ACCESSOR_DXC_ENTRY_POINT = "CSMain"
 MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES = (
     MLX_ARG_REDUCE_SOURCE,
     MLX_BINARY_TWO_SOURCE,
-    "mlx/backend/metal/kernels/logsumexp.metal",
+    MLX_LOGSUMEXP_SOURCE,
     MLX_RMS_NORM_SOURCE,
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
-    "mlx/backend/metal/kernels/softmax.metal",
+    MLX_SOFTMAX_SOURCE,
 )
 MLX_DIRECTX_VULKAN_FRONTIER_SOURCES = (
-    "mlx/backend/metal/kernels/arange.metal",
+    MLX_ARANGE_SOURCE,
     MLX_ARG_REDUCE_SOURCE,
     MLX_BINARY_TWO_SOURCE,
-    "mlx/backend/metal/kernels/layer_norm.metal",
-    "mlx/backend/metal/kernels/logsumexp.metal",
+    MLX_LAYER_NORM_SOURCE,
+    MLX_LOGSUMEXP_SOURCE,
     "mlx/backend/metal/kernels/random.metal",
     MLX_RMS_NORM_SOURCE,
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
-    "mlx/backend/metal/kernels/softmax.metal",
+    MLX_SOFTMAX_SOURCE,
     "mlx/backend/metal/kernels/ternary.metal",
 )
 MLX_CLEAN_REDUCED_FRONTIER_SOURCES = tuple(
@@ -92,13 +95,31 @@ MLX_REDUCED_FRONTIER_SOURCES = tuple(
     )
 )
 # Subset of the clean frontier gated by DXC on Windows. The DirectX/Vulkan frontier
-# is still translated in full (and all Vulkan artifacts are spirv-val'd), but the
-# remaining kernels have tracked structural or semantic defects and stay outside
-# the DirectX compile gate until those are fixed.
+# is still translated in full (and all Vulkan artifacts are spirv-val'd), while
+# the remaining kernels stay outside the DirectX compile gate under tracked gaps.
 MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = (
-    "mlx/backend/metal/kernels/arange.metal",
+    MLX_ARANGE_SOURCE,
     MLX_ARG_REDUCE_SOURCE,
+    MLX_LAYER_NORM_SOURCE,
+    MLX_LOGSUMEXP_SOURCE,
+    MLX_RMS_NORM_SOURCE,
     MLX_ROPE_SOURCE,
+    MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
+    MLX_SOFTMAX_SOURCE,
+)
+# Pinned generated compute entries compiled by official DXC v1.9.2602.24.
+MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
+    MLX_ARANGE_SOURCE: 11,
+    MLX_ARG_REDUCE_SOURCE: 24,
+    MLX_LAYER_NORM_SOURCE: 12,
+    MLX_LOGSUMEXP_SOURCE: 6,
+    MLX_RMS_NORM_SOURCE: 12,
+    MLX_ROPE_SOURCE: 18,
+    MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
+    MLX_SOFTMAX_SOURCE: 10,
+}
+MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT = sum(
+    MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
 )
 MLX_FRONTIER_SPECIALIZATION_CONSTANTS = {
     "1": False,
@@ -1935,7 +1956,9 @@ def _scaled_attention_local_alias_evidence(
             generated_by_target["vulkan"],
         )
     )
-    expected_entry_count = 42
+    expected_entry_count = MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS[
+        MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE
+    ]
     _require(
         directx_entry_count == expected_entry_count
         and vulkan_entry_count == expected_entry_count,
@@ -1961,6 +1984,22 @@ def _scaled_attention_local_alias_evidence(
             "https://github.com/CrossGL/crosstl/issues/1568"
         ),
     }
+
+
+def _directx_toolchain_entry_point(run: Mapping[str, Any]) -> str | None:
+    command = run.get("command")
+    if not isinstance(command, list) or any(
+        not isinstance(argument, str) for argument in command
+    ):
+        return None
+    try:
+        profile = command[command.index("-T") + 1]
+        entry_point = command[command.index("-E") + 1]
+    except (ValueError, IndexError):
+        return None
+    if not profile.startswith("cs_") or not entry_point:
+        return None
+    return entry_point
 
 
 def _translate_directx_vulkan_frontier(
@@ -2115,6 +2154,38 @@ def _translate_directx_vulkan_frontier(
         for run in toolchain_runs
         if isinstance(run, dict) and run.get("target") == "vulkan"
     ]
+    directx_entry_points_by_source: dict[str, list[str]] = {
+        source: [] for source in MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+    }
+    for run in directx_runs:
+        if run.get("status") != "ok":
+            continue
+        source = run.get("source")
+        _require(
+            source in directx_entry_points_by_source,
+            f"DirectX toolchain validation reported an unexpected source: {source}",
+        )
+        entry_point = _directx_toolchain_entry_point(run)
+        _require(
+            entry_point is not None,
+            "DirectX toolchain validation did not record a compute entry command",
+        )
+        validated_entries = directx_entry_points_by_source[source]
+        _require(
+            entry_point not in validated_entries,
+            f"DirectX toolchain validation duplicated {source} entry {entry_point}",
+        )
+        validated_entries.append(entry_point)
+    directx_validated_entry_point_counts = {
+        source: len(entry_points)
+        for source, entry_points in directx_entry_points_by_source.items()
+        if entry_points
+    }
+    directx_validated_sources = [
+        source
+        for source in MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+        if source in directx_validated_entry_point_counts
+    ]
     required_toolchains = {
         "directx": (
             require_directx_toolchain,
@@ -2134,6 +2205,19 @@ def _translate_directx_vulkan_frontier(
                 and artifact.get("status") == "translated"
                 and isinstance(artifact.get("path"), str)
             }
+            if target == "directx":
+                artifact_sources = {
+                    artifact.get("source")
+                    for artifact in artifact_payload.get("artifacts", [])
+                    if isinstance(artifact, dict)
+                    and artifact.get("target") == target
+                    and artifact.get("status") == "translated"
+                    and isinstance(artifact.get("source"), str)
+                }
+                _require(
+                    artifact_sources == set(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+                    "DirectX toolchain artifact sources did not match the frontier",
+                )
             validated_paths = {
                 run.get("path")
                 for run in runs
@@ -2160,6 +2244,16 @@ def _translate_directx_vulkan_frontier(
                     "validation issues are tracked"
                 ),
             )
+    if require_directx_toolchain and run_toolchains:
+        _require(
+            directx_validated_sources == list(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+            "DirectX toolchain did not validate every configured source",
+        )
+        _require(
+            directx_validated_entry_point_counts
+            == MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS,
+            "DirectX toolchain did not validate every generated compute entry point",
+        )
     return {
         "name": "directx-vulkan-frontier",
         "status": "passed",
@@ -2171,6 +2265,22 @@ def _translate_directx_vulkan_frontier(
         "targets": ["directx", "vulkan"],
         "toolchainRuns": len(toolchain_runs),
         "directxToolchainRequired": require_directx_toolchain,
+        "directxToolchainSources": list(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+        "directxToolchainArtifactCount": len(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+        "directxToolchainExpectedEntryPointCounts": dict(
+            MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+        ),
+        "directxToolchainExpectedEntryPointCount": (
+            MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT
+        ),
+        "directxToolchainValidatedSources": directx_validated_sources,
+        "directxToolchainValidatedArtifactCount": len(directx_validated_sources),
+        "directxToolchainValidatedEntryPointCounts": (
+            directx_validated_entry_point_counts
+        ),
+        "directxToolchainValidatedEntryPointCount": sum(
+            directx_validated_entry_point_counts.values()
+        ),
         "vulkanToolchainRequired": require_vulkan_toolchain,
         "directxValidationStatus": (
             "validated" if run_toolchains and directx_runs else "not-required"

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2149,6 +2149,17 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "Verify MLX frontier accounting" in mlx_porting
     assert "expected 11 clean MLX frontier sources" in mlx_porting
     assert "fence contract accounting must be 3 failed, 0 emitted" in mlx_porting
+    assert "MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES" in mlx_porting
+    assert "MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS" in mlx_porting
+    assert 'checks["directx-vulkan-frontier"]' in mlx_porting
+    assert 'directx["directxToolchainArtifactCount"]' in mlx_porting
+    assert 'directx["directxToolchainValidatedArtifactCount"]' in mlx_porting
+    assert 'directx["directxToolchainValidatedEntryPointCounts"]' in mlx_porting
+    assert 'directx["directxToolchainValidatedEntryPointCount"]' in mlx_porting
+    assert 'directx["toolchainRuns"] != directx_entry_point_count' in mlx_porting
+    assert "DirectX frontier accounting is incomplete" in mlx_porting
+    assert "DirectX frontier toolchain must validate every configured" in mlx_porting
+    assert "source artifact and compute entry" in mlx_porting
     assert 'checks["reference-accessor-lvalue-identity"]' in mlx_porting
     assert "reference accessor proof accounting is incomplete" in mlx_porting
     assert "reference accessor {target} storage evidence is incomplete" in mlx_porting
@@ -2259,6 +2270,9 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
             in harness
         )
     assert "MLX_DIRECTX_VULKAN_FRONTIER_SOURCES" in harness
+    assert "MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES" in harness
+    assert "MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS" in harness
+    assert "MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT" in harness
     assert "MLX_BLOCKED_REDUCED_FRONTIER_SOURCES" in harness
     assert "_check_atomic_fence_contract" in harness
     assert "project.translate.directx-atomic-fence-unsupported" in harness

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -9,6 +9,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 HARNESS_PATH = ROOT / "demos" / "integrations" / "mlx" / "run_mlx_porting.py"
 MLX_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "mlx-project-porting.yml"
+MLX_README_PATH = ROOT / "demos" / "integrations" / "mlx" / "README.md"
 
 
 def _load_harness():
@@ -1317,24 +1318,31 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert opengl_frontier["runtime_parity_claimed"] is False
 
     directx = expected_gaps["directx_toolchain_status"]
+    assert directx["compiler"] == {"name": "dxc", "version": "v1.9.2602.24"}
     assert directx["dxc_validated_sources"] == list(
         module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+    )
+    assert directx["expected_entry_point_counts"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+    )
+    assert sum(directx["expected_entry_point_counts"].values()) == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT
     )
     assert set(directx["directx_toolchain_gaps"]) == set(
         module.MLX_REDUCED_FRONTIER_SOURCES
     ) - set(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
-    assert (
-        "1519"
-        not in directx["directx_toolchain_gaps"][
-            "mlx/backend/metal/kernels/layer_norm.metal"
-        ]
-    )
-    assert (
-        "1519"
-        not in directx["directx_toolchain_gaps"][
-            module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE
-        ]
-    )
+    directx_gaps = directx["directx_toolchain_gaps"]
+    assert "issues/1694" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
+    assert "issues/1695" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
+    assert "issues/1696" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
+    assert "issues/1542" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
+    assert "issues/1695" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
+    assert "issues/1491" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
+    assert "issues/1524" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
+    assert "issues/1537" in directx_gaps[module.MLX_FENCE_SOURCE]
+    assert "issues/1518" not in json.dumps(directx_gaps)
+    assert directx["native_runtime_executed"] is False
+    assert directx["runtime_parity_claimed"] is False
 
     pointer_reinterpretation = expected_gaps["pointer_reinterpretation_status"]
     assert pointer_reinterpretation["status"] == "partial"
@@ -1479,7 +1487,7 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
         "static_members": 42,
     }
     assert function_local_alias["native_validation"] == {
-        "directx": "translated-dxc-blocked-by-existing-issues",
+        "directx": "dxc-validated",
         "opengl": "validated",
         "vulkan": "validated",
     }
@@ -1696,11 +1704,11 @@ def test_arg_reduce_advances_into_clean_toolchain_frontiers():
     assert module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES == (
         module.MLX_ARG_REDUCE_SOURCE,
         module.MLX_BINARY_TWO_SOURCE,
-        "mlx/backend/metal/kernels/logsumexp.metal",
-        "mlx/backend/metal/kernels/rms_norm.metal",
+        module.MLX_LOGSUMEXP_SOURCE,
+        module.MLX_RMS_NORM_SOURCE,
         module.MLX_ROPE_SOURCE,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
-        "mlx/backend/metal/kernels/softmax.metal",
+        module.MLX_SOFTMAX_SOURCE,
     )
     assert module.MLX_REDUCED_FRONTIER_SOURCES == tuple(
         sorted(
@@ -1816,7 +1824,7 @@ def test_empty_initializer_issue_is_resolved_for_pinned_quantized_nax():
     )
 
 
-def test_scaled_dot_product_attention_enters_opengl_function_constant_frontier():
+def test_scaled_dot_product_attention_enters_native_toolchain_frontiers():
     module = _load_harness()
     source = module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE
     resolved_issue = "https://github.com/CrossGL/crosstl/issues/1535"
@@ -1832,6 +1840,7 @@ def test_scaled_dot_product_attention_enters_opengl_function_constant_frontier()
     assert resolved_issue in module.RESOLVED_FRONTIER_ISSUES
     assert resolved_issue not in module.FULL_CORPUS_TRACKED_ISSUES
     assert source in module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES
+    assert source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
     assert module.OPENGL_SCALED_DOT_PRODUCT_ATTENTION_TRACKED_ISSUES == (
         function_constant_issue,
     )
@@ -3627,7 +3636,7 @@ def test_reduced_frontier_accepts_multiple_vulkan_toolchain_runs_per_artifact(
     assert module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE in toolchain_config
 
 
-def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
+def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     tmp_path, monkeypatch
 ):
     module = _load_harness()
@@ -3642,14 +3651,14 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
 
     frontier_count = len(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
     directx_subset_count = len(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
-    directx_paths = [
-        f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
+    directx_paths = {
+        source: f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
         for source in module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
-    ]
-    directx_subset_paths = [
-        f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
+    }
+    directx_subset_paths = {
+        source: f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
         for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
-    ]
+    }
     commands = []
     alias_evidence = {"source": module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE}
     monkeypatch.setattr(
@@ -3661,8 +3670,8 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
     def fake_run_command(name, command, *, log_dir, check=True, timeout_seconds=None):
         commands.append((name, list(command)))
         is_toolchain = name != "translate-directx-vulkan-frontier"
-        # The DXC compile gate runs only on the verified subset; the translation
-        # frontier still emits every frontier artifact.
+        # The DXC compile gate runs only on its eight-source frontier; the
+        # translation frontier still emits every clean frontier artifact.
         report_directx_paths = directx_subset_paths if is_toolchain else directx_paths
         report = {
             "summary": {
@@ -3683,8 +3692,13 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
                 },
             },
             "artifacts": [
-                {"target": "directx", "path": path, "status": "translated"}
-                for path in report_directx_paths
+                {
+                    "source": source,
+                    "target": "directx",
+                    "path": path,
+                    "status": "translated",
+                }
+                for source, path in report_directx_paths.items()
             ],
             "validation": {
                 "summary": {"failedCount": 0},
@@ -3693,11 +3707,23 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
                     if not is_toolchain
                     else [
                         {
+                            "source": source,
                             "target": "directx",
                             "path": path,
+                            "command": [
+                                "dxc",
+                                "-T",
+                                "cs_6_0",
+                                "-E",
+                                "CSMain" if index == 0 else f"CSMain_{index + 1}",
+                                path,
+                            ],
                             "status": "ok",
                         }
-                        for path in directx_subset_paths
+                        for source, path in directx_subset_paths.items()
+                        for index in range(
+                            module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS[source]
+                        )
                     ]
                 ),
             },
@@ -3727,9 +3753,29 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
         require_vulkan_toolchain=False,
     )
 
-    assert result["toolchainRuns"] == directx_subset_count
+    assert result["toolchainRuns"] == (module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT)
     assert result["status"] == "passed"
     assert result["directxToolchainRequired"] is True
+    assert result["directxToolchainSources"] == list(
+        module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+    )
+    assert result["directxToolchainArtifactCount"] == directx_subset_count
+    assert result["directxToolchainExpectedEntryPointCounts"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+    )
+    assert result["directxToolchainExpectedEntryPointCount"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT
+    )
+    assert result["directxToolchainValidatedSources"] == list(
+        module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+    )
+    assert result["directxToolchainValidatedArtifactCount"] == directx_subset_count
+    assert result["directxToolchainValidatedEntryPointCounts"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+    )
+    assert result["directxToolchainValidatedEntryPointCount"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT
+    )
     assert result["semanticReadinessStatus"] == "not-established"
     assert result["directxValidationStatus"] == "validated"
     assert result["vulkanValidationStatus"] == "not-run"
@@ -3742,13 +3788,13 @@ def test_reduced_frontier_requires_directx_toolchain_runs_per_artifact(
     assert "[project.specialization_constants]" in toolchain_config
     for selector, value in module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS.items():
         assert f"{json.dumps(selector)} = {json.dumps(value)}" in toolchain_config
-    # The DXC compile gate is scoped to the verified subset, not the whole
-    # frontier, so only those sources appear in the toolchain config.
+    # The DXC compile gate is scoped to its eight-source frontier, not the whole
+    # clean translation frontier, so only those sources appear in this config.
     for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES:
         assert source in toolchain_config
 
 
-def test_directx_toolchain_frontier_includes_rope_and_gap_ledger_matches():
+def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     module = _load_harness()
     gaps = json.loads(
         (ROOT / "demos" / "integrations" / "mlx" / "expected-gaps.json").read_text(
@@ -3756,14 +3802,76 @@ def test_directx_toolchain_frontier_includes_rope_and_gap_ledger_matches():
         )
     )
 
-    assert module.MLX_ROPE_SOURCE in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
-    assert module.MLX_ROPE_SOURCE in module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
+    expected_sources = (
+        module.MLX_ARANGE_SOURCE,
+        module.MLX_ARG_REDUCE_SOURCE,
+        module.MLX_LAYER_NORM_SOURCE,
+        module.MLX_LOGSUMEXP_SOURCE,
+        module.MLX_RMS_NORM_SOURCE,
+        module.MLX_ROPE_SOURCE,
+        module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
+        module.MLX_SOFTMAX_SOURCE,
+    )
+    assert module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES == expected_sources
+    assert set(expected_sources) < set(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
+    assert tuple(module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS) == expected_sources
+    assert {
+        source: module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS[source]
+        for source in (
+            module.MLX_LAYER_NORM_SOURCE,
+            module.MLX_LOGSUMEXP_SOURCE,
+            module.MLX_RMS_NORM_SOURCE,
+            module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
+            module.MLX_SOFTMAX_SOURCE,
+        )
+    } == {
+        module.MLX_LAYER_NORM_SOURCE: 12,
+        module.MLX_LOGSUMEXP_SOURCE: 6,
+        module.MLX_RMS_NORM_SOURCE: 12,
+        module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
+        module.MLX_SOFTMAX_SOURCE: 10,
+    }
+    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == sum(
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
+    )
     directx_status = gaps["directx_toolchain_status"]
     assert directx_status["specialization_constants"] == (
         module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS
     )
-    assert module.MLX_ROPE_SOURCE in directx_status["dxc_validated_sources"]
-    assert module.MLX_ROPE_SOURCE not in directx_status["directx_toolchain_gaps"]
+    assert directx_status["dxc_validated_sources"] == list(expected_sources)
+    assert directx_status["expected_entry_point_counts"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
+    )
+    assert set(directx_status["directx_toolchain_gaps"]) == {
+        module.MLX_BINARY_TWO_SOURCE,
+        "mlx/backend/metal/kernels/random.metal",
+        "mlx/backend/metal/kernels/ternary.metal",
+        module.MLX_FENCE_SOURCE,
+    }
+    assert {
+        f"https://github.com/CrossGL/crosstl/issues/{issue}"
+        for issue in (1694, 1695, 1696)
+    } <= set(gaps["tracked_issues"])
+
+
+def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
+    readme = MLX_README_PATH.read_text(encoding="utf-8")
+    normalized_readme = " ".join(readme.split())
+
+    assert "official DXC v1.9.2602.24 on Windows CI" in readme
+    assert (
+        "the eight-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`"
+        in normalized_readme
+    )
+    assert "11, 24, 12, 6, 12, 18, 42, and 10 entries respectively" in (
+        normalized_readme
+    )
+    for issue in (1694, 1695, 1696, 1542, 1491, 1524, 1537):
+        assert f"https://github.com/CrossGL/crosstl/issues/{issue}" in readme
+    assert "does not dispatch these kernels or establish numerical parity" in (
+        normalized_readme
+    )
+    assert "DirectX remains outside the DXC gate" not in readme
 
 
 def test_binary_resource_relocation_issue_is_full_corpus_only():


### PR DESCRIPTION
## Summary

- expand the pinned MLX DirectX compiler frontier from three to eight Metal kernel sources
- require official DXC v1.9.2602.24 to compile all 135 generated compute entries on Windows CI
- record per-source artifact and entry-point accounting in the portability summary and workflow assertions
- update the gap ledger with the remaining binary, random, ternary, and fence blockers

## Validation

- `/Users/nripeshn/Documents/PythonPrograms/crossgl-workspace/3/.venv/bin/python -m pytest -q -n auto tests/test_ci_workflows.py tests/test_mlx_porting_harness.py`: 134 passed
- `/Users/nripeshn/Documents/PythonPrograms/crossgl-workspace/3/.venv/bin/pre-commit run --all-files`
- `/Users/nripeshn/Documents/PythonPrograms/crossgl-workspace/3/.venv/bin/python tools/support_matrix.py check`
- `/Users/nripeshn/Documents/PythonPrograms/crossgl-workspace/3/.venv/bin/python tools/sync_support_issues.py --dry-run --repo CrossGL/crosstl`: zero desired issues
- local official DXC v1.9.2602.24 sweep compiled every generated entry for the five added sources: 12 `layer_norm`, 6 `logsumexp`, 12 `rms_norm`, 42 `scaled_dot_product_attention`, and 10 `softmax`

## Scope

This establishes HLSL compiler acceptance for the expanded frontier at MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`. It does not dispatch the generated shaders, integrate the MLX host runtime, or claim numerical parity.

Progresses #1518.

Support issue traceability: no issue closed
