### PR TITLE
Add a headless OpenGL compute runtime

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -230,7 +230,7 @@ jobs:
           - os: ubuntu-latest
             adapter: opengl
             required_tools: glslangValidator
-            install_command: sudo apt-get update && sudo apt-get install -y glslang-tools
+            install_command: sudo apt-get update && sudo apt-get install -y glslang-tools libegl1 libegl-mesa0 libgl1 libgl1-mesa-dri mesa-utils
           - os: ubuntu-latest
             adapter: vulkan
             required_tools: spirv-val,spirv-as
@@ -317,6 +317,11 @@ jobs:
         run: |
           python -m pip install vulkan==1.3.275.1
 
+      - name: Install OpenGL runtime dependency
+        if: matrix.adapter == 'opengl' && steps.probe_runtime_parity.outputs.available == 'true'
+        run: |
+          python -m pip install "moderngl>=5.10,<6"
+
       - name: Run runtime parity tests
         if: steps.probe_runtime_parity.outputs.available == 'true'
         shell: bash
@@ -333,6 +338,18 @@ jobs:
             tests/test_translator/test_native_runtime_drivers.py \
             -k "runtime_parity" \
             --junitxml support/generated/runtime-parity-${{ matrix.adapter }}-${{ matrix.os }}.xml
+
+      - name: Run OpenGL compute runtime test
+        if: matrix.adapter == 'opengl' && steps.probe_runtime_parity.outputs.available == 'true'
+        shell: bash
+        env:
+          CROSTL_RUN_OPENGL_DEVICE_TEST: "1"
+          EGL_PLATFORM: surfaceless
+          LIBGL_ALWAYS_SOFTWARE: "1"
+        run: |
+          python -m pytest -q \
+            tests/test_translator/test_native_runtime_drivers.py \
+            -k "opengl_compute_runtime_executes_vector_scale_on_device"
 
       - name: Record unavailable runtime parity adapter
         if: steps.probe_runtime_parity.outputs.available != 'true'

--- a/crosstl/project/__init__.py
+++ b/crosstl/project/__init__.py
@@ -10,7 +10,7 @@ from .host_reflection import (
     ReflectionDiagnostic,
     reflect_target_host_interface,
 )
