### PR TITLE
Add a Direct3D compute runtime driver

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -362,6 +362,56 @@ jobs:
             echo "- Missing tools: ${{ steps.probe_runtime_parity.outputs.missing }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  directx-native-runtime-smoke:
+    name: Direct3D 12 Native Runtime Smoke (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install DirectX Shader Compiler
+        shell: pwsh
+        run: |
+          $ProgressPreference = "SilentlyContinue"
+          $archive = Join-Path $env:RUNNER_TEMP "dxc.zip"
+          $dxcRoot = Join-Path $env:RUNNER_TEMP "dxc"
+          $dxcUri = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/dxc_2026_02_20.zip"
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            try {
+              Invoke-WebRequest -Uri $dxcUri -OutFile $archive
+              break
+            } catch {
+              if ($attempt -eq 5) {
+                throw
+              }
+              Write-Warning "DXC download failed on attempt $attempt; retrying."
+              Start-Sleep -Seconds (10 * $attempt)
+            }
+          }
+          Expand-Archive -Path $archive -DestinationPath $dxcRoot -Force
+          $dxc = Get-ChildItem -Path $dxcRoot -Recurse -Filter dxc.exe |
+            Where-Object { $_.FullName -match "\\bin\\x64\\dxc.exe$" } |
+            Select-Object -First 1
+          if ($null -eq $dxc) {
+            throw "dxc.exe not found in release archive."
+          }
+          $dxc.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install Direct3D runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[directx-runtime]"
+
+      - name: Run native Direct3D runtime smoke test
+        run: python tools/directx_runtime_smoke.py
+
   compiler-smoke-linux:
     name: Compiler Smoke (Linux CUDA/DXC/SPIR-V/Slang)
     runs-on: ubuntu-24.04

--- a/crosstl/project/__init__.py
+++ b/crosstl/project/__init__.py
@@ -10,7 +10,11 @@ from .host_reflection import (
     ReflectionDiagnostic,
     reflect_target_host_interface,
 )
