### PR TITLE
Expand MLX ternary compiler frontiers

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -171,6 +171,7 @@ jobs:
           from demos.integrations.mlx.run_mlx_porting import (
               MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS,
               MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES,
+              MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES,
           )
 
           fence_source = "mlx/backend/metal/kernels/fence.metal"
@@ -181,15 +182,16 @@ jobs:
           )
           directx_frontier_count = len(directx_frontier_sources)
           directx_entry_point_count = sum(directx_entry_point_counts.values())
-          opengl_frontier_sources = {
-              "mlx/backend/metal/kernels/arg_reduce.metal",
+          opengl_frontier_sources = set(MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES)
+          opengl_frontier_count = len(opengl_frontier_sources)
+          required_opengl_promotions = {
               "mlx/backend/metal/kernels/binary_two.metal",
-              "mlx/backend/metal/kernels/logsumexp.metal",
-              "mlx/backend/metal/kernels/rms_norm.metal",
-              "mlx/backend/metal/kernels/rope.metal",
-              "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
-              "mlx/backend/metal/kernels/softmax.metal",
+              "mlx/backend/metal/kernels/ternary.metal",
           }
+          if not required_opengl_promotions <= opengl_frontier_sources:
+              raise SystemExit("required OpenGL frontier promotions are missing")
+          if opengl_frontier_count != 8:
+              raise SystemExit("expected 8 OpenGL toolchain frontier sources")
           payload = json.loads(
               Path("mlx-upstream/.crosstl-mlx-porting/summary.json").read_text(
                   encoding="utf-8"
@@ -334,25 +336,29 @@ jobs:
                   )
           opengl = checks["opengl-frontier"]
           if set(opengl["sources"]) != opengl_frontier_sources:
-              raise SystemExit("expected 7 OpenGL toolchain frontier sources")
+              raise SystemExit("OpenGL toolchain frontier sources are incomplete")
           if (
-              opengl["sourceCount"] != 7
-              or opengl["artifactCount"] != 7
+              opengl["sourceCount"] != opengl_frontier_count
+              or opengl["artifactCount"] != opengl_frontier_count
               or opengl["projectDiagnosticCount"] != 0
           ):
-              raise SystemExit("OpenGL frontier accounting must be 7 sources, 7 artifacts, and 0 project diagnostics")
+              raise SystemExit(
+                  "OpenGL frontier accounting must cover every configured source "
+                  "with one artifact and zero project diagnostics"
+              )
           if os.environ["RUNNER_OS"] == "Linux":
               validated_sources = set(opengl["toolchainValidatedSources"])
               validation_outputs = set(opengl["nativeValidationOutputs"])
               if (
                   opengl["toolchainRequired"] is not True
                   or opengl["nativeValidationStatus"] != "validated"
-                  or opengl["toolchainValidatedArtifactCount"] != 7
+                  or opengl["toolchainValidatedArtifactCount"]
+                  != opengl_frontier_count
                   or validated_sources != opengl_frontier_sources
                   or validation_outputs != opengl_frontier_sources
               ):
                   raise SystemExit(
-                      "OpenGL frontier toolchain must validate all 7 source paths"
+                      "OpenGL frontier toolchain must validate every source path"
                   )
           PY
 

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -58,23 +58,24 @@ The current harness verifies:
   and both OpenGL-derived and native SPIR-V validation run in the required Linux
   toolchain gate;
 - DirectX HLSL smoke checks with official DXC v1.9.2602.24 on Windows CI for
-  the eight-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`,
+  the nine-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`,
   `logsumexp.metal`, `rms_norm.metal`, `rope.metal`,
-  `scaled_dot_product_attention.metal`, and `softmax.metal` frontier. At the
-  pinned revision the gate compiles every generated compute entry: 11, 24, 12,
-  6, 12, 18, 42, and 10 entries respectively. The pinned rope translation
+  `scaled_dot_product_attention.metal`, `softmax.metal`, and `ternary.metal`
+  frontier. At the pinned revision the gate compiles every generated compute
+  entry: 11, 24, 12, 6, 12, 18, 42, 10, and 212 entries respectively, for 347
+  generated compute entries in total. The pinned rope translation
   supplies required function constant IDs through the quoted `"1"`, `"2"`, and
   `"3"` selectors in `[project.specialization_constants]` and materializes the
-  concrete DirectX variant before compilation. `binary_two.metal` remains
-  outside the gate under [#1694](https://github.com/CrossGL/crosstl/issues/1694)
-  and [#1695](https://github.com/CrossGL/crosstl/issues/1695), `random.metal`
-  under [#1696](https://github.com/CrossGL/crosstl/issues/1696) with runtime
-  dispatch metadata still tracked by
-  [#1542](https://github.com/CrossGL/crosstl/issues/1542), and `ternary.metal`
-  first under [#1695](https://github.com/CrossGL/crosstl/issues/1695), with later
-  entries still dependent on
-  [#1491](https://github.com/CrossGL/crosstl/issues/1491) and
-  [#1524](https://github.com/CrossGL/crosstl/issues/1524). `fence.metal` is
+  concrete DirectX variant before compilation. Aggregate conditional lowering
+  completed under [#1695](https://github.com/CrossGL/crosstl/issues/1695) admits
+  every pinned `ternary.metal` entry to this compiler gate. `binary_two.metal`
+  remains outside the gate under
+  [#1694](https://github.com/CrossGL/crosstl/issues/1694) and
+  [#1701](https://github.com/CrossGL/crosstl/issues/1701), while `random.metal`
+  remains outside the gate under
+  [#1696](https://github.com/CrossGL/crosstl/issues/1696), with runtime dispatch
+  metadata still tracked by
+  [#1542](https://github.com/CrossGL/crosstl/issues/1542). `fence.metal` is
   excluded because its DirectX translation intentionally fails under
   [#1537](https://github.com/CrossGL/crosstl/issues/1537) before DXC. This gate
   establishes compiler acceptance only; it does not dispatch these kernels or
@@ -86,13 +87,13 @@ The current harness verifies:
 - OpenGL artifact generation for `arange.metal`, including deterministic
   separation of the source `float` and `bfloat16_t` helper declarations after
   both map to GLSL `float` and source-typed call rewriting coverage;
-- OpenGL artifact generation for the clean seven-source `arg_reduce.metal`,
+- OpenGL artifact generation for the clean eight-source `arg_reduce.metal`,
   `binary_two.metal`, `logsumexp.metal`, `rms_norm.metal`, `rope.metal`,
-  `scaled_dot_product_attention.metal`, and `softmax.metal` frontier. Project
-  translation must emit seven artifacts with zero diagnostics. In the
-  CI-required mode every artifact compiles for OpenGL/SPIR-V 1.3 and passes
-  `spirv-val`. This is native artifact validation only; the gate does not run
-  the kernels or establish runtime parity;
+  `scaled_dot_product_attention.metal`, `softmax.metal`, and `ternary.metal`
+  frontier. Project translation must emit eight artifacts with zero diagnostics.
+  In the CI-required mode every artifact compiles for OpenGL/SPIR-V 1.3 and
+  passes `spirv-val`. This is native artifact validation only; the gate does not
+  run the kernels or establish runtime parity;
 - on Linux CI, full project materialization of `gemv.metal` to OpenGL followed
   by native GLSL compilation and SPIR-V 1.3 validation for all 225 source
   specializations represented by the generated artifact;
@@ -132,6 +133,8 @@ those reports, generated logs, available generated artifacts, and a concise JSON
 summary.
 Because `binary_two.metal` was already in the DirectX/Vulkan frontier, its OpenGL
 promotion does not change either reduced source count.
+The same applies to `ternary.metal`: its OpenGL promotion expands the native
+toolchain gate without changing the 11-source clean reduced frontier.
 
 The checked-in historical full-corpus scout snapshot against MLX revision
 `968d264f2903d578e699c4452a4dbf48633921aa`
@@ -290,8 +293,8 @@ the fixed arrays of resource aliases introduced by the pinned revision's wide
 quantized matrix-vector helpers. CrossGL/crosstl#1671 tracks workgroup backing
 provenance through nested FFT helper parameters. CrossGL/crosstl#1672 tracks
 owner-dependent `constexpr` helper calls in quantized struct static members.
-CrossGL/crosstl#1491 tracks remaining qualified-static-constant materialization,
-including the current `ternary.metal` DirectX exclusion.
+CrossGL/crosstl#1491 tracks remaining qualified-static-constant materialization
+outside the compiler-validated DirectX frontier.
 Built-in overloads are resolved alongside user-defined wrappers by source
 signature.
 Before native validation, the harness verifies
@@ -302,7 +305,7 @@ target. It first compiles the focused scalar-conversion fixtures successfully,
 then compiles the translated `arange.metal` artifact. Shuffle-and-fill wrappers
 lower through backend-neutral subgroup semantics and preserve their explicit
 fill value for lanes below the delta.
-The reduced DirectX/Vulkan frontier and the seven-source OpenGL artifact gate
+The reduced DirectX/Vulkan frontier and the eight-source OpenGL artifact gate
 include `scaled_dot_product_attention.metal`. Function-local scalar
 and vector aliases now retain lexical scope and resolve across declarations,
 constructors, casts, and generic static-member owners. For the pinned attention
@@ -345,7 +348,7 @@ compiles for OpenGL/SPIR-V 1.3, and the resulting SPIR-V passes `spirv-val`. Thi
 resolves [#1661](https://github.com/CrossGL/crosstl/issues/1661) for the pinned
 frontier. It is artifact and toolchain evidence only; it does not establish
 numerical or runtime parity.
-The seven-source OpenGL/SPIR-V gate includes `rms_norm.metal`, `rope.metal`, and
+The eight-source OpenGL/SPIR-V gate includes `rms_norm.metal`, `rope.metal`, and
 `scaled_dot_product_attention.metal`. Their Metal function constants retain
 their numeric identifiers as native GLSL specialization constants; the gate
 compiles each generated module for OpenGL/SPIR-V 1.3 and validates the resulting

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -119,14 +119,15 @@
       "mlx/backend/metal/kernels/rms_norm.metal",
       "mlx/backend/metal/kernels/rope.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
-      "mlx/backend/metal/kernels/softmax.metal"
+      "mlx/backend/metal/kernels/softmax.metal",
+      "mlx/backend/metal/kernels/ternary.metal"
     ],
-    "source_count": 7,
+    "source_count": 8,
     "target": "opengl",
-    "artifact_count": 7,
+    "artifact_count": 8,
     "project_diagnostic_count": 0,
-    "glslang_compiled_artifact_count": 7,
-    "spirv_validated_artifact_count": 7,
+    "glslang_compiled_artifact_count": 8,
+    "spirv_validated_artifact_count": 8,
     "glslang_target_environments": [
       "opengl",
       "spirv1.3"
@@ -394,7 +395,7 @@
   },
   "directx_toolchain_status": {
     "status": "passing",
-    "note": "Windows CI compiles every generated compute entry in the eight-source DirectX HLSL frontier below. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity. binary_two.metal, random.metal, and ternary.metal remain outside the clean-frontier DXC gate for the listed defects; fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
+    "note": "Windows CI compiles all 347 generated compute entries in the nine-source DirectX HLSL frontier below. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity. binary_two.metal and random.metal remain outside the clean-frontier DXC gate for the listed defects; fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
     "compiler": {
       "name": "dxc",
       "version": "v1.9.2602.24"
@@ -419,7 +420,8 @@
       "mlx/backend/metal/kernels/rms_norm.metal": 12,
       "mlx/backend/metal/kernels/rope.metal": 18,
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": 42,
-      "mlx/backend/metal/kernels/softmax.metal": 10
+      "mlx/backend/metal/kernels/softmax.metal": 10,
+      "mlx/backend/metal/kernels/ternary.metal": 212
     },
     "dxc_validated_sources": [
       "mlx/backend/metal/kernels/arange.metal",
@@ -429,12 +431,12 @@
       "mlx/backend/metal/kernels/rms_norm.metal",
       "mlx/backend/metal/kernels/rope.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
-      "mlx/backend/metal/kernels/softmax.metal"
+      "mlx/backend/metal/kernels/softmax.metal",
+      "mlx/backend/metal/kernels/ternary.metal"
     ],
     "directx_toolchain_gaps": {
-      "mlx/backend/metal/kernels/binary_two.metal": "generated HLSL still has target-ABI signature collisions when distinct Metal scalar overloads collapse (https://github.com/CrossGL/crosstl/issues/1694) and structure-valued conditional expressions that require aggregate lowering instead of HLSL struct operators (https://github.com/CrossGL/crosstl/issues/1695)",
+      "mlx/backend/metal/kernels/binary_two.metal": "generated HLSL still has target-ABI signature collisions when distinct Metal scalar overloads collapse (https://github.com/CrossGL/crosstl/issues/1694) and minimum-precision signed integer division and remainder operations that require widening before DXC compilation (https://github.com/CrossGL/crosstl/issues/1701)",
       "mlx/backend/metal/kernels/random.metal": "union-backed aliases still require storage-preserving HLSL lowering (https://github.com/CrossGL/crosstl/issues/1696); reflected dispatch-grid cbuffer binding and dispatch-plan metadata also remain required before native execution (https://github.com/CrossGL/crosstl/issues/1542)",
-      "mlx/backend/metal/kernels/ternary.metal": "DXC first rejects a structure-valued conditional expression that requires aggregate lowering instead of HLSL struct operators (https://github.com/CrossGL/crosstl/issues/1695); later entries still depend on qualified static-constant and concrete type-trait value materialization (https://github.com/CrossGL/crosstl/issues/1491, https://github.com/CrossGL/crosstl/issues/1524)",
       "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)"
     },
     "native_runtime_executed": false,
@@ -604,8 +606,8 @@
     "https://github.com/CrossGL/crosstl/issues/1671",
     "https://github.com/CrossGL/crosstl/issues/1672",
     "https://github.com/CrossGL/crosstl/issues/1694",
-    "https://github.com/CrossGL/crosstl/issues/1695",
     "https://github.com/CrossGL/crosstl/issues/1696",
+    "https://github.com/CrossGL/crosstl/issues/1701",
     "https://github.com/CrossGL/crosstl/issues/1312",
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1676",
@@ -644,6 +646,7 @@
     "https://github.com/CrossGL/crosstl/issues/1660"
   ],
   "resolved_issues": [
+    "https://github.com/CrossGL/crosstl/issues/1695",
     "https://github.com/CrossGL/crosstl/issues/1667",
     "https://github.com/CrossGL/crosstl/issues/1668",
     "https://github.com/CrossGL/crosstl/issues/1661",

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -46,6 +46,7 @@ MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE = (
     "mlx/backend/metal/kernels/scaled_dot_product_attention.metal"
 )
 MLX_SOFTMAX_SOURCE = "mlx/backend/metal/kernels/softmax.metal"
+MLX_TERNARY_SOURCE = "mlx/backend/metal/kernels/ternary.metal"
 REFERENCE_ACCESSOR_FIXTURE_NAME = "reference_accessor_lvalue.metal"
 REFERENCE_ACCESSOR_FIXTURE_PATH = (
     Path(__file__).resolve().parent / "fixtures" / REFERENCE_ACCESSOR_FIXTURE_NAME
@@ -61,6 +62,7 @@ MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES = (
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
     MLX_SOFTMAX_SOURCE,
+    MLX_TERNARY_SOURCE,
 )
 MLX_DIRECTX_VULKAN_FRONTIER_SOURCES = (
     MLX_ARANGE_SOURCE,
@@ -73,7 +75,7 @@ MLX_DIRECTX_VULKAN_FRONTIER_SOURCES = (
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
     MLX_SOFTMAX_SOURCE,
-    "mlx/backend/metal/kernels/ternary.metal",
+    MLX_TERNARY_SOURCE,
 )
 MLX_CLEAN_REDUCED_FRONTIER_SOURCES = tuple(
     dict.fromkeys(
@@ -106,6 +108,7 @@ MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = (
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
     MLX_SOFTMAX_SOURCE,
+    MLX_TERNARY_SOURCE,
 )
 # Pinned generated compute entries compiled by official DXC v1.9.2602.24.
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
@@ -117,6 +120,7 @@ MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
     MLX_ROPE_SOURCE: 18,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
     MLX_SOFTMAX_SOURCE: 10,
+    MLX_TERNARY_SOURCE: 212,
 }
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT = sum(
     MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
@@ -280,6 +284,7 @@ FULL_CORPUS_TRACKED_ISSUES = (
     *METAL_ROUNDTRIP_SEMANTIC_TRACKED_ISSUES,
 )
 RESOLVED_FRONTIER_ISSUES = (
+    "https://github.com/CrossGL/crosstl/issues/1695",
     "https://github.com/CrossGL/crosstl/issues/1667",
     "https://github.com/CrossGL/crosstl/issues/1668",
     "https://github.com/CrossGL/crosstl/issues/1661",

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2167,12 +2167,13 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
         "reference accessor {target} const-read evidence is incomplete" in mlx_porting
     )
     assert "reference accessor {target} native validation must be" in mlx_porting
-    assert "expected 7 OpenGL toolchain frontier sources" in mlx_porting
-    assert (
-        "OpenGL frontier accounting must be 7 sources, 7 artifacts, "
-        "and 0 project diagnostics"
-    ) in mlx_porting
-    assert "OpenGL frontier toolchain must validate all 7 source paths" in mlx_porting
+    assert "MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES" in mlx_porting
+    assert "expected 8 OpenGL toolchain frontier sources" in mlx_porting
+    assert "OpenGL frontier accounting must cover every configured source" in (
+        mlx_porting
+    )
+    assert "with one artifact and zero project diagnostics" in mlx_porting
+    assert "OpenGL frontier toolchain must validate every source path" in mlx_porting
     assert "mlx/backend/metal/kernels/binary_two.metal" in mlx_porting
     assert "mesa-vulkan-drivers" in mlx_porting
     assert "python -m pip install vulkan==1.3.275.1" in mlx_porting

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -1304,8 +1304,9 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
         module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES
     )
     assert opengl_frontier["project_diagnostic_count"] == 0
-    assert opengl_frontier["glslang_compiled_artifact_count"] == 7
-    assert opengl_frontier["spirv_validated_artifact_count"] == 7
+    assert len(module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES) == 8
+    assert opengl_frontier["glslang_compiled_artifact_count"] == 8
+    assert opengl_frontier["spirv_validated_artifact_count"] == 8
     assert opengl_frontier["glslang_target_environments"] == [
         "opengl",
         "spirv1.3",
@@ -1333,13 +1334,12 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     ) - set(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
     directx_gaps = directx["directx_toolchain_gaps"]
     assert "issues/1694" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
-    assert "issues/1695" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
+    assert "issues/1701" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
     assert "issues/1696" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
     assert "issues/1542" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
-    assert "issues/1695" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
-    assert "issues/1491" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
-    assert "issues/1524" in directx_gaps["mlx/backend/metal/kernels/ternary.metal"]
+    assert module.MLX_TERNARY_SOURCE not in directx_gaps
     assert "issues/1537" in directx_gaps[module.MLX_FENCE_SOURCE]
+    assert "issues/1695" not in json.dumps(directx_gaps)
     assert "issues/1518" not in json.dumps(directx_gaps)
     assert directx["native_runtime_executed"] is False
     assert directx["runtime_parity_claimed"] is False
@@ -1709,6 +1709,7 @@ def test_arg_reduce_advances_into_clean_toolchain_frontiers():
         module.MLX_ROPE_SOURCE,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
         module.MLX_SOFTMAX_SOURCE,
+        module.MLX_TERNARY_SOURCE,
     )
     assert module.MLX_REDUCED_FRONTIER_SOURCES == tuple(
         sorted(
@@ -1754,6 +1755,41 @@ def test_binary_two_advances_into_opengl_toolchain_frontier_without_source_growt
         "resolved_issue": issue,
         "resolved_by_commit": "db593d19bfa04b7a58ef9f4b6b224842d802173f",
     }
+
+
+def test_opengl_toolchain_frontier_matches_pinned_validator_inventory():
+    module = _load_harness()
+    expected_gaps = json.loads(
+        (ROOT / "demos" / "integrations" / "mlx" / "expected-gaps.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected_sources = (
+        module.MLX_ARG_REDUCE_SOURCE,
+        module.MLX_BINARY_TWO_SOURCE,
+        module.MLX_LOGSUMEXP_SOURCE,
+        module.MLX_RMS_NORM_SOURCE,
+        module.MLX_ROPE_SOURCE,
+        module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
+        module.MLX_SOFTMAX_SOURCE,
+        module.MLX_TERNARY_SOURCE,
+    )
+
+    assert module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES == expected_sources
+    assert len(expected_sources) == 8
+    status = expected_gaps["opengl_frontier_status"]
+    assert status["sources"] == list(expected_sources)
+    assert status["source_count"] == 8
+    assert status["artifact_count"] == 8
+    assert status["glslang_compiled_artifact_count"] == 8
+    assert status["spirv_validated_artifact_count"] == 8
+    assert status["runtime_integration_included"] is False
+    assert status["runtime_parity_claimed"] is False
+
+    workflow = MLX_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES" in workflow
+    assert "if opengl_frontier_count != 8:" in workflow
+    assert "expected 8 OpenGL toolchain frontier sources" in workflow
 
 
 def test_fence_is_blocked_outside_clean_and_directx_toolchain_frontiers():
@@ -2330,6 +2366,8 @@ def test_opengl_frontier_required_toolchain_compiles_and_validates_artifacts(
         "validate-scaled-dot-product-attention-opengl-spirv",
         "validate-softmax-opengl",
         "validate-softmax-opengl-spirv",
+        "validate-ternary-opengl",
+        "validate-ternary-opengl-spirv",
     ]
     assert commands[1][1][:5] == [
         "/tools/glslangValidator",
@@ -2363,6 +2401,7 @@ def test_opengl_frontier_required_toolchain_compiles_and_validates_artifacts(
     for source in module.MLX_OPENGL_TOOLCHAIN_FRONTIER_SOURCES:
         assert source in config
     assert module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE in config
+    assert module.MLX_TERNARY_SOURCE in config
     assert "mlx/backend/metal/kernels/rms_norm.metal" in config
     assert 'targets = ["opengl"]' in config
 
@@ -3670,7 +3709,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     def fake_run_command(name, command, *, log_dir, check=True, timeout_seconds=None):
         commands.append((name, list(command)))
         is_toolchain = name != "translate-directx-vulkan-frontier"
-        # The DXC compile gate runs only on its eight-source frontier; the
+        # The DXC compile gate runs only on its configured source frontier; the
         # translation frontier still emits every clean frontier artifact.
         report_directx_paths = directx_subset_paths if is_toolchain else directx_paths
         report = {
@@ -3788,7 +3827,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert "[project.specialization_constants]" in toolchain_config
     for selector, value in module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS.items():
         assert f"{json.dumps(selector)} = {json.dumps(value)}" in toolchain_config
-    # The DXC compile gate is scoped to its eight-source frontier, not the whole
+    # The DXC compile gate is scoped to its configured frontier, not the whole
     # clean translation frontier, so only those sources appear in this config.
     for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES:
         assert source in toolchain_config
@@ -3811,6 +3850,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_ROPE_SOURCE,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
         module.MLX_SOFTMAX_SOURCE,
+        module.MLX_TERNARY_SOURCE,
     )
     assert module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES == expected_sources
     assert set(expected_sources) < set(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
@@ -3823,6 +3863,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
             module.MLX_RMS_NORM_SOURCE,
             module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
             module.MLX_SOFTMAX_SOURCE,
+            module.MLX_TERNARY_SOURCE,
         )
     } == {
         module.MLX_LAYER_NORM_SOURCE: 12,
@@ -3830,10 +3871,13 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_RMS_NORM_SOURCE: 12,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
         module.MLX_SOFTMAX_SOURCE: 10,
+        module.MLX_TERNARY_SOURCE: 212,
     }
+    assert len(expected_sources) == 9
     assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == sum(
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
     )
+    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 347
     directx_status = gaps["directx_toolchain_status"]
     assert directx_status["specialization_constants"] == (
         module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS
@@ -3845,13 +3889,16 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     assert set(directx_status["directx_toolchain_gaps"]) == {
         module.MLX_BINARY_TWO_SOURCE,
         "mlx/backend/metal/kernels/random.metal",
-        "mlx/backend/metal/kernels/ternary.metal",
         module.MLX_FENCE_SOURCE,
     }
     assert {
         f"https://github.com/CrossGL/crosstl/issues/{issue}"
-        for issue in (1694, 1695, 1696)
+        for issue in (1694, 1696, 1701)
     } <= set(gaps["tracked_issues"])
+    aggregate_issue = "https://github.com/CrossGL/crosstl/issues/1695"
+    assert aggregate_issue in module.RESOLVED_FRONTIER_ISSUES
+    assert aggregate_issue in gaps["resolved_issues"]
+    assert aggregate_issue not in gaps["tracked_issues"]
 
 
 def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
@@ -3860,13 +3907,14 @@ def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
 
     assert "official DXC v1.9.2602.24 on Windows CI" in readme
     assert (
-        "the eight-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`"
+        "the nine-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`"
         in normalized_readme
     )
-    assert "11, 24, 12, 6, 12, 18, 42, and 10 entries respectively" in (
+    assert "11, 24, 12, 6, 12, 18, 42, 10, and 212 entries respectively" in (
         normalized_readme
     )
-    for issue in (1694, 1695, 1696, 1542, 1491, 1524, 1537):
+    assert "347 generated compute entries" in normalized_readme
+    for issue in (1694, 1695, 1696, 1701, 1542, 1537):
         assert f"https://github.com/CrossGL/crosstl/issues/{issue}" in readme
     assert "does not dispatch these kernels or establish numerical parity" in (
         normalized_readme


### PR DESCRIPTION
## Summary

- add pinned `ternary.metal` to the DirectX compiler frontier, raising the gate to 9 sources and 347 generated compute entries
- add the same source to the OpenGL toolchain frontier, raising that gate to 8 translated and validated artifacts
- derive workflow accounting from the harness inventories and update the machine-readable expected-gap record
- record aggregate conditional lowering as resolved while retaining the independent `binary_two.metal`, `random.metal`, and fence blockers

## Validation

- official DXC `v1.9.2602.24` compiled all 212 generated `ternary.metal` compute entries as `cs_6_0`
- `glslangValidator --target-env opengl --target-env spirv1.3` compiled the generated OpenGL artifact
- `spirv-val --target-env spv1.3` validated the resulting module
- the real pinned reduced-frontier harness passed with the OpenGL toolchain required
- `python -m pytest -q -n auto tests/test_mlx_porting_harness.py tests/test_ci_workflows.py` (`135 passed`)
- `pre-commit run --all-files`
- support matrix check and support issue dry-run (`0` desired issues)

This expands compiler and artifact validation only. It does not claim Direct3D/OpenGL dispatch or MLX numerical parity.

Support issue traceability: no issue closed