-from .native_runtime_drivers import VulkanComputeRuntime
+from .native_runtime_drivers import OpenGLComputeRuntime, VulkanComputeRuntime
 from .pipeline import (
     RUNTIME_DEVICE_RUNNER_MANIFEST_KIND,
     ProjectConfig,
@@ -131,6 +131,7 @@ __all__ = [
     "NativeRuntimeParityAdapter",
     "NativeRuntimeValidationCommand",
     "OpenGLRuntimeParityAdapter",
+    "OpenGLComputeRuntime",
     "RuntimeAdapter",
     "RuntimeAdapterDispatchError",
     "RuntimeAdapterSetupError",

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -45,6 +45,255 @@ class _VulkanBufferResource:
     memory: Any
 
 
+@dataclass(frozen=True)
+class _PreparedOpenGLBuffer:
+    name: str
+    binding_index: int
+    resource_kind: str | None
+    dtype: str
+    shape: tuple[int, ...]
+    source: str | None
+    output_name: str | None
+    payload: bytes
+
+    @property
+    def size(self) -> int:
+        return len(self.payload)
+
+
+class OpenGLComputeRuntime:
+    """Optional headless OpenGL compute runtime for buffer fixtures.
+
+    ModernGL is imported lazily so the runtime remains optional. Context
+    creation prefers EGL before allowing ModernGL to choose its platform
+    default.
+    """
+
+    name = "opengl-compute-runtime"
+
+    def __init__(
+        self,
+        *,
+        module_loader: Any | None = None,
+        context_factory: Any | None = None,
+        context_backends: Sequence[str | None] = ("egl", None),
+        require_version: int = 430,
+    ):
+        self._module_loader = module_loader or importlib.import_module
+        self._context_factory = context_factory
+        self.context_backends = tuple(context_backends)
+        self.require_version = int(require_version)
+
+    def is_available(
+        self,
+        adapter: Any,
+        request: RuntimeExecutionRequest,
+    ) -> RuntimeExecutorAvailability:
+        _ = adapter, request
+        try:
+            moderngl = self._load_moderngl()
+        except RuntimeExecutorUnavailable as exc:
+            return RuntimeExecutorAvailability(
+                False,
+                reason=str(exc),
+                details={
+                    "reasonKind": "dependency-unavailable",
+                    "target": "opengl",
+                    "missingPythonModules": ["moderngl"],
+                },
+            )
+
+        context = None
+        try:
+            context, backend = self._create_context(moderngl)
+            version_code = int(getattr(context, "version_code", 0) or 0)
+            if version_code and version_code < self.require_version:
+                raise RuntimeExecutorUnavailable(
+                    "OpenGL compute requires context version "
+                    f"{self.require_version}, got {version_code}."
+                )
+        except Exception as exc:  # pragma: no cover - depends on local GL loader
+            return RuntimeExecutorAvailability(
+                False,
+                reason=f"OpenGL compute runtime is unavailable: {exc}",
+                details={
+                    "reasonKind": "opengl-runtime-unavailable",
+                    "target": "opengl",
+                    "error": str(exc),
+                },
+            )
+        finally:
+            _release_opengl_object(context)
+
+        return RuntimeExecutorAvailability(
+            True,
+            details={
+                "reasonKind": "available",
+                "target": "opengl",
+                "runtime": self.name,
+                "contextBackend": backend or "default",
+                "versionCode": version_code,
+            },
+        )
+
+    def load_artifact(self, adapter: Any, state: Any, module_path: Path) -> str:
+        _ = adapter, state
+        try:
+            source = Path(module_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeAdapterSetupError(
+                f"OpenGL runtime artifact could not be read: {exc}",
+                details={"target": "opengl", "modulePath": str(module_path)},
+            ) from exc
+        if not source.strip():
+            raise RuntimeAdapterSetupError(
+                "OpenGL runtime artifact is empty.",
+                details={"target": "opengl", "modulePath": str(module_path)},
+            )
+        return source
+
+    def dispatch(
+        self,
+        adapter: Any,
+        state: Any,
+        request: NativeRuntimeDispatchRequest,
+    ) -> dict[str, Mapping[str, Any]]:
+        _ = adapter, state
+        if request.entry_point not in (None, "main"):
+            raise RuntimeExecutorUnavailable(
+                "OpenGL compute artifacts expose the selected entry point as main; "
+                f"got {request.entry_point!r}."
+            )
+
+        moderngl = self._load_moderngl()
+        shader_source = self._shader_source(request)
+        prepared_buffers = _prepare_opengl_buffers(request.buffers)
+        workgroup_count = _workgroup_count(request, target="OpenGL")
+        if not prepared_buffers:
+            raise RuntimeExecutorUnavailable(
+                "OpenGL compute runtime requires at least one buffer resource."
+            )
+
+        context = None
+        shader = None
+        resources: list[tuple[_PreparedOpenGLBuffer, Any]] = []
+        try:
+            context, _backend = self._create_context(moderngl)
+            try:
+                shader = context.compute_shader(shader_source)
+            except Exception as exc:
+                raise RuntimeAdapterSetupError(
+                    f"OpenGL compute shader compilation or linking failed: {exc}",
+                    details={"target": "opengl", "runtime": self.name},
+                ) from exc
+
+            for prepared in prepared_buffers:
+                buffer = self._create_buffer(context, prepared)
+                resources.append((prepared, buffer))
+            self._bind_constants(shader, request.constants)
+            shader.run(
+                group_x=workgroup_count[0],
+                group_y=workgroup_count[1],
+                group_z=workgroup_count[2],
+            )
+            context.memory_barrier()
+            finish = getattr(context, "finish", None)
+            if callable(finish):
+                finish()
+            return self._read_outputs(resources)
+        except (RuntimeAdapterSetupError, RuntimeExecutorUnavailable):
+            raise
+        except RuntimeAdapterDispatchError:
+            raise
+        except Exception as exc:
+            raise RuntimeAdapterDispatchError(
+                f"OpenGL compute dispatch failed: {exc}",
+                details={"target": "opengl", "runtime": self.name},
+            ) from exc
+        finally:
+            for _prepared, buffer in reversed(resources):
+                _release_opengl_object(buffer)
+            _release_opengl_object(shader)
+            _release_opengl_object(context)
+
+    def _load_moderngl(self) -> Any:
+        try:
+            return self._module_loader("moderngl")
+        except Exception as exc:
+            raise RuntimeExecutorUnavailable(
+                "ModernGL is unavailable; install the optional 'moderngl' package "
+                "to run OpenGL runtime fixtures."
+            ) from exc
+
+    def _create_context(self, moderngl: Any) -> tuple[Any, str | None]:
+        if self._context_factory is not None:
+            return self._context_factory(moderngl), None
+
+        failures = []
+        for backend in self.context_backends:
+            kwargs = {"require": self.require_version}
+            if backend is not None:
+                kwargs["backend"] = backend
+            try:
+                return moderngl.create_standalone_context(**kwargs), backend
+            except Exception as exc:
+                failures.append(f"{backend or 'default'}: {exc}")
+        raise RuntimeExecutorUnavailable(
+            "No headless OpenGL compute context could be created ("
+            + "; ".join(failures)
+            + ")."
+        )
+
+    def _shader_source(self, request: NativeRuntimeDispatchRequest) -> str:
+        if isinstance(request.loaded_artifact, str):
+            return request.loaded_artifact
+        return self.load_artifact(None, None, request.module_path)
+
+    def _create_buffer(self, context: Any, prepared: _PreparedOpenGLBuffer) -> Any:
+        if prepared.payload:
+            buffer = context.buffer(prepared.payload)
+        else:
+            buffer = context.buffer(reserve=max(prepared.size, 1))
+        if prepared.resource_kind in {"constant-buffer", "uniform"}:
+            buffer.bind_to_uniform_block(prepared.binding_index)
+        else:
+            buffer.bind_to_storage_buffer(prepared.binding_index)
+        return buffer
+
+    def _bind_constants(self, shader: Any, constants: Mapping[str, Any]) -> None:
+        for name, binding in constants.items():
+            if binding.value is None:
+                raise RuntimeExecutorUnavailable(
+                    f"OpenGL runtime constant {name!r} has no bound value."
+                )
+            try:
+                uniform = shader[name]
+            except (KeyError, TypeError) as exc:
+                raise RuntimeExecutorUnavailable(
+                    f"OpenGL runtime constant {name!r} is not an active uniform."
+                ) from exc
+            value = binding.value
+            if isinstance(value, list):
+                value = tuple(value)
+            uniform.value = value
+
+    def _read_outputs(
+        self,
+        resources: Sequence[tuple[_PreparedOpenGLBuffer, Any]],
+    ) -> dict[str, Mapping[str, Any]]:
+        outputs: dict[str, Mapping[str, Any]] = {}
+        for prepared, buffer in resources:
+            if prepared.source != "expectedOutput":
+                continue
+            payload = buffer.read(size=prepared.size)
+            outputs[prepared.output_name or prepared.name] = {
+                "dtype": prepared.dtype,
+                "shape": list(prepared.shape),
+                "values": _unpack_values(payload, prepared.dtype, target="OpenGL"),
+            }
+        return outputs
+
+
 class VulkanComputeRuntime:
     """Reference Vulkan compute runtime for simple storage-buffer fixtures.
 
@@ -591,6 +840,17 @@ def _read_mapped_memory(mapped: Any, size: int) -> bytes:
         view.release()
 
 
+def _release_opengl_object(value: Any) -> None:
+    if value is None:
+        return
+    release = getattr(value, "release", None)
+    if callable(release):
+        try:
+            release()
+        except Exception:
+            pass
+
+
 def _vulkan_descriptor_type(vk: Any, resource_kind: str | None) -> Any:
     if resource_kind in {"constant-buffer", "uniform"}:
         return vk.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
@@ -632,7 +892,7 @@ def _prepare_vulkan_buffers(
                 "Vulkan compute runtime requires unique set/binding pairs."
             )
         seen_bindings.add(descriptor)
-        dtype = _normalize_dtype(binding.dtype)
+        dtype = _normalize_dtype(binding.dtype, target="Vulkan")
         shape = tuple(int(value) for value in binding.shape)
         element_count = (
             math.prod(shape) if shape else len(_flatten_values(binding.value))
@@ -640,7 +900,12 @@ def _prepare_vulkan_buffers(
         if binding.source == "expectedOutput":
             payload = b"\x00" * (element_count * _dtype_size(dtype))
         else:
-            payload = _pack_values(binding.value, dtype, expected_count=element_count)
+            payload = _pack_values(
+                binding.value,
+                dtype,
+                expected_count=element_count,
+                target="Vulkan",
+            )
         prepared.append(
             _PreparedVulkanBuffer(
                 name=name,
@@ -659,6 +924,79 @@ def _prepare_vulkan_buffers(
     )
 
 
+def _prepare_opengl_buffers(
+    bindings: Mapping[str, NativeRuntimeBufferBinding],
+) -> tuple[_PreparedOpenGLBuffer, ...]:
+    prepared = []
+    seen_bindings: set[tuple[str, int]] = set()
+    for name, binding in bindings.items():
+        resource = binding.binding
+        if resource.kind not in (
+            None,
+            "buffer",
+            "storage-buffer",
+            "constant-buffer",
+            "uniform",
+        ):
+            raise RuntimeExecutorUnavailable(
+                f"OpenGL compute runtime supports buffer resources only: {name}."
+            )
+        if resource.binding is None:
+            raise RuntimeExecutorUnavailable(
+                f"OpenGL compute runtime requires an explicit binding for {name}."
+            )
+        set_index = _int_field(resource.set, default=0)
+        if set_index != 0:
+            raise RuntimeExecutorUnavailable(
+                "OpenGL compute runtime does not support nonzero descriptor sets."
+            )
+        binding_index = _int_field(resource.binding)
+        namespace = (
+            "uniform" if resource.kind in {"constant-buffer", "uniform"} else "storage"
+        )
+        descriptor = (namespace, binding_index)
+        if descriptor in seen_bindings:
+            raise RuntimeExecutorUnavailable(
+                f"OpenGL compute runtime requires unique {namespace} buffer bindings."
+            )
+        seen_bindings.add(descriptor)
+        dtype = _normalize_dtype(binding.dtype, target="OpenGL")
+        shape = tuple(int(value) for value in binding.shape)
+        element_count = (
+            math.prod(shape) if shape else len(_flatten_values(binding.value))
+        )
+        if binding.source == "expectedOutput":
+            payload = b"\x00" * (element_count * _dtype_size(dtype))
+        else:
+            payload = _pack_values(
+                binding.value,
+                dtype,
+                expected_count=element_count,
+                target="OpenGL",
+            )
+        prepared.append(
+            _PreparedOpenGLBuffer(
+                name=name,
+                binding_index=binding_index,
+                resource_kind=resource.kind,
+                dtype=dtype,
+                shape=shape,
+                source=binding.source,
+                output_name=_runtime_value_name(binding),
+                payload=payload,
+            )
+        )
+    return tuple(
+        sorted(
+            prepared,
+            key=lambda item: (
+                item.resource_kind in {"constant-buffer", "uniform"},
+                item.binding_index,
+            ),
+        )
+    )
+
+
 def _runtime_value_name(binding: NativeRuntimeBufferBinding) -> str | None:
     value_name = binding.metadata.get("runtimeValueName")
     if isinstance(value_name, str) and value_name.strip():
@@ -666,11 +1004,15 @@ def _runtime_value_name(binding: NativeRuntimeBufferBinding) -> str | None:
     return None
 
 
-def _workgroup_count(request: NativeRuntimeDispatchRequest) -> tuple[int, int, int]:
+def _workgroup_count(
+    request: NativeRuntimeDispatchRequest,
+    *,
+    target: str = "Vulkan",
+) -> tuple[int, int, int]:
     dispatch = request.dispatch
     if dispatch is None:
         raise RuntimeExecutorUnavailable(
-            "Vulkan compute runtime requires dispatch geometry."
+            f"{target} compute runtime requires dispatch geometry."
         )
     if dispatch.workgroup_count:
         values = tuple(int(value) for value in dispatch.workgroup_count)
@@ -684,15 +1026,21 @@ def _workgroup_count(request: NativeRuntimeDispatchRequest) -> tuple[int, int, i
         )
     else:
         raise RuntimeExecutorUnavailable(
-            "Vulkan compute runtime requires workgroupCount or globalSize/workgroupSize."
+            f"{target} compute runtime requires workgroupCount or "
+            "globalSize/workgroupSize."
         )
-    return _pad3(values, field_name="workgroupCount")
+    return _pad3(values, field_name="workgroupCount", target=target)
 
 
-def _pad3(values: Sequence[int], *, field_name: str) -> tuple[int, int, int]:
+def _pad3(
+    values: Sequence[int],
+    *,
+    field_name: str,
+    target: str = "Vulkan",
+) -> tuple[int, int, int]:
     if len(values) > 3:
         raise RuntimeExecutorUnavailable(
-            f"Vulkan compute runtime {field_name} must have at most three dimensions."
+            f"{target} compute runtime {field_name} must have at most three dimensions."
         )
     padded = tuple(max(1, int(value)) for value in values) + (1,) * (3 - len(values))
     return padded[:3]
@@ -711,7 +1059,7 @@ def _int_field(value: Any, *, default: int | None = None) -> int:
         ) from exc
 
 
-def _normalize_dtype(dtype: str | None) -> str:
+def _normalize_dtype(dtype: str | None, *, target: str = "Vulkan") -> str:
     aliases = {
         "float": "float32",
         "f32": "float32",
@@ -725,7 +1073,8 @@ def _normalize_dtype(dtype: str | None) -> str:
     value = aliases.get(normalized, normalized)
     if value not in {"float32", "uint32", "int32"}:
         raise RuntimeExecutorUnavailable(
-            f"Vulkan compute runtime supports float32, uint32, and int32 buffers, not {dtype!r}."
+            f"{target} compute runtime supports float32, uint32, and int32 buffers, "
+            f"not {dtype!r}."
         )
     return value
 
@@ -751,21 +1100,36 @@ def _flatten_values(value: Any) -> list[Any]:
     return [value]
 
 
-def _pack_values(value: Any, dtype: str, *, expected_count: int) -> bytes:
+def _pack_values(
+    value: Any,
+    dtype: str,
+    *,
+    expected_count: int,
+    target: str = "Vulkan",
+) -> bytes:
     values = _flatten_values(value)
     if len(values) != expected_count:
         raise RuntimeExecutorUnavailable(
-            "Vulkan compute runtime buffer value count does not match shape."
+            f"{target} compute runtime buffer value count does not match shape."
         )
     return struct.pack("<" + _dtype_format(dtype) * expected_count, *values)
 
 
-def _unpack_values(payload: bytes, dtype: str) -> list[Any]:
+def _unpack_values(
+    payload: bytes,
+    dtype: str,
+    *,
+    target: str = "Vulkan",
+) -> list[Any]:
     size = _dtype_size(dtype)
     if len(payload) % size:
         raise RuntimeAdapterDispatchError(
-            "Vulkan runtime output byte length is not aligned to the dtype size.",
-            details={"target": "vulkan", "dtype": dtype, "byteLength": len(payload)},
+            f"{target} runtime output byte length is not aligned to the dtype size.",
+            details={
+                "target": target.lower(),
+                "dtype": dtype,
+                "byteLength": len(payload),
+            },
         )
     count = len(payload) // size
     if count == 0:

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -178,29 +178,87 @@ class OpenGLComputeRuntime:
         shader = None
         resources: list[tuple[_PreparedOpenGLBuffer, Any]] = []
         try:
-            context, _backend = self._create_context(moderngl)
+            try:
+                context, _backend = self._create_context(moderngl)
+            except Exception as exc:
+                raise RuntimeAdapterSetupError(
+                    f"OpenGL compute context creation failed: {exc}",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "context-creation-failed",
+                    },
+                ) from exc
             try:
                 shader = context.compute_shader(shader_source)
             except Exception as exc:
                 raise RuntimeAdapterSetupError(
                     f"OpenGL compute shader compilation or linking failed: {exc}",
-                    details={"target": "opengl", "runtime": self.name},
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "shader-compilation-or-linking-failed",
+                    },
                 ) from exc
 
             for prepared in prepared_buffers:
-                buffer = self._create_buffer(context, prepared)
+                try:
+                    buffer = self._create_buffer(context, prepared)
+                except Exception as exc:
+                    raise RuntimeAdapterSetupError(
+                        f"OpenGL resource binding failed for {prepared.name!r}: {exc}",
+                        details={
+                            "target": "opengl",
+                            "runtime": self.name,
+                            "reasonKind": "resource-binding-failed",
+                            "resource": prepared.name,
+                            "binding": prepared.binding_index,
+                        },
+                    ) from exc
                 resources.append((prepared, buffer))
             self._bind_constants(shader, request.constants)
-            shader.run(
-                group_x=workgroup_count[0],
-                group_y=workgroup_count[1],
-                group_z=workgroup_count[2],
-            )
-            context.memory_barrier()
-            finish = getattr(context, "finish", None)
-            if callable(finish):
-                finish()
-            return self._read_outputs(resources)
+            try:
+                shader.run(
+                    group_x=workgroup_count[0],
+                    group_y=workgroup_count[1],
+                    group_z=workgroup_count[2],
+                )
+            except Exception as exc:
+                raise RuntimeAdapterDispatchError(
+                    f"OpenGL compute dispatch failed: {exc}",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "dispatch-failed",
+                    },
+                ) from exc
+            try:
+                context.memory_barrier()
+                finish = getattr(context, "finish", None)
+                if callable(finish):
+                    finish()
+            except Exception as exc:
+                raise RuntimeAdapterDispatchError(
+                    f"OpenGL compute synchronization failed: {exc}",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "synchronization-failed",
+                    },
+                ) from exc
+            try:
+                return self._read_outputs(resources)
+            except RuntimeAdapterDispatchError:
+                raise
+            except Exception as exc:
+                raise RuntimeAdapterDispatchError(
+                    f"OpenGL compute output readback failed: {exc}",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "readback-failed",
+                    },
+                ) from exc
         except (RuntimeAdapterSetupError, RuntimeExecutorUnavailable):
             raise
         except RuntimeAdapterDispatchError:
@@ -254,28 +312,55 @@ class OpenGLComputeRuntime:
             buffer = context.buffer(prepared.payload)
         else:
             buffer = context.buffer(reserve=max(prepared.size, 1))
-        if prepared.resource_kind in {"constant-buffer", "uniform"}:
-            buffer.bind_to_uniform_block(prepared.binding_index)
-        else:
-            buffer.bind_to_storage_buffer(prepared.binding_index)
+        try:
+            if prepared.resource_kind in {"constant-buffer", "uniform"}:
+                buffer.bind_to_uniform_block(prepared.binding_index)
+            else:
+                buffer.bind_to_storage_buffer(prepared.binding_index)
+        except Exception:
+            _release_opengl_object(buffer)
+            raise
         return buffer
 
     def _bind_constants(self, shader: Any, constants: Mapping[str, Any]) -> None:
         for name, binding in constants.items():
             if binding.value is None:
-                raise RuntimeExecutorUnavailable(
-                    f"OpenGL runtime constant {name!r} has no bound value."
+                raise RuntimeAdapterSetupError(
+                    f"OpenGL runtime constant {name!r} has no bound value.",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "constant-value-missing",
+                        "constant": name,
+                    },
                 )
             try:
                 uniform = shader[name]
             except (KeyError, TypeError) as exc:
-                raise RuntimeExecutorUnavailable(
-                    f"OpenGL runtime constant {name!r} is not an active uniform."
+                raise RuntimeAdapterSetupError(
+                    f"OpenGL runtime constant {name!r} is not an active uniform.",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "active-uniform-missing",
+                        "constant": name,
+                    },
                 ) from exc
             value = binding.value
             if isinstance(value, list):
                 value = tuple(value)
-            uniform.value = value
+            try:
+                uniform.value = value
+            except Exception as exc:
+                raise RuntimeAdapterSetupError(
+                    f"OpenGL runtime constant {name!r} could not be bound: {exc}",
+                    details={
+                        "target": "opengl",
+                        "runtime": self.name,
+                        "reasonKind": "constant-binding-failed",
+                        "constant": name,
+                    },
+                ) from exc
 
     def _read_outputs(
         self,
@@ -1127,6 +1212,7 @@ def _unpack_values(
             f"{target} runtime output byte length is not aligned to the dtype size.",
             details={
                 "target": target.lower(),
+                "reasonKind": "output-layout-invalid",
                 "dtype": dtype,
                 "byteLength": len(payload),
             },

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -1609,6 +1609,10 @@ def native_runtime_parity_adapter(
         raise RuntimeVerificationError(
             f"Native runtime parity adapter is not available for {target}."
         )
+    if runtime is None and normalized == "opengl":
+        from .native_runtime_drivers import OpenGLComputeRuntime
+
+        runtime = OpenGLComputeRuntime()
     return adapter_class(runtime=runtime, **kwargs)
 
 

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import struct
 import subprocess
 from pathlib import Path
 
@@ -9,8 +10,10 @@ import pytest
 import crosstl.project as project_api
 from crosstl._crosstl import translate
 from crosstl.project.native_runtime_drivers import (
+    OpenGLComputeRuntime,
     VulkanComputeRuntime,
     _first_vulkan_handle,
+    _prepare_opengl_buffers,
     _prepare_vulkan_buffers,
     _read_mapped_memory,
     _write_mapped_memory,
@@ -18,11 +21,15 @@ from crosstl.project.native_runtime_drivers import (
 from crosstl.project.runtime_verification import (
     UNAVAILABLE,
     NativeRuntimeBufferBinding,
+    NativeRuntimeConstantBinding,
+    NativeRuntimeDispatchRequest,
     RuntimeAdapterSetupError,
     RuntimeArtifactSelector,
+    RuntimeDispatchGeometry,
     RuntimeExecutionRequest,
     RuntimeFixture,
     RuntimeResourceBinding,
+    RuntimeSpecializationConstant,
     VulkanRuntimeParityAdapter,
     verify_runtime_test_manifest,
 )
@@ -42,6 +49,321 @@ def _runtime_request(tmp_path: Path) -> RuntimeExecutionRequest:
         artifact_path=tmp_path / "out" / "vulkan" / "add.spv",
         project_root=tmp_path,
     )
+
+
+def test_opengl_compute_runtime_reports_missing_python_binding(tmp_path):
+    def missing_loader(name):
+        assert name == "moderngl"
+        raise ModuleNotFoundError(name)
+
+    runtime = OpenGLComputeRuntime(module_loader=missing_loader)
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details["reasonKind"] == "dependency-unavailable"
+    assert availability.details["missingPythonModules"] == ["moderngl"]
+
+
+def test_opengl_compute_runtime_probes_and_releases_headless_context(tmp_path):
+    class FakeContext:
+        version_code = 460
+
+        def __init__(self):
+            self.released = False
+
+        def release(self):
+            self.released = True
+
+    context = FakeContext()
+    runtime = OpenGLComputeRuntime(
+        module_loader=lambda name: object(),
+        context_factory=lambda module: context,
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is True
+    assert availability.details["runtime"] == "opengl-compute-runtime"
+    assert availability.details["versionCode"] == 460
+    assert context.released is True
+
+
+def test_opengl_compute_runtime_loads_utf8_glsl(tmp_path):
+    artifact_path = tmp_path / "add.comp"
+    artifact_path.write_text("#version 430\nvoid main() {}\n", encoding="utf-8")
+    runtime = OpenGLComputeRuntime(module_loader=lambda name: object())
+
+    assert runtime.load_artifact(None, None, artifact_path).startswith("#version 430")
+
+
+def test_prepare_opengl_buffers_packs_storage_and_uniform_buffers():
+    buffers = _prepare_opengl_buffers(
+        {
+            "lhs": NativeRuntimeBufferBinding(
+                name="lhs",
+                binding=RuntimeResourceBinding(
+                    name="lhs",
+                    kind="storage-buffer",
+                    set=0,
+                    binding=0,
+                ),
+                value=[1.0, 2.0],
+                source="input",
+                dtype="float32",
+                shape=(2,),
+            ),
+            "params": NativeRuntimeBufferBinding(
+                name="params",
+                binding=RuntimeResourceBinding(
+                    name="params",
+                    kind="constant-buffer",
+                    set=0,
+                    binding=0,
+                ),
+                value=[3],
+                source="input",
+                dtype="uint32",
+                shape=(1,),
+            ),
+            "out": NativeRuntimeBufferBinding(
+                name="out",
+                binding=RuntimeResourceBinding(
+                    name="out",
+                    kind="storage-buffer",
+                    set=0,
+                    binding=1,
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(2,),
+                metadata={"runtimeValueName": "result"},
+            ),
+        }
+    )
+
+    assert [(buffer.resource_kind, buffer.binding_index) for buffer in buffers] == [
+        ("storage-buffer", 0),
+        ("storage-buffer", 1),
+        ("constant-buffer", 0),
+    ]
+    assert buffers[0].payload == b"\x00\x00\x80?\x00\x00\x00@"
+    assert buffers[1].payload == b"\x00" * 8
+    assert buffers[1].output_name == "result"
+    assert buffers[2].payload == b"\x03\x00\x00\x00"
+
+
+def test_opengl_compute_runtime_dispatches_and_reads_storage_buffer(tmp_path):
+    class FakeUniform:
+        value = None
+
+    class FakeBuffer:
+        def __init__(self, payload):
+            self.payload = bytearray(payload)
+            self.storage_binding = None
+            self.uniform_binding = None
+            self.released = False
+
+        def bind_to_storage_buffer(self, binding):
+            self.storage_binding = binding
+
+        def bind_to_uniform_block(self, binding):
+            self.uniform_binding = binding
+
+        def read(self, size):
+            return bytes(self.payload[:size])
+
+        def release(self):
+            self.released = True
+
+    class FakeShader:
+        def __init__(self, context):
+            self.context = context
+            self.uniforms = {"scale": FakeUniform()}
+            self.run_args = None
+            self.released = False
+
+        def __getitem__(self, name):
+            return self.uniforms[name]
+
+        def run(self, **kwargs):
+            self.run_args = kwargs
+            lhs, out = self.context.buffers
+            values = struct.unpack("<2f", lhs.payload)
+            scale = self.uniforms["scale"].value
+            out.payload[:] = struct.pack("<2f", *(value * scale for value in values))
+
+        def release(self):
+            self.released = True
+
+    class FakeContext:
+        version_code = 460
+
+        def __init__(self):
+            self.buffers = []
+            self.shader = None
+            self.barrier_called = False
+            self.finish_called = False
+            self.released = False
+
+        def compute_shader(self, source):
+            assert source.startswith("#version 430")
+            self.shader = FakeShader(self)
+            return self.shader
+
+        def buffer(self, data=None, reserve=None):
+            payload = data if data is not None else b"\x00" * reserve
+            buffer = FakeBuffer(payload)
+            self.buffers.append(buffer)
+            return buffer
+
+        def memory_barrier(self):
+            self.barrier_called = True
+
+        def finish(self):
+            self.finish_called = True
+
+        def release(self):
+            self.released = True
+
+    context = FakeContext()
+    runtime = OpenGLComputeRuntime(
+        module_loader=lambda name: object(),
+        context_factory=lambda module: context,
+    )
+    request = NativeRuntimeDispatchRequest(
+        target="opengl",
+        artifact={"target": "opengl"},
+        artifact_path=tmp_path / "add.comp",
+        module_path=tmp_path / "add.comp",
+        loaded_artifact="#version 430\nvoid main() {}\n",
+        buffers={
+            "lhs": NativeRuntimeBufferBinding(
+                name="lhs",
+                binding=RuntimeResourceBinding(
+                    name="lhs", kind="storage-buffer", set=0, binding=0
+                ),
+                value=[1.0, 2.0],
+                source="input",
+                dtype="float32",
+                shape=(2,),
+            ),
+            "out": NativeRuntimeBufferBinding(
+                name="out",
+                binding=RuntimeResourceBinding(
+                    name="out", kind="storage-buffer", set=0, binding=1
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(2,),
+                metadata={"runtimeValueName": "result"},
+            ),
+        },
+        constants={
+            "scale": NativeRuntimeConstantBinding(
+                name="scale",
+                constant=RuntimeSpecializationConstant(
+                    name="scale", kind="uniform", dtype="float32"
+                ),
+                value=3.0,
+                source="input",
+            )
+        },
+        dispatch=RuntimeDispatchGeometry(entry_point="main", workgroup_count=(2, 1, 1)),
+        entry_point="main",
+    )
+
+    outputs = runtime.dispatch(None, None, request)
+
+    assert outputs == {
+        "result": {"dtype": "float32", "shape": [2], "values": [3.0, 6.0]}
+    }
+    assert context.shader.run_args == {"group_x": 2, "group_y": 1, "group_z": 1}
+    assert context.shader.uniforms["scale"].value == 3.0
+    assert context.barrier_called is True
+    assert context.finish_called is True
+    assert all(buffer.released for buffer in context.buffers)
+    assert context.shader.released is True
+    assert context.released is True
+
+
+def test_opengl_compute_runtime_is_exported_from_project_api():
+    assert project_api.OpenGLComputeRuntime is OpenGLComputeRuntime
+
+
+def test_opengl_compute_runtime_executes_vector_scale_on_device(tmp_path):
+    if os.environ.get("CROSTL_RUN_OPENGL_DEVICE_TEST") != "1":
+        pytest.skip("set CROSTL_RUN_OPENGL_DEVICE_TEST=1 to run OpenGL device test")
+    pytest.importorskip("moderngl")
+
+    source_path = tmp_path / "scale.cgl"
+    source_path.write_text(
+        """
+shader OpenGLRuntimeScale {
+    StructuredBuffer<float> input_values @ binding(0);
+    RWStructuredBuffer<float> output_values @ binding(1);
+
+    compute {
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+        void main(uint3 tid @ gl_GlobalInvocationID) {
+            float value = buffer_load(input_values, tid.x);
+            buffer_store(output_values, tid.x, value * 2.0);
+        }
+    }
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    translated = translate(
+        str(source_path),
+        backend="opengl",
+        format_output=False,
+    )
+
+    runtime = OpenGLComputeRuntime(context_backends=("egl",))
+    request = NativeRuntimeDispatchRequest(
+        target="opengl",
+        artifact={"target": "opengl"},
+        artifact_path=tmp_path / "scale.comp",
+        module_path=tmp_path / "scale.comp",
+        loaded_artifact=translated,
+        buffers={
+            "input_values": NativeRuntimeBufferBinding(
+                name="input_values",
+                binding=RuntimeResourceBinding(
+                    name="input_values", kind="storage-buffer", set=0, binding=0
+                ),
+                value=[1.5, -2.0, 4.0],
+                source="input",
+                dtype="float32",
+                shape=(3,),
+            ),
+            "output_values": NativeRuntimeBufferBinding(
+                name="output_values",
+                binding=RuntimeResourceBinding(
+                    name="output_values", kind="storage-buffer", set=0, binding=1
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(3,),
+                metadata={"runtimeValueName": "scaled"},
+            ),
+        },
+        constants={},
+        dispatch=RuntimeDispatchGeometry(entry_point="main", workgroup_count=(3, 1, 1)),
+        entry_point="main",
+    )
+
+    outputs = runtime.dispatch(None, None, request)
+
+    assert outputs == {
+        "scaled": {
+            "dtype": "float32",
+            "shape": [3],
+            "values": [3.0, -4.0, 8.0],
+        }
+    }
 
 
 def test_vulkan_compute_runtime_reports_missing_python_binding(tmp_path):

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -23,6 +23,7 @@ from crosstl.project.runtime_verification import (
     NativeRuntimeBufferBinding,
     NativeRuntimeConstantBinding,
     NativeRuntimeDispatchRequest,
+    RuntimeAdapterDispatchError,
     RuntimeAdapterSetupError,
     RuntimeArtifactSelector,
     RuntimeDispatchGeometry,
@@ -48,6 +49,30 @@ def _runtime_request(tmp_path: Path) -> RuntimeExecutionRequest:
         artifact={"target": "vulkan", "path": "out/vulkan/add.spv"},
         artifact_path=tmp_path / "out" / "vulkan" / "add.spv",
         project_root=tmp_path,
+    )
+
+
+def _opengl_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
+    return NativeRuntimeDispatchRequest(
+        target="opengl",
+        artifact={"target": "opengl"},
+        artifact_path=tmp_path / "runtime.comp",
+        module_path=tmp_path / "runtime.comp",
+        loaded_artifact="#version 430\nvoid main() {}\n",
+        buffers={
+            "output_values": NativeRuntimeBufferBinding(
+                name="output_values",
+                binding=RuntimeResourceBinding(
+                    name="output_values", kind="storage-buffer", set=0, binding=0
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(1,),
+            )
+        },
+        constants={},
+        dispatch=RuntimeDispatchGeometry(entry_point="main", workgroup_count=(1, 1, 1)),
+        entry_point="main",
     )
 
 
@@ -283,6 +308,114 @@ def test_opengl_compute_runtime_dispatches_and_reads_storage_buffer(tmp_path):
     assert context.barrier_called is True
     assert context.finish_called is True
     assert all(buffer.released for buffer in context.buffers)
+    assert context.shader.released is True
+    assert context.released is True
+
+
+def test_opengl_compute_runtime_releases_buffer_when_binding_fails(tmp_path):
+    class FailingBuffer:
+        def __init__(self):
+            self.released = False
+
+        def bind_to_storage_buffer(self, binding):
+            _ = binding
+            raise RuntimeError("storage binding unavailable")
+
+        def release(self):
+            self.released = True
+
+    class FakeShader:
+        def __init__(self):
+            self.released = False
+
+        def release(self):
+            self.released = True
+
+    class FakeContext:
+        def __init__(self):
+            self.buffer_resource = FailingBuffer()
+            self.shader = FakeShader()
+            self.released = False
+
+        def compute_shader(self, source):
+            _ = source
+            return self.shader
+
+        def buffer(self, data=None, reserve=None):
+            _ = data, reserve
+            return self.buffer_resource
+
+        def release(self):
+            self.released = True
+
+    context = FakeContext()
+    runtime = OpenGLComputeRuntime(
+        module_loader=lambda name: object(),
+        context_factory=lambda module: context,
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        runtime.dispatch(None, None, _opengl_dispatch_request(tmp_path))
+
+    assert excinfo.value.details["reasonKind"] == "resource-binding-failed"
+    assert excinfo.value.details["resource"] == "output_values"
+    assert context.buffer_resource.released is True
+    assert context.shader.released is True
+    assert context.released is True
+
+
+def test_opengl_compute_runtime_reports_synchronization_failure(tmp_path):
+    class FakeBuffer:
+        def __init__(self):
+            self.released = False
+
+        def bind_to_storage_buffer(self, binding):
+            _ = binding
+
+        def release(self):
+            self.released = True
+
+    class FakeShader:
+        def __init__(self):
+            self.released = False
+
+        def run(self, **kwargs):
+            _ = kwargs
+
+        def release(self):
+            self.released = True
+
+    class FakeContext:
+        def __init__(self):
+            self.buffer_resource = FakeBuffer()
+            self.shader = FakeShader()
+            self.released = False
+
+        def compute_shader(self, source):
+            _ = source
+            return self.shader
+
+        def buffer(self, data=None, reserve=None):
+            _ = data, reserve
+            return self.buffer_resource
+
+        def memory_barrier(self):
+            raise RuntimeError("barrier failed")
+
+        def release(self):
+            self.released = True
+
+    context = FakeContext()
+    runtime = OpenGLComputeRuntime(
+        module_loader=lambda name: object(),
+        context_factory=lambda module: context,
+    )
+
+    with pytest.raises(RuntimeAdapterDispatchError) as excinfo:
+        runtime.dispatch(None, None, _opengl_dispatch_request(tmp_path))
+
+    assert excinfo.value.details["reasonKind"] == "synchronization-failed"
+    assert context.buffer_resource.released is True
     assert context.shader.released is True
     assert context.released is True
 

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -512,6 +512,7 @@ def test_project_package_exposes_public_api_surface():
         "NativeRuntimeDispatchRequest",
         "NativeRuntimeParityAdapter",
         "NativeRuntimeValidationCommand",
+        "OpenGLComputeRuntime",
         "OpenGLRuntimeParityAdapter",
         "RuntimeAdapter",
         "RuntimeAdapterDispatchError",

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -1856,6 +1856,7 @@ def test_runtime_parity_native_factories_create_target_adapters():
     assert set(adapters) == {"directx", "opengl", "vulkan"}
     assert isinstance(adapters["directx"], DirectXRuntimeParityAdapter)
     assert isinstance(adapters["opengl"], OpenGLRuntimeParityAdapter)
+    assert adapters["opengl"].runtime.name == "opengl-compute-runtime"
     assert isinstance(adapters["vulkan"], VulkanRuntimeParityAdapter)
     assert isinstance(
         native_runtime_parity_adapter("DirectX"), DirectXRuntimeParityAdapter


### PR DESCRIPTION
## Summary

- add an optional ModernGL/EGL compute runtime for native OpenGL parity fixtures
- bind storage and uniform buffers, scalar constants, dispatch geometry, synchronization, and deterministic output readback
- select the runtime from the native OpenGL adapter factory and report phase-specific setup and dispatch failures
- execute a translated compute fixture on Linux Mesa in the runtime-parity CI matrix

## Validation

- `pre-commit run --all-files`
- `python -m pytest -q -n auto tests/test_translator` (`8668 passed, 147 skipped`)
- translated OpenGL compute dispatch and numerical readback on Mesa llvmpipe
- support matrix check and support issue dry-run

## Scope

The driver supports the runtime fixture contract for tightly packed `float32`, `uint32`, and `int32` buffers plus scalar or vector uniforms. Target physical-layout metadata for wider and packed source types remains tracked separately in #1543. This change establishes generic OpenGL execution infrastructure; it does not claim MLX-wide runtime or numerical parity.

Closes #1516