-from .native_runtime_drivers import OpenGLComputeRuntime, VulkanComputeRuntime
+from .native_runtime_drivers import (
+    DirectXComputeRuntime,
+    OpenGLComputeRuntime,
+    VulkanComputeRuntime,
+)
 from .pipeline import (
     RUNTIME_DEVICE_RUNNER_MANIFEST_KIND,
     ProjectConfig,
@@ -124,6 +128,7 @@ __all__ = [
     "REFLECTION_TOOL_UNAVAILABLE",
     "REFLECTION_UNSUPPORTED_FORMAT",
     "ReflectionDiagnostic",
+    "DirectXComputeRuntime",
     "DirectXRuntimeParityAdapter",
     "NativeRuntimeBufferBinding",
     "NativeRuntimeConstantBinding",

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import ctypes
 import importlib
 import math
+import re
 import struct
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -19,6 +21,40 @@ from .runtime_verification import (
     RuntimeExecutorAvailability,
     RuntimeExecutorUnavailable,
 )
+
+
+@dataclass(frozen=True)
+class _PreparedDirectXBuffer:
+    name: str
+    namespace: str
+    binding_index: int
+    dtype: str
+    shape: tuple[int, ...]
+    source: str | None
+    output_name: str | None
+    payload: bytes
+    allocation_size: int
+    stride: int = 0
+
+    @property
+    def size(self) -> int:
+        return len(self.payload)
+
+
+@dataclass
+class _DirectXBufferResource:
+    prepared: _PreparedDirectXBuffer
+    upload_buffer: Any
+    device_buffer: Any
+
+
+@dataclass(frozen=True)
+class _DirectXConstantValue:
+    name: str
+    binding_index: int
+    byte_offset: int
+    dtype: str
+    payload: bytes
 
 
 @dataclass(frozen=True)
@@ -59,6 +95,407 @@ class _PreparedOpenGLBuffer:
     @property
     def size(self) -> int:
         return len(self.payload)
+
+
+class DirectXComputeRuntime:
+    """Optional Direct3D 12 compute runtime for buffer fixtures.
+
+    ``compushady`` is imported lazily and receives the DXIL emitted by the
+    native DirectX parity adapter. Its descriptor-list API represents
+    contiguous CBV, SRV, and UAV registers in space zero; unsupported layouts
+    are rejected before resource creation.
+    """
+
+    name = "directx-compute-runtime"
+    supported_platforms = ("win32", "cygwin")
+
+    def __init__(
+        self,
+        *,
+        module_loader: Any | None = None,
+        platform_name: str | None = None,
+    ):
+        self._module_loader = module_loader or importlib.import_module
+        self.platform_name = platform_name or sys.platform
+
+    def is_available(
+        self,
+        adapter: Any,
+        request: RuntimeExecutionRequest,
+    ) -> RuntimeExecutorAvailability:
+        _ = adapter, request
+        if not self._platform_supported():
+            return RuntimeExecutorAvailability(
+                False,
+                reason=(
+                    "Direct3D 12 compute runtime is available on Windows only; "
+                    f"current platform is {self.platform_name}."
+                ),
+                details={
+                    "reasonKind": "platform-unavailable",
+                    "target": "directx",
+                    "platform": self.platform_name,
+                    "requiredPlatforms": list(self.supported_platforms),
+                },
+            )
+        try:
+            compushady = self._load_compushady()
+        except RuntimeExecutorUnavailable as exc:
+            return RuntimeExecutorAvailability(
+                False,
+                reason=str(exc),
+                details={
+                    "reasonKind": "dependency-unavailable",
+                    "target": "directx",
+                    "missingPythonModules": ["compushady"],
+                },
+            )
+
+        try:
+            backend = compushady.get_backend()
+        except Exception as exc:  # pragma: no cover - depends on local D3D loader
+            return RuntimeExecutorAvailability(
+                False,
+                reason=f"Direct3D 12 backend initialization failed: {exc}",
+                details={
+                    "reasonKind": "direct3d-runtime-unavailable",
+                    "target": "directx",
+                    "error": str(exc),
+                },
+            )
+        backend_name = _compushady_backend_name(backend)
+        if backend_name != "d3d12":
+            return RuntimeExecutorAvailability(
+                False,
+                reason=(
+                    "compushady is not using its Direct3D 12 backend; "
+                    f"active backend is {backend_name or 'unknown'}."
+                ),
+                details={
+                    "reasonKind": "backend-unavailable",
+                    "target": "directx",
+                    "requiredBackend": "d3d12",
+                    "activeBackend": backend_name,
+                },
+            )
+        try:
+            device = self._select_device(compushady)
+        except Exception as exc:  # pragma: no cover - depends on local adapters
+            return RuntimeExecutorAvailability(
+                False,
+                reason=f"No Direct3D 12 compute device is available: {exc}",
+                details={
+                    "reasonKind": "device-unavailable",
+                    "target": "directx",
+                    "runtime": self.name,
+                    "error": str(exc),
+                },
+            )
+        if device is None:
+            return RuntimeExecutorAvailability(
+                False,
+                reason="No Direct3D 12 compute device is available.",
+                details={
+                    "reasonKind": "device-unavailable",
+                    "target": "directx",
+                    "runtime": self.name,
+                },
+            )
+
+        details: dict[str, Any] = {
+            "reasonKind": "available",
+            "target": "directx",
+            "runtime": self.name,
+            "backend": backend_name,
+        }
+        device_name = getattr(device, "name", None)
+        if isinstance(device_name, str) and device_name:
+            details["device"] = device_name
+        for field_name, detail_name in (
+            ("is_hardware", "isHardware"),
+            ("is_discrete", "isDiscrete"),
+        ):
+            value = getattr(device, field_name, None)
+            if isinstance(value, bool):
+                details[detail_name] = value
+        return RuntimeExecutorAvailability(True, details=details)
+
+    def load_artifact(self, adapter: Any, state: Any, module_path: Path) -> bytes:
+        _ = adapter, state
+        try:
+            shader = Path(module_path).read_bytes()
+        except OSError as exc:
+            raise RuntimeAdapterSetupError(
+                f"DirectX runtime artifact could not be read: {exc}",
+                details={
+                    "target": "directx",
+                    "reasonKind": "artifact-read-failed",
+                    "modulePath": str(module_path),
+                },
+            ) from exc
+        if not shader:
+            raise RuntimeAdapterSetupError(
+                "DirectX runtime artifact is empty.",
+                details={
+                    "target": "directx",
+                    "reasonKind": "artifact-empty",
+                    "modulePath": str(module_path),
+                },
+            )
+        return shader
+
+    def dispatch(
+        self,
+        adapter: Any,
+        state: Any,
+        request: NativeRuntimeDispatchRequest,
+    ) -> dict[str, Mapping[str, Any]]:
+        _ = adapter, state
+        if not self._platform_supported():
+            raise RuntimeExecutorUnavailable(
+                "Direct3D 12 compute runtime is available on Windows only."
+            )
+        if (
+            request.dispatch is not None
+            and request.dispatch.entry_point is not None
+            and request.entry_point is not None
+            and request.dispatch.entry_point != request.entry_point
+        ):
+            raise RuntimeAdapterSetupError(
+                "DirectX runtime entry-point metadata is inconsistent.",
+                details={
+                    "target": "directx",
+                    "reasonKind": "entry-point-mismatch",
+                    "entryPoint": request.entry_point,
+                    "dispatchEntryPoint": request.dispatch.entry_point,
+                },
+            )
+
+        compushady = self._load_compushady()
+        shader = self._shader_code(request)
+        prepared = (
+            *_prepare_directx_buffers(request.buffers),
+            *_prepare_directx_constants(request.constants),
+        )
+        prepared = _validate_directx_register_layout(prepared)
+        workgroup_count = _workgroup_count(request, target="DirectX")
+
+        owned_objects: list[Any] = []
+        resources: list[_DirectXBufferResource] = []
+        compute = None
+        try:
+            try:
+                backend = compushady.get_backend()
+                backend_name = _compushady_backend_name(backend)
+                if backend_name != "d3d12":
+                    raise RuntimeExecutorUnavailable(
+                        "compushady must use its Direct3D 12 backend for DXIL dispatch."
+                    )
+                device = self._select_device(compushady)
+                if device is None:
+                    raise RuntimeExecutorUnavailable(
+                        "No Direct3D 12 compute device is available."
+                    )
+            except RuntimeExecutorUnavailable:
+                raise
+            except Exception as exc:
+                raise RuntimeAdapterSetupError(
+                    f"Direct3D 12 device selection failed: {exc}",
+                    details={
+                        "target": "directx",
+                        "runtime": self.name,
+                        "reasonKind": "device-selection-failed",
+                    },
+                ) from exc
+
+            for item in prepared:
+                try:
+                    resource = self._create_buffer_resource(
+                        compushady,
+                        device,
+                        item,
+                        owned_objects,
+                    )
+                except (RuntimeAdapterSetupError, RuntimeExecutorUnavailable):
+                    raise
+                except Exception as exc:
+                    raise RuntimeAdapterSetupError(
+                        f"DirectX resource creation failed for {item.name!r}: {exc}",
+                        details={
+                            "target": "directx",
+                            "runtime": self.name,
+                            "reasonKind": "resource-creation-failed",
+                            "resource": item.name,
+                            "namespace": item.namespace,
+                            "binding": item.binding_index,
+                        },
+                    ) from exc
+                resources.append(resource)
+
+            bound_resources = {
+                namespace: [
+                    resource.device_buffer
+                    for resource in resources
+                    if resource.prepared.namespace == namespace
+                ]
+                for namespace in ("cbv", "srv", "uav")
+            }
+            try:
+                compute = compushady.Compute(
+                    shader,
+                    cbv=bound_resources["cbv"],
+                    srv=bound_resources["srv"],
+                    uav=bound_resources["uav"],
+                    device=device,
+                )
+                owned_objects.append(compute)
+            except Exception as exc:
+                raise RuntimeAdapterSetupError(
+                    f"DirectX compute pipeline creation failed: {exc}",
+                    details={
+                        "target": "directx",
+                        "runtime": self.name,
+                        "reasonKind": "compute-pipeline-creation-failed",
+                        "cbvCount": len(bound_resources["cbv"]),
+                        "srvCount": len(bound_resources["srv"]),
+                        "uavCount": len(bound_resources["uav"]),
+                    },
+                ) from exc
+            try:
+                compute.dispatch(*workgroup_count)
+            except Exception as exc:
+                raise RuntimeAdapterDispatchError(
+                    f"DirectX compute dispatch failed: {exc}",
+                    details={
+                        "target": "directx",
+                        "runtime": self.name,
+                        "reasonKind": "dispatch-failed",
+                        "workgroupCount": list(workgroup_count),
+                    },
+                ) from exc
+            return self._read_outputs(
+                compushady,
+                device,
+                resources,
+                owned_objects,
+            )
+        except (
+            RuntimeAdapterDispatchError,
+            RuntimeAdapterSetupError,
+            RuntimeExecutorUnavailable,
+        ):
+            raise
+        except Exception as exc:
+            raise RuntimeAdapterDispatchError(
+                f"DirectX compute dispatch failed: {exc}",
+                details={"target": "directx", "runtime": self.name},
+            ) from exc
+        finally:
+            for value in reversed(owned_objects):
+                _release_directx_object(value)
+            resources.clear()
+            compute = None
+
+    def _platform_supported(self) -> bool:
+        return any(
+            self.platform_name.startswith(platform)
+            for platform in self.supported_platforms
+        )
+
+    def _load_compushady(self) -> Any:
+        try:
+            return self._module_loader("compushady")
+        except Exception as exc:
+            raise RuntimeExecutorUnavailable(
+                "compushady is unavailable; install the optional 'compushady' "
+                "package to run DirectX runtime fixtures."
+            ) from exc
+
+    def _select_device(self, compushady: Any) -> Any:
+        get_current_device = getattr(compushady, "get_current_device", None)
+        if callable(get_current_device):
+            return get_current_device()
+        get_best_device = getattr(compushady, "get_best_device", None)
+        if callable(get_best_device):
+            return get_best_device()
+        raise RuntimeExecutorUnavailable(
+            "compushady does not expose a Direct3D device selector."
+        )
+
+    def _shader_code(self, request: NativeRuntimeDispatchRequest) -> bytes:
+        if isinstance(request.loaded_artifact, (bytes, bytearray, memoryview)):
+            shader = bytes(request.loaded_artifact)
+            if shader:
+                return shader
+        return self.load_artifact(None, None, request.module_path)
+
+    def _create_buffer_resource(
+        self,
+        compushady: Any,
+        device: Any,
+        prepared: _PreparedDirectXBuffer,
+        owned_objects: list[Any],
+    ) -> _DirectXBufferResource:
+        upload_buffer = compushady.Buffer(
+            prepared.allocation_size,
+            compushady.HEAP_UPLOAD,
+            device=device,
+        )
+        owned_objects.append(upload_buffer)
+        payload = prepared.payload.ljust(prepared.allocation_size, b"\x00")
+        upload_buffer.upload(payload)
+        device_buffer = compushady.Buffer(
+            prepared.allocation_size,
+            compushady.HEAP_DEFAULT,
+            stride=prepared.stride,
+            device=device,
+        )
+        owned_objects.append(device_buffer)
+        upload_buffer.copy_to(device_buffer)
+        return _DirectXBufferResource(
+            prepared=prepared,
+            upload_buffer=upload_buffer,
+            device_buffer=device_buffer,
+        )
+
+    def _read_outputs(
+        self,
+        compushady: Any,
+        device: Any,
+        resources: Sequence[_DirectXBufferResource],
+        owned_objects: list[Any],
+    ) -> dict[str, Mapping[str, Any]]:
+        outputs: dict[str, Mapping[str, Any]] = {}
+        for resource in resources:
+            prepared = resource.prepared
+            if prepared.source != "expectedOutput":
+                continue
+            try:
+                readback = compushady.Buffer(
+                    prepared.allocation_size,
+                    compushady.HEAP_READBACK,
+                    device=device,
+                )
+                owned_objects.append(readback)
+                resource.device_buffer.copy_to(readback)
+                payload = bytes(readback.readback(prepared.size))
+            except Exception as exc:
+                raise RuntimeAdapterDispatchError(
+                    f"DirectX output readback failed for {prepared.name!r}: {exc}",
+                    details={
+                        "target": "directx",
+                        "runtime": self.name,
+                        "reasonKind": "readback-failed",
+                        "resource": prepared.name,
+                        "binding": prepared.binding_index,
+                    },
+                ) from exc
+            outputs[prepared.output_name or prepared.name] = {
+                "dtype": prepared.dtype,
+                "shape": list(prepared.shape),
+                "values": _unpack_values(payload, prepared.dtype, target="DirectX"),
+            }
+        return outputs
 
 
 class OpenGLComputeRuntime:
@@ -923,6 +1360,590 @@ def _read_mapped_memory(mapped: Any, size: int) -> bytes:
         return byte_view[:size].tobytes()
     finally:
         view.release()
+
+
+def _compushady_backend_name(backend: Any) -> str:
+    value = getattr(backend, "name", backend if isinstance(backend, str) else "")
+    return str(value or "").strip().lower().rsplit(".", 1)[-1]
+
+
+def _release_directx_object(value: Any) -> None:
+    if value is None:
+        return
+    for method_name in ("release", "close"):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+            return
+
+
+def _prepare_directx_buffers(
+    bindings: Mapping[str, NativeRuntimeBufferBinding],
+) -> tuple[_PreparedDirectXBuffer, ...]:
+    prepared = []
+    for name, binding in bindings.items():
+        resource = binding.binding
+        namespace = _directx_resource_namespace(name, binding)
+        binding_value = resource.binding
+        if binding_value is None:
+            binding_value = resource.index
+        if binding_value is None:
+            raise _directx_setup_error(
+                f"DirectX compute runtime requires an explicit register for {name}.",
+                "register-missing",
+                resource=name,
+                namespace=namespace,
+            )
+        binding_index = _directx_int_field(
+            binding_value,
+            field_name="binding",
+            resource=name,
+            register_prefix=namespace[0],
+        )
+        set_index = _directx_int_field(
+            resource.set,
+            field_name="set",
+            resource=name,
+            default=0,
+        )
+        if set_index != 0:
+            raise _directx_setup_error(
+                "DirectX compute runtime supports register space zero only.",
+                "unsupported-register-space",
+                resource=name,
+                namespace=namespace,
+                binding=binding_index,
+                registerSpace=set_index,
+            )
+        if namespace == "cbv" and binding.source == "expectedOutput":
+            raise _directx_setup_error(
+                "DirectX constant buffers cannot be runtime output resources.",
+                "unsupported-output-resource",
+                resource=name,
+                namespace=namespace,
+                binding=binding_index,
+            )
+
+        dtype = _normalize_directx_dtype(binding.dtype, resource=name)
+        try:
+            shape = tuple(int(value) for value in binding.shape)
+        except (TypeError, ValueError) as exc:
+            raise _directx_setup_error(
+                f"DirectX runtime buffer {name!r} has an invalid shape.",
+                "invalid-buffer-shape",
+                resource=name,
+            ) from exc
+        if any(value < 0 for value in shape):
+            raise _directx_setup_error(
+                f"DirectX runtime buffer {name!r} has a negative shape dimension.",
+                "invalid-buffer-shape",
+                resource=name,
+                shape=list(shape),
+            )
+        element_count = (
+            math.prod(shape) if shape else len(_flatten_values(binding.value))
+        )
+        if element_count <= 0:
+            raise _directx_setup_error(
+                f"DirectX runtime buffer {name!r} has no addressable elements.",
+                "buffer-size-missing",
+                resource=name,
+                shape=list(shape),
+            )
+        if binding.source == "expectedOutput":
+            payload = b"\x00" * (element_count * _dtype_size(dtype))
+        else:
+            try:
+                payload = _pack_values(
+                    binding.value,
+                    dtype,
+                    expected_count=element_count,
+                    target="DirectX",
+                )
+            except (RuntimeExecutorUnavailable, struct.error) as exc:
+                raise _directx_setup_error(
+                    f"DirectX runtime buffer {name!r} could not be packed: {exc}",
+                    "buffer-packing-failed",
+                    resource=name,
+                    dtype=dtype,
+                    shape=list(shape),
+                ) from exc
+
+        stride = _directx_buffer_stride(binding, namespace, dtype, len(payload))
+        allocation_size = (
+            _align_to(len(payload), 256) if namespace == "cbv" else len(payload)
+        )
+        prepared.append(
+            _PreparedDirectXBuffer(
+                name=name,
+                namespace=namespace,
+                binding_index=binding_index,
+                dtype=dtype,
+                shape=shape,
+                source=binding.source,
+                output_name=_runtime_value_name(binding),
+                payload=payload,
+                allocation_size=allocation_size,
+                stride=stride,
+            )
+        )
+    return tuple(
+        sorted(
+            prepared,
+            key=lambda item: (
+                {"cbv": 0, "srv": 1, "uav": 2}[item.namespace],
+                item.binding_index,
+            ),
+        )
+    )
+
+
+def _prepare_directx_constants(
+    bindings: Mapping[str, Any],
+) -> tuple[_PreparedDirectXBuffer, ...]:
+    grouped: dict[int, list[_DirectXConstantValue]] = {}
+    for name, binding in bindings.items():
+        metadata = _directx_constant_metadata(binding)
+        mechanism = str(metadata.get("mechanism") or "").strip().lower()
+        constant_kind = str(binding.constant.kind or "").strip().lower()
+        if mechanism in {"compiled", "compiled-literal", "static"} or (
+            not mechanism
+            and constant_kind
+            in {"scalar-constant", "compile-time-constant", "static-constant"}
+        ):
+            _validate_directx_compiled_constant(name, binding)
+            continue
+        if not mechanism and constant_kind in {"constant-buffer", "cbv", "uniform"}:
+            mechanism = "constant-buffer"
+        if mechanism not in {"constant-buffer", "cbv"}:
+            raise _directx_setup_error(
+                f"DirectX runtime constant {name!r} has no supported binding mechanism.",
+                "unsupported-constant-binding",
+                constant=name,
+                constantKind=binding.constant.kind,
+            )
+
+        binding_value = metadata.get("binding", metadata.get("register"))
+        if binding_value is None:
+            raise _directx_setup_error(
+                f"DirectX runtime constant {name!r} requires a CBV register.",
+                "constant-register-missing",
+                constant=name,
+            )
+        binding_index = _directx_int_field(
+            binding_value,
+            field_name="binding",
+            resource=name,
+            register_prefix="b",
+        )
+        set_index = _directx_int_field(
+            metadata.get("set", metadata.get("space")),
+            field_name="set",
+            resource=name,
+            default=0,
+        )
+        if set_index != 0:
+            raise _directx_setup_error(
+                "DirectX runtime constants support register space zero only.",
+                "unsupported-register-space",
+                constant=name,
+                namespace="cbv",
+                binding=binding_index,
+                registerSpace=set_index,
+            )
+        byte_offset = _directx_int_field(
+            metadata.get("byteOffset", metadata.get("offset")),
+            field_name="byteOffset",
+            resource=name,
+            default=0,
+        )
+        if byte_offset % 4:
+            raise _directx_setup_error(
+                f"DirectX runtime constant {name!r} must be four-byte aligned.",
+                "constant-offset-invalid",
+                constant=name,
+                byteOffset=byte_offset,
+            )
+        dtype = _normalize_directx_dtype(binding.constant.dtype, resource=name)
+        values = _flatten_values(binding.value)
+        if not values:
+            raise _directx_setup_error(
+                f"DirectX runtime constant {name!r} has no bound value.",
+                "constant-value-missing",
+                constant=name,
+            )
+        try:
+            payload = _pack_values(
+                binding.value,
+                dtype,
+                expected_count=len(values),
+                target="DirectX",
+            )
+        except (RuntimeExecutorUnavailable, struct.error) as exc:
+            raise _directx_setup_error(
+                f"DirectX runtime constant {name!r} could not be packed: {exc}",
+                "constant-packing-failed",
+                constant=name,
+                dtype=dtype,
+            ) from exc
+        grouped.setdefault(binding_index, []).append(
+            _DirectXConstantValue(
+                name=name,
+                binding_index=binding_index,
+                byte_offset=byte_offset,
+                dtype=dtype,
+                payload=payload,
+            )
+        )
+
+    prepared = []
+    for binding_index, constants in sorted(grouped.items()):
+        ranges: list[tuple[int, int, str]] = []
+        payload_size = max(
+            value.byte_offset + len(value.payload) for value in constants
+        )
+        payload = bytearray(payload_size)
+        for value in sorted(constants, key=lambda item: (item.byte_offset, item.name)):
+            start = value.byte_offset
+            end = start + len(value.payload)
+            overlap = next(
+                (
+                    existing_name
+                    for existing_start, existing_end, existing_name in ranges
+                    if start < existing_end and end > existing_start
+                ),
+                None,
+            )
+            if overlap is not None:
+                raise _directx_setup_error(
+                    "DirectX runtime constants have overlapping CBV byte ranges.",
+                    "constant-layout-overlap",
+                    namespace="cbv",
+                    binding=binding_index,
+                    constant=value.name,
+                    overlaps=overlap,
+                )
+            payload[start:end] = value.payload
+            ranges.append((start, end, value.name))
+        names = ", ".join(value.name for value in constants)
+        prepared.append(
+            _PreparedDirectXBuffer(
+                name=f"constants[{names}]",
+                namespace="cbv",
+                binding_index=binding_index,
+                dtype="uint32",
+                shape=(),
+                source="constant",
+                output_name=None,
+                payload=bytes(payload),
+                allocation_size=_align_to(payload_size, 256),
+            )
+        )
+    return tuple(prepared)
+
+
+def _validate_directx_register_layout(
+    prepared: Sequence[_PreparedDirectXBuffer],
+) -> tuple[_PreparedDirectXBuffer, ...]:
+    result = []
+    for namespace in ("cbv", "srv", "uav"):
+        resources = sorted(
+            (item for item in prepared if item.namespace == namespace),
+            key=lambda item: item.binding_index,
+        )
+        indices = [item.binding_index for item in resources]
+        if len(indices) != len(set(indices)):
+            duplicates = sorted(
+                {index for index in indices if indices.count(index) > 1}
+            )
+            raise _directx_setup_error(
+                f"DirectX runtime has duplicate {namespace.upper()} registers.",
+                "duplicate-register-binding",
+                namespace=namespace,
+                bindings=indices,
+                duplicateBindings=duplicates,
+            )
+        expected = list(range(len(indices)))
+        if indices != expected:
+            raise _directx_setup_error(
+                "compushady requires contiguous DirectX registers starting at zero.",
+                "sparse-register-layout",
+                namespace=namespace,
+                bindings=indices,
+                expectedBindings=expected,
+            )
+        result.extend(resources)
+    return tuple(result)
+
+
+def _directx_resource_namespace(
+    name: str,
+    binding: NativeRuntimeBufferBinding,
+) -> str:
+    resource = binding.binding
+    kind = str(resource.kind or "buffer").strip().lower().replace("_", "-")
+    if kind in {"constant-buffer", "constantbuffer", "uniform", "cbv"}:
+        return "cbv"
+    if kind in {"srv", "shader-resource", "read-only-buffer"}:
+        namespace = "srv"
+    elif kind in {"uav", "unordered-access", "read-write-buffer"}:
+        namespace = "uav"
+    elif kind in {"buffer", "storage-buffer"}:
+        namespace = ""
+    else:
+        raise _directx_setup_error(
+            f"DirectX compute runtime supports buffer resources only: {name}.",
+            "unsupported-resource-kind",
+            resource=name,
+            resourceKind=resource.kind,
+        )
+
+    type_name = str(resource.type_name or "").strip()
+    normalized_type = re.sub(r"\s+", "", type_name).lower()
+    type_namespace = None
+    if normalized_type:
+        if any(
+            marker in normalized_type
+            for marker in (
+                "rwstructuredbuffer",
+                "rwbyteaddressbuffer",
+                "rwbuffer<",
+                "appendstructuredbuffer",
+                "consumestructuredbuffer",
+                "rasterizerordered",
+            )
+        ):
+            type_namespace = "uav"
+        elif any(
+            marker in normalized_type
+            for marker in ("structuredbuffer", "byteaddressbuffer", "buffer<")
+        ):
+            type_namespace = "srv"
+
+    access = str(resource.access or "").strip().lower().replace("-", "_")
+    access_namespace = None
+    if access in {"write", "read_write", "readwrite"}:
+        access_namespace = "uav"
+    elif access in {"read", "read_only", "readonly"}:
+        access_namespace = "srv"
+
+    inferred = namespace or type_namespace or access_namespace
+    if binding.source == "expectedOutput":
+        if inferred == "srv":
+            raise _directx_setup_error(
+                f"DirectX output resource {name!r} is reflected as read-only.",
+                "resource-access-mismatch",
+                resource=name,
+                resourceKind=resource.kind,
+                access=resource.access,
+                type=resource.type_name,
+            )
+        return "uav"
+    return inferred or "srv"
+
+
+def _directx_buffer_stride(
+    binding: NativeRuntimeBufferBinding,
+    namespace: str,
+    dtype: str,
+    payload_size: int,
+) -> int:
+    resource = binding.binding
+    metadata = {**dict(resource.metadata), **dict(binding.metadata)}
+    explicit_stride = next(
+        (
+            metadata[key]
+            for key in ("byteStride", "elementStride", "stride")
+            if key in metadata
+        ),
+        None,
+    )
+    if explicit_stride is not None:
+        stride = _directx_int_field(
+            explicit_stride,
+            field_name="byteStride",
+            resource=binding.name,
+        )
+    else:
+        type_name = str(resource.type_name or "").strip()
+        normalized_type = re.sub(r"\s+", "", type_name).lower()
+        if namespace == "cbv":
+            stride = 0
+        elif "byteaddressbuffer" in normalized_type:
+            stride = 0
+        elif "structuredbuffer" in normalized_type:
+            match = re.search(r"structuredbuffer<([^>]+)>", normalized_type)
+            element_type = match.group(1) if match else ""
+            stride = _directx_hlsl_element_stride(element_type)
+            if stride is None:
+                raise _directx_setup_error(
+                    f"DirectX runtime cannot infer the stride for {binding.name!r}.",
+                    "buffer-stride-missing",
+                    resource=binding.name,
+                    type=resource.type_name,
+                )
+        elif re.search(r"(?:^|\w)rw?buffer<|(?:^|\w)buffer<", normalized_type):
+            raise _directx_setup_error(
+                f"DirectX typed buffer views are not supported for {binding.name!r}.",
+                "unsupported-buffer-view",
+                resource=binding.name,
+                type=resource.type_name,
+            )
+        elif type_name:
+            raise _directx_setup_error(
+                f"DirectX runtime cannot infer the buffer view for {binding.name!r}.",
+                "unsupported-buffer-view",
+                resource=binding.name,
+                type=resource.type_name,
+            )
+        else:
+            stride = _dtype_size(dtype)
+    byte_address_buffer = (
+        "byteaddressbuffer" in re.sub(r"\s+", "", str(resource.type_name or "")).lower()
+    )
+    if (
+        stride < 0
+        or (stride == 0 and namespace != "cbv" and not byte_address_buffer)
+        or (stride and payload_size % stride)
+    ):
+        raise _directx_setup_error(
+            f"DirectX runtime buffer {binding.name!r} has an invalid byte stride.",
+            "buffer-stride-invalid",
+            resource=binding.name,
+            byteStride=stride,
+            byteLength=payload_size,
+        )
+    return stride
+
+
+def _directx_hlsl_element_stride(type_name: str) -> int | None:
+    scalar_sizes = {
+        "float": 4,
+        "float32_t": 4,
+        "int": 4,
+        "int32_t": 4,
+        "uint": 4,
+        "uint32_t": 4,
+    }
+    if type_name in scalar_sizes:
+        return scalar_sizes[type_name]
+    match = re.fullmatch(r"(float|int|uint)([1-4])", type_name)
+    if match:
+        return 4 * int(match.group(2))
+    return None
+
+
+def _directx_constant_metadata(binding: Any) -> dict[str, Any]:
+    metadata = {
+        **dict(binding.constant.metadata),
+        **dict(binding.metadata),
+    }
+    nested = metadata.get("directx")
+    if isinstance(nested, Mapping):
+        metadata.update(nested)
+    directx_binding = metadata.get("directxBinding")
+    if isinstance(directx_binding, Mapping):
+        metadata.update(directx_binding)
+    elif isinstance(directx_binding, str) and "mechanism" not in metadata:
+        metadata["mechanism"] = directx_binding
+    if "kind" in metadata and "mechanism" not in metadata:
+        metadata["mechanism"] = metadata["kind"]
+    if "registerSpace" in metadata and "space" not in metadata:
+        metadata["space"] = metadata["registerSpace"]
+    return metadata
+
+
+def _validate_directx_compiled_constant(name: str, binding: Any) -> None:
+    reflected_value = binding.constant.value
+    if reflected_value is None:
+        reflected_value = binding.constant.default
+    if reflected_value is None or binding.value != reflected_value:
+        raise _directx_setup_error(
+            f"DirectX compiled constant {name!r} cannot be overridden at dispatch.",
+            "compiled-constant-mismatch",
+            constant=name,
+            reflectedValue=reflected_value,
+            boundValue=binding.value,
+        )
+
+
+def _normalize_directx_dtype(dtype: str | None, *, resource: str) -> str:
+    try:
+        return _normalize_dtype(dtype, target="DirectX")
+    except RuntimeExecutorUnavailable as exc:
+        raise _directx_setup_error(
+            str(exc),
+            "unsupported-dtype",
+            resource=resource,
+            dtype=dtype,
+        ) from exc
+
+
+def _directx_int_field(
+    value: Any,
+    *,
+    field_name: str,
+    resource: str,
+    default: int | None = None,
+    register_prefix: str | None = None,
+) -> int:
+    if value is None:
+        if default is not None:
+            return default
+        raise _directx_setup_error(
+            f"DirectX runtime {field_name} is required for {resource!r}.",
+            "integer-field-missing",
+            resource=resource,
+            field=field_name,
+        )
+    normalized = value
+    if isinstance(value, str) and register_prefix:
+        stripped = value.strip().lower()
+        if stripped.startswith(register_prefix):
+            normalized = stripped[len(register_prefix) :]
+    try:
+        result = int(normalized)
+    except (TypeError, ValueError) as exc:
+        raise _directx_setup_error(
+            f"DirectX runtime {field_name} must be an integer for {resource!r}.",
+            "integer-field-invalid",
+            resource=resource,
+            field=field_name,
+            value=value,
+        ) from exc
+    if result < 0:
+        raise _directx_setup_error(
+            f"DirectX runtime {field_name} cannot be negative for {resource!r}.",
+            "integer-field-invalid",
+            resource=resource,
+            field=field_name,
+            value=result,
+        )
+    return result
+
+
+def _directx_setup_error(
+    message: str,
+    reason_kind: str,
+    **details: Any,
+) -> RuntimeAdapterSetupError:
+    return RuntimeAdapterSetupError(
+        message,
+        details={
+            "target": "directx",
+            "runtime": DirectXComputeRuntime.name,
+            "reasonKind": reason_kind,
+            **details,
+        },
+    )
+
+
+def _align_to(value: int, alignment: int) -> int:
+    value = max(value, 1)
+    return max(alignment, ((value + alignment - 1) // alignment) * alignment)
 
 
 def _release_opengl_object(value: Any) -> None:

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -1363,7 +1363,9 @@ def _read_mapped_memory(mapped: Any, size: int) -> bytes:
 
 
 def _compushady_backend_name(backend: Any) -> str:
-    value = getattr(backend, "name", backend if isinstance(backend, str) else "")
+    value = getattr(backend, "name", None) or getattr(backend, "__name__", None)
+    if value is None and isinstance(backend, str):
+        value = backend
     return str(value or "").strip().lower().rsplit(".", 1)[-1]
 
 

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -107,7 +107,7 @@ class DirectXComputeRuntime:
     """
 
     name = "directx-compute-runtime"
-    supported_platforms = ("win32", "cygwin")
+    supported_platforms = ("win32",)
 
     def __init__(
         self,
@@ -183,9 +183,9 @@ class DirectXComputeRuntime:
         except Exception as exc:  # pragma: no cover - depends on local adapters
             return RuntimeExecutorAvailability(
                 False,
-                reason=f"No Direct3D 12 compute device is available: {exc}",
+                reason=f"Direct3D 12 device selection failed: {exc}",
                 details={
-                    "reasonKind": "device-unavailable",
+                    "reasonKind": "device-selection-failed",
                     "target": "directx",
                     "runtime": self.name,
                     "error": str(exc),
@@ -412,6 +412,15 @@ class DirectXComputeRuntime:
             ) from exc
 
     def _select_device(self, compushady: Any) -> Any:
+        get_discovered_devices = getattr(compushady, "get_discovered_devices", None)
+        if not callable(get_discovered_devices):
+            raise RuntimeExecutorUnavailable(
+                "compushady does not expose Direct3D device discovery."
+            )
+        devices = get_discovered_devices()
+        if not devices:
+            return None
+
         get_current_device = getattr(compushady, "get_current_device", None)
         if callable(get_current_device):
             return get_current_device()
@@ -1755,6 +1764,18 @@ def _directx_buffer_stride(
 ) -> int:
     resource = binding.binding
     metadata = {**dict(resource.metadata), **dict(binding.metadata)}
+    type_name = str(resource.type_name or "").strip()
+    normalized_type = re.sub(r"\s+", "", type_name).lower()
+    if namespace != "cbv" and (
+        "byteaddressbuffer" in normalized_type
+        or ("buffer<" in normalized_type and "structuredbuffer<" not in normalized_type)
+    ):
+        raise _directx_setup_error(
+            f"DirectX buffer view is not supported for {binding.name!r}.",
+            "unsupported-buffer-view",
+            resource=binding.name,
+            type=resource.type_name,
+        )
     explicit_stride = next(
         (
             metadata[key]
@@ -1770,11 +1791,7 @@ def _directx_buffer_stride(
             resource=binding.name,
         )
     else:
-        type_name = str(resource.type_name or "").strip()
-        normalized_type = re.sub(r"\s+", "", type_name).lower()
         if namespace == "cbv":
-            stride = 0
-        elif "byteaddressbuffer" in normalized_type:
             stride = 0
         elif "structuredbuffer" in normalized_type:
             match = re.search(r"structuredbuffer<([^>]+)>", normalized_type)
@@ -1787,13 +1804,6 @@ def _directx_buffer_stride(
                     resource=binding.name,
                     type=resource.type_name,
                 )
-        elif re.search(r"(?:^|\w)rw?buffer<|(?:^|\w)buffer<", normalized_type):
-            raise _directx_setup_error(
-                f"DirectX typed buffer views are not supported for {binding.name!r}.",
-                "unsupported-buffer-view",
-                resource=binding.name,
-                type=resource.type_name,
-            )
         elif type_name:
             raise _directx_setup_error(
                 f"DirectX runtime cannot infer the buffer view for {binding.name!r}.",
@@ -1803,12 +1813,9 @@ def _directx_buffer_stride(
             )
         else:
             stride = _dtype_size(dtype)
-    byte_address_buffer = (
-        "byteaddressbuffer" in re.sub(r"\s+", "", str(resource.type_name or "")).lower()
-    )
     if (
         stride < 0
-        or (stride == 0 and namespace != "cbv" and not byte_address_buffer)
+        or (stride == 0 and namespace != "cbv")
         or (stride and payload_size % stride)
     ):
         raise _directx_setup_error(

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -1482,7 +1482,7 @@ class DirectXRuntimeParityAdapter(NativeRuntimeParityAdapter):
     target = "directx"
     targets = ("directx",)
     required_tools = ("dxc",)
-    supported_platforms = ("win32", "cygwin")
+    supported_platforms = ("win32",)
 
     def validation_commands(
         self,

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -1609,10 +1609,14 @@ def native_runtime_parity_adapter(
         raise RuntimeVerificationError(
             f"Native runtime parity adapter is not available for {target}."
         )
-    if runtime is None and normalized == "opengl":
-        from .native_runtime_drivers import OpenGLComputeRuntime
+    if runtime is None and normalized in {"directx", "opengl"}:
+        from .native_runtime_drivers import DirectXComputeRuntime, OpenGLComputeRuntime
 
-        runtime = OpenGLComputeRuntime()
+        runtime = (
+            DirectXComputeRuntime()
+            if normalized == "directx"
+            else OpenGLComputeRuntime()
+        )
     return adapter_class(runtime=runtime, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=["gast", "tomli; python_version<'3.11'"],
+    extras_require={
+        "directx-runtime": [
+            "compushady>=0.17.5,<0.18; platform_system=='Windows'",
+        ],
+    },
     entry_points={
         "console_scripts": [
             "crosstl=crosstl._crosstl:main",

--- a/tests/test_backend/test_package_contracts.py
+++ b/tests/test_backend/test_package_contracts.py
@@ -1,9 +1,23 @@
+import ast
 import importlib
 import inspect
 import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def _setup_keyword(name):
+    tree = ast.parse((ROOT / "setup.py").read_text(encoding="utf-8"))
+    setup_call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "setup"
+    )
+    keyword = next(item for item in setup_call.keywords if item.arg == name)
+    return ast.literal_eval(keyword.value)
 
 
 def _catalog_backends():
@@ -48,6 +62,14 @@ def test_native_backend_modules_are_importable():
                 failures.append(f"{module}: {type(exc).__name__}: {exc}")
 
     assert not failures, "Native backend import failures:\n" + "\n".join(failures)
+
+
+def test_directx_runtime_extra_declares_supported_compushady_release():
+    extras = _setup_keyword("extras_require")
+
+    assert extras["directx-runtime"] == [
+        "compushady>=0.17.5,<0.18; platform_system=='Windows'"
+    ]
 
 
 def test_native_backend_packages_expose_core_frontend_classes():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -277,6 +277,7 @@ def test_full_suite_runs_fail_closed_windows_directx_native_runtime_smoke():
     assert "DirectXShaderCompiler/releases/download/v1.9.2602" in smoke_job
     assert 'python -m pip install -e ".[directx-runtime]"' in smoke_job
     assert "python tools/directx_runtime_smoke.py" in smoke_job
+    assert "continue-on-error" not in smoke_job
     assert "crosstl.translate(" in smoke_runner
     assert '[dxc, "-T", "cs_6_0", "-E", "CSMain"' in smoke_runner
     assert "runtime.dispatch(" in smoke_runner

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -259,6 +259,33 @@ def test_full_suite_runs_runtime_parity_only_for_available_adapters():
     assert '-k "runtime_parity"' in full_suite
 
 
+def test_full_suite_runs_fail_closed_windows_directx_native_runtime_smoke():
+    workflows = _workflow_texts()
+    full_suite = workflows.get("full-tests.yml", "")
+    smoke_runner = (ROOT / "tools" / "directx_runtime_smoke.py").read_text(
+        encoding="utf-8"
+    )
+    smoke_job = full_suite[
+        full_suite.index("  directx-native-runtime-smoke:") : full_suite.index(
+            "  compiler-smoke-linux:"
+        )
+    ]
+
+    assert "Direct3D 12 Native Runtime Smoke (Windows)" in smoke_job
+    assert "runs-on: windows-latest" in smoke_job
+    assert 'python-version: "3.12"' in smoke_job
+    assert "DirectXShaderCompiler/releases/download/v1.9.2602" in smoke_job
+    assert 'python -m pip install -e ".[directx-runtime]"' in smoke_job
+    assert "python tools/directx_runtime_smoke.py" in smoke_job
+    assert "crosstl.translate(" in smoke_runner
+    assert '[dxc, "-T", "cs_6_0", "-E", "CSMain"' in smoke_runner
+    assert "runtime.dispatch(" in smoke_runner
+    assert 'reason_kind != "device-unavailable"' in smoke_runner
+    assert "DIRECTX_RUNTIME_SMOKE_SKIPPED" in smoke_runner
+    assert "DXC compilation failed" in smoke_runner
+    assert "native runtime readback mismatch" in smoke_runner
+
+
 def test_open_source_porting_demo_workflow_feeds_support_failure_summaries():
     workflows = _workflow_texts()
     demo = workflows.get("demo.yml", "")

--- a/tests/test_directx_runtime_smoke.py
+++ b/tests/test_directx_runtime_smoke.py
@@ -1,0 +1,107 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from crosstl.project.runtime_verification import RuntimeExecutorAvailability
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_PATH = ROOT / "tools" / "directx_runtime_smoke.py"
+
+
+def _load_smoke_module():
+    spec = importlib.util.spec_from_file_location("directx_runtime_smoke", SMOKE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _ProbeRuntime:
+    def __init__(self, availability):
+        self.availability = availability
+
+    def is_available(self, adapter, request):
+        return self.availability
+
+
+def test_directx_runtime_smoke_reports_skip_for_missing_adapter(tmp_path, monkeypatch):
+    module = _load_smoke_module()
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    runtime = _ProbeRuntime(
+        RuntimeExecutorAvailability(
+            False,
+            reason="No Direct3D 12 compute device is available.",
+            details={"reasonKind": "device-unavailable"},
+        )
+    )
+
+    assert module._probe_runtime(runtime, tmp_path) is False
+    assert "Status: skipped" in summary.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "reason_kind",
+    [
+        "backend-unavailable",
+        "dependency-unavailable",
+        "direct3d-runtime-unavailable",
+        "platform-unavailable",
+    ],
+)
+def test_directx_runtime_smoke_fails_closed_before_adapter_selection(
+    tmp_path, reason_kind
+):
+    module = _load_smoke_module()
+    runtime = _ProbeRuntime(
+        RuntimeExecutorAvailability(
+            False,
+            reason="runtime probe failed",
+            details={"reasonKind": reason_kind},
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="runtime probe failed"):
+        module._probe_runtime(runtime, tmp_path)
+
+
+def test_directx_runtime_smoke_translates_compiles_and_builds_dispatch(
+    tmp_path, monkeypatch
+):
+    module = _load_smoke_module()
+
+    def passing_dxc(command, **kwargs):
+        _ = kwargs
+        output_path = Path(command[command.index("-Fo") + 1])
+        output_path.write_bytes(b"DXBC-smoke")
+        return type("Result", (), {"returncode": 0, "stderr": "", "stdout": ""})()
+
+    monkeypatch.setattr(module.subprocess, "run", passing_dxc)
+
+    hlsl_path, dxil_path = module._translate_and_compile(tmp_path, "dxc")
+    request = module._dispatch_request(hlsl_path, dxil_path)
+
+    assert "RWStructuredBuffer<float> outputBuffer : register(u0);" in (
+        hlsl_path.read_text(encoding="utf-8")
+    )
+    assert request.loaded_artifact == b"DXBC-smoke"
+    assert request.entry_point == "CSMain"
+    assert request.dispatch.workgroup_count == (4, 1, 1)
+
+
+def test_directx_runtime_smoke_fails_closed_for_dxc_errors(tmp_path, monkeypatch):
+    module = _load_smoke_module()
+
+    def failing_dxc(command, **kwargs):
+        _ = command, kwargs
+        return type(
+            "Result",
+            (),
+            {"returncode": 1, "stderr": "invalid shader", "stdout": ""},
+        )()
+
+    monkeypatch.setattr(module.subprocess, "run", failing_dxc)
+
+    with pytest.raises(RuntimeError, match="DXC compilation failed: invalid shader"):
+        module._translate_and_compile(tmp_path, "dxc")

--- a/tests/test_directx_runtime_smoke.py
+++ b/tests/test_directx_runtime_smoke.py
@@ -46,6 +46,7 @@ def test_directx_runtime_smoke_reports_skip_for_missing_adapter(tmp_path, monkey
     [
         "backend-unavailable",
         "dependency-unavailable",
+        "device-selection-failed",
         "direct3d-runtime-unavailable",
         "platform-unavailable",
     ],

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -214,6 +214,7 @@ class _FakeCompushady:
     def __init__(self, *, backend="d3d12"):
         self.backend = type("Backend", (), {"name": backend})()
         self.device = _FakeDirectXDevice()
+        self.devices = [self.device]
         self.buffers = []
         self.computes = []
         self.fail_device = False
@@ -225,6 +226,9 @@ class _FakeCompushady:
 
     def get_backend(self):
         return self.backend
+
+    def get_discovered_devices(self):
+        return self.devices
 
     def get_current_device(self):
         if self.fail_device:
@@ -269,7 +273,7 @@ def test_directx_compute_runtime_reports_unsupported_platform_without_import(tmp
         "reasonKind": "platform-unavailable",
         "target": "directx",
         "platform": "darwin",
-        "requiredPlatforms": ["win32", "cygwin"],
+        "requiredPlatforms": ["win32"],
     }
 
 
@@ -311,7 +315,7 @@ def test_compushady_backend_name_accepts_imported_backend_module():
     assert _compushady_backend_name(backend) == "d3d12"
 
 
-def test_directx_compute_runtime_reports_device_initialization_failure(tmp_path):
+def test_directx_compute_runtime_fails_closed_for_device_selection_error(tmp_path):
     module = _FakeCompushady()
     module.fail_device = True
     runtime = DirectXComputeRuntime(
@@ -322,8 +326,23 @@ def test_directx_compute_runtime_reports_device_initialization_failure(tmp_path)
     availability = runtime.is_available(None, _runtime_request(tmp_path))
 
     assert availability.available is False
-    assert availability.details["reasonKind"] == "device-unavailable"
+    assert availability.details["reasonKind"] == "device-selection-failed"
     assert availability.details["error"] == "device creation failed"
+
+
+def test_directx_compute_runtime_reports_empty_device_list(tmp_path):
+    module = _FakeCompushady()
+    module.devices = []
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details["reasonKind"] == "device-unavailable"
+    assert "error" not in availability.details
 
 
 def test_directx_compute_runtime_reports_selected_device(tmp_path):
@@ -421,6 +440,40 @@ def test_prepare_directx_buffers_rejects_unsupported_resource_kind(tmp_path):
         _prepare_directx_buffers({"lhs": binding})
 
     assert excinfo.value.details["reasonKind"] == "unsupported-resource-kind"
+
+
+@pytest.mark.parametrize(
+    ("type_name", "metadata"),
+    [
+        ("ByteAddressBuffer", {}),
+        ("RWBuffer<float>", {"byteStride": 4}),
+    ],
+)
+def test_prepare_directx_buffers_rejects_views_compushady_cannot_describe(
+    tmp_path,
+    type_name,
+    metadata,
+):
+    request = _directx_dispatch_request(tmp_path)
+    lhs = request.buffers["lhs"]
+    binding = NativeRuntimeBufferBinding(
+        **{
+            **lhs.__dict__,
+            "binding": RuntimeResourceBinding(
+                **{
+                    **lhs.binding.__dict__,
+                    "type_name": type_name,
+                    "metadata": metadata,
+                }
+            ),
+        }
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_buffers({"lhs": binding})
+
+    assert excinfo.value.details["reasonKind"] == "unsupported-buffer-view"
+    assert excinfo.value.details["type"] == type_name
 
 
 def test_prepare_directx_buffers_rejects_sparse_registers(tmp_path):

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -10,16 +10,21 @@ import pytest
 import crosstl.project as project_api
 from crosstl._crosstl import translate
 from crosstl.project.native_runtime_drivers import (
+    DirectXComputeRuntime,
     OpenGLComputeRuntime,
     VulkanComputeRuntime,
     _first_vulkan_handle,
+    _prepare_directx_buffers,
+    _prepare_directx_constants,
     _prepare_opengl_buffers,
     _prepare_vulkan_buffers,
     _read_mapped_memory,
+    _validate_directx_register_layout,
     _write_mapped_memory,
 )
 from crosstl.project.runtime_verification import (
     UNAVAILABLE,
+    DirectXRuntimeParityAdapter,
     NativeRuntimeBufferBinding,
     NativeRuntimeConstantBinding,
     NativeRuntimeDispatchRequest,
@@ -28,6 +33,7 @@ from crosstl.project.runtime_verification import (
     RuntimeArtifactSelector,
     RuntimeDispatchGeometry,
     RuntimeExecutionRequest,
+    RuntimeExecutorUnavailable,
     RuntimeFixture,
     RuntimeResourceBinding,
     RuntimeSpecializationConstant,
@@ -74,6 +80,656 @@ def _opengl_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
         dispatch=RuntimeDispatchGeometry(entry_point="main", workgroup_count=(1, 1, 1)),
         entry_point="main",
     )
+
+
+def _directx_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
+    return NativeRuntimeDispatchRequest(
+        target="directx",
+        artifact={"target": "directx"},
+        artifact_path=tmp_path / "runtime.hlsl",
+        module_path=tmp_path / "runtime.dxil",
+        loaded_artifact=b"DXBC\x00\x01",
+        buffers={
+            "params": NativeRuntimeBufferBinding(
+                name="params",
+                binding=RuntimeResourceBinding(
+                    name="params",
+                    kind="constant-buffer",
+                    type_name="Params",
+                    set=0,
+                    binding=0,
+                    access="read",
+                ),
+                value=[3],
+                source="input",
+                dtype="uint32",
+                shape=(1,),
+            ),
+            "lhs": NativeRuntimeBufferBinding(
+                name="lhs",
+                binding=RuntimeResourceBinding(
+                    name="lhs",
+                    kind="buffer",
+                    type_name="StructuredBuffer<float>",
+                    set=0,
+                    binding=0,
+                    access="read",
+                ),
+                value=[1.0, 2.0],
+                source="input",
+                dtype="float32",
+                shape=(2,),
+            ),
+            "out": NativeRuntimeBufferBinding(
+                name="out",
+                binding=RuntimeResourceBinding(
+                    name="out",
+                    kind="buffer",
+                    type_name="RWStructuredBuffer<float>",
+                    set=0,
+                    binding=0,
+                    access="read_write",
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(2,),
+                metadata={"runtimeValueName": "result"},
+            ),
+        },
+        constants={},
+        dispatch=RuntimeDispatchGeometry(entry_point="main", workgroup_count=(2, 3, 1)),
+        entry_point="main",
+    )
+
+
+class _FakeDirectXDevice:
+    name = "Fake Direct3D Adapter"
+    is_hardware = True
+    is_discrete = False
+
+
+class _FakeDirectXBuffer:
+    def __init__(self, runtime, size, heap_type, stride, device):
+        self.runtime = runtime
+        self.size = size
+        self.heap_type = heap_type
+        self.stride = stride
+        self.device = device
+        self.payload = bytearray(size)
+        self.released = False
+
+    def upload(self, payload):
+        self.payload[: len(payload)] = payload
+
+    def copy_to(self, destination):
+        if (
+            destination.heap_type == self.runtime.HEAP_READBACK
+            and self.runtime.fail_readback_copy
+        ):
+            raise RuntimeError("readback copy failed")
+        destination.payload[: len(self.payload)] = self.payload
+
+    def readback(self, size=0, offset=0):
+        if self.runtime.fail_readback:
+            raise RuntimeError("readback failed")
+        size = size or len(self.payload) - offset
+        return bytes(self.payload[offset : offset + size])
+
+    def release(self):
+        self.released = True
+
+
+class _FakeDirectXCompute:
+    def __init__(self, runtime, shader, cbv, srv, uav, device):
+        self.runtime = runtime
+        self.shader = shader
+        self.cbv = cbv
+        self.srv = srv
+        self.uav = uav
+        self.device = device
+        self.dispatch_args = None
+        self.released = False
+
+    def dispatch(self, x, y, z):
+        self.dispatch_args = (x, y, z)
+        if self.runtime.fail_dispatch:
+            raise RuntimeError("dispatch rejected")
+        scale = struct.unpack("<I", self.cbv[0].payload[:4])[0]
+        values = struct.unpack("<2f", self.srv[0].payload[:8])
+        self.uav[0].payload[:8] = struct.pack(
+            "<2f", *(value * scale for value in values)
+        )
+
+    def release(self):
+        self.released = True
+
+
+class _FakeCompushady:
+    HEAP_DEFAULT = 0
+    HEAP_UPLOAD = 1
+    HEAP_READBACK = 2
+
+    def __init__(self, *, backend="d3d12"):
+        self.backend = type("Backend", (), {"name": backend})()
+        self.device = _FakeDirectXDevice()
+        self.buffers = []
+        self.computes = []
+        self.fail_device = False
+        self.fail_compute = False
+        self.fail_dispatch = False
+        self.fail_default_buffer = False
+        self.fail_readback_copy = False
+        self.fail_readback = False
+
+    def get_backend(self):
+        return self.backend
+
+    def get_current_device(self):
+        if self.fail_device:
+            raise RuntimeError("device creation failed")
+        return self.device
+
+    def Buffer(self, size, heap_type=0, stride=0, device=None):
+        if heap_type == self.HEAP_DEFAULT and self.fail_default_buffer:
+            raise RuntimeError("default buffer creation failed")
+        buffer = _FakeDirectXBuffer(self, size, heap_type, stride, device)
+        self.buffers.append(buffer)
+        return buffer
+
+    def Compute(self, shader, cbv=None, srv=None, uav=None, device=None):
+        if self.fail_compute:
+            raise RuntimeError("pipeline creation failed")
+        compute = _FakeDirectXCompute(
+            self,
+            shader,
+            list(cbv or []),
+            list(srv or []),
+            list(uav or []),
+            device,
+        )
+        self.computes.append(compute)
+        return compute
+
+
+def test_directx_compute_runtime_reports_unsupported_platform_without_import(tmp_path):
+    def unexpected_loader(name):
+        raise AssertionError(f"unexpected import: {name}")
+
+    runtime = DirectXComputeRuntime(
+        module_loader=unexpected_loader,
+        platform_name="darwin",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details == {
+        "reasonKind": "platform-unavailable",
+        "target": "directx",
+        "platform": "darwin",
+        "requiredPlatforms": ["win32", "cygwin"],
+    }
+
+
+def test_directx_compute_runtime_reports_missing_python_binding(tmp_path):
+    def missing_loader(name):
+        assert name == "compushady"
+        raise ModuleNotFoundError(name)
+
+    runtime = DirectXComputeRuntime(
+        module_loader=missing_loader,
+        platform_name="win32",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details["reasonKind"] == "dependency-unavailable"
+    assert availability.details["missingPythonModules"] == ["compushady"]
+
+
+def test_directx_compute_runtime_reports_wrong_compushady_backend(tmp_path):
+    module = _FakeCompushady(backend="vulkan")
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details["reasonKind"] == "backend-unavailable"
+    assert availability.details["requiredBackend"] == "d3d12"
+    assert availability.details["activeBackend"] == "vulkan"
+
+
+def test_directx_compute_runtime_reports_device_initialization_failure(tmp_path):
+    module = _FakeCompushady()
+    module.fail_device = True
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is False
+    assert availability.details["reasonKind"] == "device-unavailable"
+    assert availability.details["error"] == "device creation failed"
+
+
+def test_directx_compute_runtime_reports_selected_device(tmp_path):
+    module = _FakeCompushady()
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+
+    availability = runtime.is_available(None, _runtime_request(tmp_path))
+
+    assert availability.available is True
+    assert availability.details == {
+        "reasonKind": "available",
+        "target": "directx",
+        "runtime": "directx-compute-runtime",
+        "backend": "d3d12",
+        "device": "Fake Direct3D Adapter",
+        "isHardware": True,
+        "isDiscrete": False,
+    }
+
+
+def test_directx_compute_runtime_loads_nonempty_dxil(tmp_path):
+    artifact_path = tmp_path / "add.dxil"
+    artifact_path.write_bytes(b"DXBC\x00\x01")
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: object(),
+        platform_name="win32",
+    )
+
+    assert runtime.load_artifact(None, None, artifact_path) == b"DXBC\x00\x01"
+
+
+def test_directx_compute_runtime_rejects_empty_dxil(tmp_path):
+    artifact_path = tmp_path / "empty.dxil"
+    artifact_path.write_bytes(b"")
+    runtime = DirectXComputeRuntime(platform_name="win32")
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        runtime.load_artifact(None, None, artifact_path)
+
+    assert excinfo.value.details["reasonKind"] == "artifact-empty"
+
+
+def test_prepare_directx_buffers_maps_and_packs_descriptor_namespaces(tmp_path):
+    prepared = _validate_directx_register_layout(
+        _prepare_directx_buffers(_directx_dispatch_request(tmp_path).buffers)
+    )
+
+    assert [(item.name, item.namespace, item.binding_index) for item in prepared] == [
+        ("params", "cbv", 0),
+        ("lhs", "srv", 0),
+        ("out", "uav", 0),
+    ]
+    assert prepared[0].payload == struct.pack("<I", 3)
+    assert prepared[0].allocation_size == 256
+    assert prepared[0].stride == 0
+    assert prepared[1].payload == struct.pack("<2f", 1.0, 2.0)
+    assert prepared[1].stride == 4
+    assert prepared[2].payload == b"\x00" * 8
+    assert prepared[2].output_name == "result"
+
+
+def test_prepare_directx_buffers_rejects_nonzero_register_space(tmp_path):
+    request = _directx_dispatch_request(tmp_path)
+    lhs = request.buffers["lhs"]
+    binding = NativeRuntimeBufferBinding(
+        **{
+            **lhs.__dict__,
+            "binding": RuntimeResourceBinding(**{**lhs.binding.__dict__, "set": 2}),
+        }
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_buffers({"lhs": binding})
+
+    assert excinfo.value.details["reasonKind"] == "unsupported-register-space"
+    assert excinfo.value.details["registerSpace"] == 2
+
+
+def test_prepare_directx_buffers_rejects_unsupported_resource_kind(tmp_path):
+    request = _directx_dispatch_request(tmp_path)
+    lhs = request.buffers["lhs"]
+    binding = NativeRuntimeBufferBinding(
+        **{
+            **lhs.__dict__,
+            "binding": RuntimeResourceBinding(
+                **{**lhs.binding.__dict__, "kind": "texture"}
+            ),
+        }
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_buffers({"lhs": binding})
+
+    assert excinfo.value.details["reasonKind"] == "unsupported-resource-kind"
+
+
+def test_prepare_directx_buffers_rejects_sparse_registers(tmp_path):
+    request = _directx_dispatch_request(tmp_path)
+    lhs = request.buffers["lhs"]
+    binding = NativeRuntimeBufferBinding(
+        **{
+            **lhs.__dict__,
+            "binding": RuntimeResourceBinding(**{**lhs.binding.__dict__, "binding": 1}),
+        }
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _validate_directx_register_layout(_prepare_directx_buffers({"lhs": binding}))
+
+    assert excinfo.value.details["reasonKind"] == "sparse-register-layout"
+    assert excinfo.value.details["namespace"] == "srv"
+    assert excinfo.value.details["bindings"] == [1]
+    assert excinfo.value.details["expectedBindings"] == [0]
+
+
+def test_prepare_directx_buffers_rejects_duplicate_registers(tmp_path):
+    request = _directx_dispatch_request(tmp_path)
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _validate_directx_register_layout(
+            _prepare_directx_buffers(
+                {
+                    "lhs": request.buffers["lhs"],
+                    "rhs": NativeRuntimeBufferBinding(
+                        **{
+                            **request.buffers["lhs"].__dict__,
+                            "name": "rhs",
+                        }
+                    ),
+                }
+            )
+        )
+
+    assert excinfo.value.details["reasonKind"] == "duplicate-register-binding"
+    assert excinfo.value.details["duplicateBindings"] == [0]
+
+
+def test_prepare_directx_constants_packs_explicit_constant_buffer():
+    constants = _prepare_directx_constants(
+        {
+            "scale": NativeRuntimeConstantBinding(
+                name="scale",
+                constant=RuntimeSpecializationConstant(
+                    name="scale",
+                    kind="constant-buffer",
+                    dtype="float32",
+                    metadata={
+                        "directx": {
+                            "binding": "b0",
+                            "byteOffset": 0,
+                        }
+                    },
+                ),
+                value=2.5,
+            ),
+            "count": NativeRuntimeConstantBinding(
+                name="count",
+                constant=RuntimeSpecializationConstant(
+                    name="count",
+                    kind="constant-buffer",
+                    dtype="uint32",
+                    metadata={
+                        "directx": {
+                            "binding": "b0",
+                            "byteOffset": 4,
+                        }
+                    },
+                ),
+                value=3,
+            ),
+        }
+    )
+
+    assert len(constants) == 1
+    assert constants[0].namespace == "cbv"
+    assert constants[0].binding_index == 0
+    assert constants[0].payload == struct.pack("<fI", 2.5, 3)
+    assert constants[0].allocation_size == 256
+
+
+def test_prepare_directx_constants_accepts_matching_compiled_literal():
+    constants = _prepare_directx_constants(
+        {
+            "tile_size": NativeRuntimeConstantBinding(
+                name="tile_size",
+                constant=RuntimeSpecializationConstant(
+                    name="tile_size",
+                    kind="scalar-constant",
+                    dtype="uint32",
+                    value=4,
+                ),
+                value=4,
+            )
+        }
+    )
+
+    assert constants == ()
+
+
+def test_prepare_directx_constants_rejects_ambiguous_specialization_constant():
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_constants(
+            {
+                "tile_size": NativeRuntimeConstantBinding(
+                    name="tile_size",
+                    constant=RuntimeSpecializationConstant(
+                        name="tile_size",
+                        dtype="uint32",
+                        value=4,
+                    ),
+                    value=4,
+                )
+            }
+        )
+
+    assert excinfo.value.details["reasonKind"] == "unsupported-constant-binding"
+
+
+def test_directx_compute_runtime_dispatches_and_reads_typed_output(tmp_path):
+    module = _FakeCompushady()
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+
+    outputs = runtime.dispatch(None, None, _directx_dispatch_request(tmp_path))
+
+    assert outputs == {
+        "result": {
+            "dtype": "float32",
+            "shape": [2],
+            "values": [3.0, 6.0],
+        }
+    }
+    compute = module.computes[0]
+    assert compute.shader == b"DXBC\x00\x01"
+    assert compute.dispatch_args == (2, 3, 1)
+    assert len(compute.cbv) == len(compute.srv) == len(compute.uav) == 1
+    assert compute.cbv[0].size == 256
+    assert compute.srv[0].stride == compute.uav[0].stride == 4
+    assert all(buffer.device is module.device for buffer in module.buffers)
+    assert all(buffer.released for buffer in module.buffers)
+    assert compute.released is True
+
+
+def test_directx_runtime_adapter_compiles_dxil_and_dispatches_fixture(tmp_path):
+    artifact_path = tmp_path / "out" / "directx" / "scale.hlsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(
+        "[numthreads(1,1,1)] void main() {}\n",
+        encoding="utf-8",
+    )
+    module = _FakeCompushady()
+
+    def compile_dxil(command, *, input_text=None):
+        assert input_text is None
+        output_path = Path(command[command.index("-Fo") + 1])
+        output_path.write_bytes(b"DXBC\x00\x01")
+        return {"returncode": 0}
+
+    adapter = DirectXRuntimeParityAdapter(
+        runtime=DirectXComputeRuntime(
+            module_loader=lambda name: module,
+            platform_name="win32",
+        ),
+        required_tools=(),
+        supported_platforms=(),
+        tool_resolver=lambda tool: f"/fake/{tool}",
+        command_runner=compile_dxil,
+    )
+    report = verify_runtime_test_manifest(
+        {
+            "kind": "crosstl-project-portability-report",
+            "project": {"root": str(tmp_path), "targets": ["directx"]},
+            "artifacts": [
+                {
+                    "source": "kernels/scale.cgl",
+                    "path": "out/directx/scale.hlsl",
+                    "target": "directx",
+                    "status": "translated",
+                    "entryPoints": [{"name": "main", "stage": "compute"}],
+                    "resourceBindings": [
+                        {
+                            "name": "params",
+                            "kind": "constant-buffer",
+                            "type": "Params",
+                            "set": 0,
+                            "binding": 0,
+                            "access": "read",
+                        },
+                        {
+                            "name": "lhs",
+                            "kind": "buffer",
+                            "type": "StructuredBuffer<float>",
+                            "set": 0,
+                            "binding": 0,
+                            "access": "read",
+                        },
+                        {
+                            "name": "out",
+                            "kind": "buffer",
+                            "type": "RWStructuredBuffer<float>",
+                            "set": 0,
+                            "binding": 0,
+                            "access": "read_write",
+                        },
+                    ],
+                    "dispatch": {
+                        "entryPoint": "main",
+                        "workgroupCount": [2, 3, 1],
+                    },
+                }
+            ],
+        },
+        {
+            "kind": "crosstl-project-runtime-test-manifest",
+            "adapters": [
+                {
+                    "id": "native-directx",
+                    "executor": "directx",
+                    "adapterKind": "directx-native-runtime",
+                    "platformRequirements": {"requiredTools": []},
+                }
+            ],
+            "tests": [
+                {
+                    "id": "directx-scale",
+                    "selector": {
+                        "source": "kernels/scale.cgl",
+                        "target": "directx",
+                    },
+                    "adapter": "native-directx",
+                    "inputs": [
+                        {
+                            "name": "params",
+                            "dtype": "uint32",
+                            "shape": [1],
+                            "values": [3],
+                        },
+                        {
+                            "name": "lhs",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "values": [1.0, 2.0],
+                        },
+                    ],
+                    "expectedOutputs": [
+                        {
+                            "name": "out",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "values": [3.0, 6.0],
+                        }
+                    ],
+                }
+            ],
+        },
+        executors={"directx": adapter},
+    )
+
+    result = report["results"][0]
+    assert report["success"] is True
+    assert result["status"] == "passed"
+    assert module.computes[0].shader == b"DXBC\x00\x01"
+    assert module.computes[0].dispatch_args == (2, 3, 1)
+
+
+@pytest.mark.parametrize(
+    ("failure", "reason_kind"),
+    [
+        ("fail_default_buffer", "resource-creation-failed"),
+        ("fail_compute", "compute-pipeline-creation-failed"),
+        ("fail_dispatch", "dispatch-failed"),
+        ("fail_readback_copy", "readback-failed"),
+    ],
+)
+def test_directx_compute_runtime_reports_phase_failure_and_releases_resources(
+    tmp_path,
+    failure,
+    reason_kind,
+):
+    module = _FakeCompushady()
+    setattr(module, failure, True)
+    runtime = DirectXComputeRuntime(
+        module_loader=lambda name: module,
+        platform_name="win32",
+    )
+    error_type = (
+        RuntimeAdapterSetupError
+        if reason_kind
+        in {"resource-creation-failed", "compute-pipeline-creation-failed"}
+        else RuntimeAdapterDispatchError
+    )
+
+    with pytest.raises(error_type) as excinfo:
+        runtime.dispatch(None, None, _directx_dispatch_request(tmp_path))
+
+    assert excinfo.value.details["reasonKind"] == reason_kind
+    assert all(buffer.released for buffer in module.buffers)
+    assert all(compute.released for compute in module.computes)
+
+
+def test_directx_compute_runtime_rejects_dispatch_off_windows(tmp_path):
+    runtime = DirectXComputeRuntime(platform_name="linux")
+
+    with pytest.raises(RuntimeExecutorUnavailable, match="Windows only"):
+        runtime.dispatch(None, None, _directx_dispatch_request(tmp_path))
+
+
+def test_directx_compute_runtime_is_exported_from_project_api():
+    assert project_api.DirectXComputeRuntime is DirectXComputeRuntime
 
 
 def test_opengl_compute_runtime_reports_missing_python_binding(tmp_path):

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -4,6 +4,7 @@ import shutil
 import struct
 import subprocess
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -13,6 +14,7 @@ from crosstl.project.native_runtime_drivers import (
     DirectXComputeRuntime,
     OpenGLComputeRuntime,
     VulkanComputeRuntime,
+    _compushady_backend_name,
     _first_vulkan_handle,
     _prepare_directx_buffers,
     _prepare_directx_constants,
@@ -301,6 +303,12 @@ def test_directx_compute_runtime_reports_wrong_compushady_backend(tmp_path):
     assert availability.details["reasonKind"] == "backend-unavailable"
     assert availability.details["requiredBackend"] == "d3d12"
     assert availability.details["activeBackend"] == "vulkan"
+
+
+def test_compushady_backend_name_accepts_imported_backend_module():
+    backend = ModuleType("compushady.backends.d3d12")
+
+    assert _compushady_backend_name(backend) == "d3d12"
 
 
 def test_directx_compute_runtime_reports_device_initialization_failure(tmp_path):

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -506,6 +506,7 @@ def test_project_package_exposes_public_api_surface():
         "REFLECTION_TOOL_UNAVAILABLE",
         "REFLECTION_UNSUPPORTED_FORMAT",
         "ReflectionDiagnostic",
+        "DirectXComputeRuntime",
         "DirectXRuntimeParityAdapter",
         "NativeRuntimeBufferBinding",
         "NativeRuntimeConstantBinding",

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -1855,6 +1855,7 @@ def test_runtime_parity_native_factories_create_target_adapters():
 
     assert set(adapters) == {"directx", "opengl", "vulkan"}
     assert isinstance(adapters["directx"], DirectXRuntimeParityAdapter)
+    assert adapters["directx"].runtime.name == "directx-compute-runtime"
     assert isinstance(adapters["opengl"], OpenGLRuntimeParityAdapter)
     assert adapters["opengl"].runtime.name == "opengl-compute-runtime"
     assert isinstance(adapters["vulkan"], VulkanRuntimeParityAdapter)

--- a/tools/directx_runtime_smoke.py
+++ b/tools/directx_runtime_smoke.py
@@ -142,11 +142,15 @@ def _dispatch_request(hlsl_path: Path, dxil_path: Path) -> NativeRuntimeDispatch
 
 def main() -> int:
     if not sys.platform.startswith("win"):
-        raise RuntimeError("The Direct3D 12 native runtime smoke test requires Windows.")
+        raise RuntimeError(
+            "The Direct3D 12 native runtime smoke test requires Windows."
+        )
 
     dxc = shutil.which("dxc")
     if dxc is None:
-        raise RuntimeError("DXC is required for the Direct3D 12 native runtime smoke test.")
+        raise RuntimeError(
+            "DXC is required for the Direct3D 12 native runtime smoke test."
+        )
 
     with tempfile.TemporaryDirectory(prefix="crosstl-directx-runtime-") as temp_dir:
         work_dir = Path(temp_dir)

--- a/tools/directx_runtime_smoke.py
+++ b/tools/directx_runtime_smoke.py
@@ -1,0 +1,178 @@
+"""Run a native Direct3D 12 translation, compilation, and dispatch smoke test."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import crosstl
+from crosstl.project.native_runtime_drivers import DirectXComputeRuntime
+from crosstl.project.runtime_verification import (
+    NativeRuntimeBufferBinding,
+    NativeRuntimeDispatchRequest,
+    RuntimeArtifactSelector,
+    RuntimeDispatchGeometry,
+    RuntimeExecutionRequest,
+    RuntimeFixture,
+    RuntimeResourceBinding,
+)
+
+SOURCE = """\
+shader RuntimeSmoke {
+    RWStructuredBuffer<float> outputBuffer;
+    compute {
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+        void computeMain(uvec3 dispatchThreadID @ gl_GlobalInvocationID) @ stage_entry {
+            uint index = dispatchThreadID.x;
+            outputBuffer[index] = float(index) + 1.0;
+        }
+    }
+}
+"""
+EXPECTED_VALUES = [1.0, 2.0, 3.0, 4.0]
+
+
+def _write_summary(status: str, detail: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("## Direct3D 12 Native Runtime Smoke\n")
+        summary.write(f"- Status: {status}\n")
+        summary.write(f"- Detail: {detail}\n")
+
+
+def _probe_request(work_dir: Path) -> RuntimeExecutionRequest:
+    return RuntimeExecutionRequest(
+        fixture=RuntimeFixture(
+            id="directx-native-runtime-smoke",
+            selector=RuntimeArtifactSelector(target="directx"),
+        ),
+        artifact={"target": "directx", "path": "runtime-smoke.hlsl"},
+        artifact_path=work_dir / "runtime-smoke.hlsl",
+        project_root=work_dir,
+    )
+
+
+def _probe_runtime(runtime: DirectXComputeRuntime, work_dir: Path) -> bool:
+    availability = runtime.is_available(None, _probe_request(work_dir))
+    if availability.available:
+        device = availability.details.get("device", "unnamed D3D12 adapter")
+        print(f"Direct3D 12 adapter available: {device}")
+        return True
+
+    reason_kind = availability.details.get("reasonKind")
+    if reason_kind != "device-unavailable":
+        raise RuntimeError(
+            "Direct3D 12 runtime probe failed before adapter selection: "
+            f"{availability.reason or availability.details}"
+        )
+
+    detail = availability.reason or "No usable Direct3D 12 adapter exists."
+    print(f"DIRECTX_RUNTIME_SMOKE_SKIPPED: {detail}")
+    _write_summary("skipped", detail)
+    return False
+
+
+def _translate_and_compile(work_dir: Path, dxc: str) -> tuple[Path, Path]:
+    source_path = work_dir / "runtime-smoke.cgl"
+    hlsl_path = work_dir / "runtime-smoke.hlsl"
+    dxil_path = work_dir / "runtime-smoke.dxil"
+    source_path.write_text(SOURCE, encoding="utf-8")
+
+    generated = crosstl.translate(
+        str(source_path),
+        backend="directx",
+        save_shader=str(hlsl_path),
+        format_output=False,
+    )
+    if not generated.strip() or not hlsl_path.is_file():
+        raise RuntimeError("CrossTL DirectX translation did not emit HLSL.")
+
+    result = subprocess.run(
+        [dxc, "-T", "cs_6_0", "-E", "CSMain", "-Fo", str(dxil_path), str(hlsl_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        diagnostics = (result.stderr or result.stdout or "no DXC diagnostics").strip()
+        raise RuntimeError(f"DXC compilation failed: {diagnostics}")
+    if not dxil_path.is_file() or dxil_path.stat().st_size == 0:
+        raise RuntimeError("DXC reported success without emitting a DXIL artifact.")
+    return hlsl_path, dxil_path
+
+
+def _dispatch_request(hlsl_path: Path, dxil_path: Path) -> NativeRuntimeDispatchRequest:
+    return NativeRuntimeDispatchRequest(
+        target="directx",
+        artifact={"target": "directx", "path": str(hlsl_path)},
+        artifact_path=hlsl_path,
+        module_path=dxil_path,
+        loaded_artifact=dxil_path.read_bytes(),
+        buffers={
+            "outputBuffer": NativeRuntimeBufferBinding(
+                name="outputBuffer",
+                binding=RuntimeResourceBinding(
+                    name="outputBuffer",
+                    kind="buffer",
+                    type_name="RWStructuredBuffer<float>",
+                    set=0,
+                    binding=0,
+                    access="read_write",
+                ),
+                source="expectedOutput",
+                dtype="float32",
+                shape=(len(EXPECTED_VALUES),),
+                metadata={"runtimeValueName": "result"},
+            )
+        },
+        constants={},
+        dispatch=RuntimeDispatchGeometry(
+            entry_point="CSMain",
+            workgroup_count=(len(EXPECTED_VALUES), 1, 1),
+        ),
+        entry_point="CSMain",
+    )
+
+
+def main() -> int:
+    if not sys.platform.startswith("win"):
+        raise RuntimeError("The Direct3D 12 native runtime smoke test requires Windows.")
+
+    dxc = shutil.which("dxc")
+    if dxc is None:
+        raise RuntimeError("DXC is required for the Direct3D 12 native runtime smoke test.")
+
+    with tempfile.TemporaryDirectory(prefix="crosstl-directx-runtime-") as temp_dir:
+        work_dir = Path(temp_dir)
+        runtime = DirectXComputeRuntime()
+        if not _probe_runtime(runtime, work_dir):
+            return 0
+
+        hlsl_path, dxil_path = _translate_and_compile(work_dir, dxc)
+        outputs = runtime.dispatch(
+            None,
+            None,
+            _dispatch_request(hlsl_path, dxil_path),
+        )
+
+    actual = outputs.get("result", {}).get("values")
+    if actual != EXPECTED_VALUES:
+        raise RuntimeError(
+            "Direct3D 12 native runtime readback mismatch: "
+            f"expected {EXPECTED_VALUES}, received {actual}"
+        )
+
+    detail = f"translated, compiled, dispatched, and read back {len(actual)} values"
+    print(f"Direct3D 12 native runtime smoke passed: {detail}.")
+    _write_summary("passed", detail)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add an optional Direct3D 12 compute runtime backed by `compushady`
- load DXIL, bind reflected CBV/SRV/UAV resources, dispatch compute work, and return typed output values
- reject unsupported register spaces, sparse descriptor layouts, raw/typed buffer views, incompatible strides, and mutable compiled constants with structured setup diagnostics
- expose the runtime through the existing native parity adapter and a Windows-only package extra
- add a fail-closed Windows smoke job that translates CrossGL, compiles HLSL with DXC, dispatches through Direct3D 12, and verifies readback values

## Scope

The initial driver supports structured buffer fixtures and constant-buffer values in register space zero. Raw and typed buffer views are rejected because `compushady 0.17.5` does not expose enough view metadata through its stride-only buffer construction API to bind them reliably.

The smoke job skips only when device discovery returns no Direct3D 12 device. Backend initialization, dependency, selector, translation, compilation, dispatch, and readback failures fail the job.

## Validation

- `python -m pytest -q -n auto tests/test_translator tests/test_backend` (`14375 passed, 187 skipped`)
- focused runtime and CI contract tests (`1226 passed, 6 skipped`)
- `python tools/support_matrix.py check`
- `python tools/sync_support_issues.py --repo CrossGL/crosstl --dry-run` (`0` desired issues)
- `pre-commit run --all-files`

Native Direct3D execution is exercised by the new `windows-latest` smoke job.

Closes #1472
