### PR TITLE
Package selected OpenGL project entries

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -73,7 +73,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y glslang-tools libvulkan1 mesa-vulkan-drivers spirv-tools vulkan-tools
+          sudo apt-get install -y glslang-tools libegl1 libgl1-mesa-dri libglx-mesa0 mesa-vulkan-drivers spirv-tools vulkan-tools
           glslangValidator --version
 
       - name: Install Linux DXC
@@ -118,10 +118,10 @@ jobs:
           }
           $dxc.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Install Linux Vulkan runtime dependency
+      - name: Install Linux runtime dependencies
         if: runner.os == 'Linux'
         run: |
-          python -m pip install vulkan==1.3.275.1
+          python -m pip install moderngl==5.12.0 vulkan==1.3.275.1
 
       - name: Checkout pinned MLX
         shell: bash
@@ -144,6 +144,7 @@ jobs:
               --mlx-root mlx-upstream \
               --require-opengl-frontier-toolchain \
               --require-opengl-gemv-toolchain \
+              --require-opengl-native-runtime \
               --require-vulkan-gemv-toolchain \
               --require-vulkan-toolchain \
               --require-vulkan-native-runtime

--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -45,6 +45,17 @@ STDOUT_OUTPUT_PATH = "-"
 CLI_PROG = "crosstl"
 
 
+class EntryPointSelectionUnsupportedError(ValueError):
+    """Raised when a target cannot emit an independently loadable entry."""
+
+    project_diagnostic_code = "project.translate.entry-point-target-unsupported"
+    missing_capabilities = ("artifact.entry-point-selection",)
+
+    def __init__(self, message, *, entry_point=None):
+        super().__init__(message)
+        self.entry_point = entry_point
+
+
 def _non_negative_int(value):
     try:
         parsed = int(value)
@@ -104,6 +115,7 @@ def translate(
     include_paths: Optional[Sequence[str]] = None,
     defines: Optional[Mapping[str, str]] = None,
     source_options: Optional[Mapping[str, Any]] = None,
+    entry_point: Optional[str] = None,
 ) -> str:
     """Translate a shader file to another language.
 
@@ -120,6 +132,8 @@ def translate(
             Defaults to None.
         source_options (Mapping[str, object], optional): Source parser-specific
             lexer options. Defaults to None.
+        entry_point (str, optional): Emit one independently loadable source entry
+            when the target backend supports entry-scoped generation.
 
     Returns:
         str: The translated shader code
@@ -154,6 +168,14 @@ def translate(
         )
 
     shader_code = _read_shader_source(file_path, source_spec.name)
+
+    if entry_point is not None and normalized_backend in {"cgl", "crossgl"}:
+        selected_entry_point = _validated_entry_point(entry_point)
+        raise EntryPointSelectionUnsupportedError(
+            "Entry-scoped artifact generation is not supported for the CrossGL "
+            "intermediate target",
+            entry_point=selected_entry_point,
+        )
 
     if source_spec.name == "metal" and normalized_backend not in {
         "cgl",
@@ -190,7 +212,7 @@ def translate(
             codegen = get_codegen(requested_backend)
             lower_default_arguments(ast)
             validate_pointer_reinterpretation_target(ast, normalized_backend)
-            generated_code = codegen.generate(ast)
+            generated_code = _generate_target_code(codegen, ast, entry_point)
     else:
         if normalized_backend in ["cgl", "crossgl"]:
             if not source_spec.reverse_codegen_factory:
@@ -238,7 +260,7 @@ def translate(
             codegen = get_codegen(requested_backend)
             lower_default_arguments(cgl_ast)
             validate_pointer_reinterpretation_target(cgl_ast, normalized_backend)
-            generated_code = codegen.generate(cgl_ast)
+            generated_code = _generate_target_code(codegen, cgl_ast, entry_point)
 
     if (
         format_output
@@ -254,6 +276,26 @@ def translate(
             file.write(generated_code)
 
     return generated_code
+
+
+def _generate_target_code(codegen, ast, entry_point):
+    if entry_point is None:
+        return codegen.generate(ast)
+    entry_point = _validated_entry_point(entry_point)
+    generate_entry = getattr(codegen, "generate_entry", None)
+    if not callable(generate_entry):
+        raise EntryPointSelectionUnsupportedError(
+            "Entry-scoped artifact generation is not supported for the requested "
+            "target backend",
+            entry_point=entry_point,
+        )
+    return generate_entry(ast, entry_point)
+
+
+def _validated_entry_point(entry_point):
+    if not isinstance(entry_point, str) or not entry_point.strip():
+        raise ValueError("entry_point must be a non-empty string")
+    return entry_point.strip()
 
 
 def _derive_single_file_output(input_path, backend):

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -1263,6 +1263,8 @@ REPORT_PROJECT_FIELDS = frozenset(
         "outputDir",
         "sourceOverrides",
         "sourceOverrideCount",
+        "entryPointSelections",
+        "entryPointSelectionCount",
         "sourceOptions",
         "sourceOptionCount",
         "includeDirs",
@@ -1506,6 +1508,7 @@ REPORT_ARTIFACT_FIELDS = frozenset(
         "specializationMaterialization",
         "templateMaterialization",
         "requiredCapabilities",
+        "entryPoint",
     )
 )
 WEBGL_PROJECT_STAGE_LABEL_BY_GLSLANG = {
@@ -1536,6 +1539,7 @@ REPORT_ARTIFACT_INCLUDE_DEPENDENCY_PROCESSING_FIELDS = frozenset(
 )
 REPORT_HASH_FIELDS = frozenset(("algorithm", "value"))
 REPORT_ARTIFACT_PROVENANCE_FIELDS = frozenset(("pipeline", "intermediate"))
+REPORT_ARTIFACT_ENTRY_POINT_FIELDS = frozenset(("source", "target", "stage"))
 REPORT_ARTIFACT_SOURCE_REMAP_FIELDS = frozenset(
     (
         "schemaVersion",
@@ -1698,6 +1702,7 @@ VALIDATION_ARTIFACT_FIELDS = frozenset(
         "generatedSizeStatus",
         "sourceMapStatus",
         "sourceRemapStatus",
+        "entryPoint",
     )
 )
 VALIDATION_SUMMARY_FIELDS = frozenset(
@@ -1727,6 +1732,7 @@ VALIDATION_TOOLCHAIN_RUN_FIELDS = frozenset(
         "status",
         "stdout",
         "stderr",
+        "entryPoint",
     )
 )
 VALIDATION_TOOLCHAIN_RUN_CHECK_KINDS = frozenset(("artifact", "tool-availability"))
@@ -1760,7 +1766,10 @@ COMPILER_SOURCE_REMAP_PAYLOAD_FIELDS = frozenset(
 COMPILER_SOURCE_REMAP_MAPPING_FIELDS = frozenset(("generated", "original"))
 COMPILER_SOURCE_REMAP_SPAN_FIELDS = frozenset(SOURCE_MAP_SPAN_FIELDS)
 REPORT_GENERATOR_PIPELINE = "project-porting"
-REPORT_ARTIFACT_PROVENANCE_PIPELINES = ("single-file-translate",)
+REPORT_ARTIFACT_PROVENANCE_PIPELINES = (
+    "single-file-translate",
+    "entry-scoped-translate",
+)
 REPORT_ARTIFACT_PROVENANCE_INTERMEDIATES = ("crossgl",)
 REPORT_MIGRATION_SCOPE = "shader-kernel-translation"
 REPORT_MIGRATION_NON_GOALS = (
@@ -6956,6 +6965,7 @@ class ProjectConfig:
     targets: Sequence[str] | str = ()
     output_dir: str | os.PathLike[str] = DEFAULT_OUTPUT_DIR
     source_overrides: Mapping[str, str] = field(default_factory=dict)
+    entry_points: Mapping[str, str] = field(default_factory=dict)
     include_dirs: Sequence[str] | str = ()
     defines: Mapping[str, str] = field(default_factory=dict)
     source_options: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
@@ -7024,6 +7034,18 @@ class ProjectConfig:
                 _as_non_empty_str_mapping(
                     self.source_overrides,
                     field_name="ProjectConfig.source_overrides",
+                )
+            ),
+        )
+        if not isinstance(self.entry_points, Mapping):
+            raise ValueError("ProjectConfig.entry_points must be a mapping")
+        object.__setattr__(
+            self,
+            "entry_points",
+            _normalize_project_relative_path_mapping(
+                _as_non_empty_str_mapping(
+                    self.entry_points,
+                    field_name="ProjectConfig.entry_points",
                 )
             ),
         )
@@ -7567,6 +7589,21 @@ def _scan_pattern_diagnostics(config: ProjectConfig) -> list[ProjectDiagnostic]:
                 missing_capabilities=["source.override"],
             )
         )
+    for pattern in config.entry_points:
+        if _is_repository_relative_glob(pattern):
+            continue
+        diagnostics.append(
+            ProjectDiagnostic(
+                severity="error",
+                code="project.config.entry-point-pattern-outside-project",
+                message=(
+                    f"Configured entry-point selection pattern '{pattern}' is not "
+                    "repository-relative."
+                ),
+                location=location,
+                missing_capabilities=["artifact.entry-point-selection"],
+            )
+        )
     if config.source_overrides:
         register_default_sources()
         discover_backend_plugins()
@@ -7765,6 +7802,8 @@ class ProjectPortabilityReport:
                 "outputDir": str(self.config.output_path),
                 "sourceOverrides": dict(sorted(self.config.source_overrides.items())),
                 "sourceOverrideCount": len(self.config.source_overrides),
+                "entryPointSelections": dict(sorted(self.config.entry_points.items())),
+                "entryPointSelectionCount": len(self.config.entry_points),
                 "sourceOptions": {
                     name: dict(sorted(options.items()))
                     for name, options in sorted(self.config.source_options.items())
@@ -7936,6 +7975,10 @@ def load_project_config(
         project.get("source_options"),
         field_name="crosstl.toml [project.source_options]",
     )
+    entry_points = _as_non_empty_str_mapping(
+        project.get("entry_points"),
+        field_name="crosstl.toml [project.entry_points]",
+    )
     variants = project.get("variants", {})
     if not isinstance(variants, Mapping):
         raise ValueError("crosstl.toml [project.variants] must be a table")
@@ -7978,6 +8021,7 @@ def load_project_config(
         targets=_as_str_list(project.get("targets"), field_name="project.targets"),
         output_dir=_normalize_project_relative_path(output_dir or DEFAULT_OUTPUT_DIR),
         source_overrides=_normalize_project_relative_path_mapping(sources),
+        entry_points=_normalize_project_relative_path_mapping(entry_points),
         include_dirs=_normalize_project_relative_paths(
             _as_str_list(project.get("include_dirs"), field_name="project.include_dirs")
         ),
@@ -7999,6 +8043,43 @@ def _override_for_path(relative_path: str, config: ProjectConfig) -> str | None:
         if fnmatch.fnmatch(relative_path, _normalize_project_relative_path(pattern)):
             return backend
     return None
+
+
+def _entry_point_selector_priority(pattern: str, relative_path: str) -> tuple:
+    normalized = _normalize_project_relative_path(pattern)
+    wildcard_count = sum(normalized.count(character) for character in "*?[")
+    return (
+        normalized == relative_path,
+        -wildcard_count,
+        len(normalized),
+        normalized,
+    )
+
+
+def _entry_point_from_mapping(
+    relative_path: str,
+    entry_points: Mapping[str, str],
+) -> str | None:
+    normalized_path = _normalize_project_relative_path(relative_path)
+    matches = [
+        (pattern, entry_point)
+        for pattern, entry_point in entry_points.items()
+        if fnmatch.fnmatch(
+            normalized_path,
+            _normalize_project_relative_path(pattern),
+        )
+    ]
+    if not matches:
+        return None
+    _pattern, entry_point = max(
+        matches,
+        key=lambda item: _entry_point_selector_priority(item[0], normalized_path),
+    )
+    return entry_point
+
+
+def _entry_point_for_path(relative_path: str, config: ProjectConfig) -> str | None:
+    return _entry_point_from_mapping(relative_path, config.entry_points)
 
 
 def _iter_scan_candidates(config: ProjectConfig) -> list[Path]:
@@ -8061,6 +8142,29 @@ def _config_with_expanded_native_directive_variants(
         config,
         variants={**dict(config.variants), **new_variants},
     )
+
+
+def _entry_point_selection_diagnostics(
+    config: ProjectConfig,
+    units: Sequence[ProjectTranslationUnit],
+) -> list[ProjectDiagnostic]:
+    unit_paths = [unit.relative_path for unit in units]
+    return [
+        ProjectDiagnostic(
+            severity="error",
+            code="project.config.entry-point-pattern-unmatched",
+            message=(
+                f"Configured entry-point selection pattern '{pattern}' does not "
+                "match a discovered translation unit."
+            ),
+            location=_config_location(config),
+            missing_capabilities=["artifact.entry-point-selection"],
+            details={"pattern": pattern, "entryPoint": entry_point},
+        )
+        for pattern, entry_point in config.entry_points.items()
+        if _is_repository_relative_glob(pattern)
+        and not any(fnmatch.fnmatch(path, pattern) for path in unit_paths)
+    ]
 
 
 def scan_project(
@@ -8184,6 +8288,7 @@ def scan_project(
     diagnostics.extend(
         _external_corpus_source_backend_mismatch_diagnostics(scan_config, units)
     )
+    diagnostics.extend(_entry_point_selection_diagnostics(scan_config, units))
     if not units:
         diagnostics.append(
             ProjectDiagnostic(
@@ -8210,6 +8315,7 @@ def _artifact_path(
     variant: str | None = None,
     *,
     preserve_source_suffix: bool = False,
+    entry_point: str | None = None,
 ) -> Path:
     base = config.output_path / target
     if variant is not None:
@@ -8218,6 +8324,7 @@ def _artifact_path(
         unit.relative_path,
         target,
         preserve_source_suffix=preserve_source_suffix,
+        entry_point=entry_point,
     )
 
 
@@ -8226,9 +8333,19 @@ def _artifact_relative_path(
     target: str,
     *,
     preserve_source_suffix: bool = False,
+    entry_point: str | None = None,
 ) -> Path:
     extension = _artifact_target_extension(target)
     relative = PurePosixPath(source.replace("\\", "/"))
+    if entry_point is not None:
+        entry_segment = _variant_output_segment(entry_point)
+        if preserve_source_suffix:
+            entry_base = relative
+        elif relative.suffix:
+            entry_base = relative.with_suffix("")
+        else:
+            entry_base = PurePosixPath(f"{relative.as_posix()}.entries")
+        return Path((entry_base / f"{entry_segment}{extension}").as_posix())
     if preserve_source_suffix:
         if relative.suffix:
             return Path(f"{relative.as_posix()}{extension}")
@@ -19155,6 +19272,7 @@ def translate_project(
             targets=config.targets,
             output_dir=output_dir,
             source_overrides=config.source_overrides,
+            entry_points=config.entry_points,
             include_dirs=config.include_dirs,
             defines=config.defines,
             source_options=config.source_options,
@@ -19191,6 +19309,7 @@ def translate_project(
     preserve_source_suffix = _artifact_source_suffix_pairs(scan.units, selected_targets)
 
     for unit in scan.units:
+        selected_entry_point = _entry_point_for_path(unit.relative_path, config)
         required_capabilities = _required_capabilities_for_unit(unit)
         source_supports_defines = _source_frontend_supports_lexer_keyword(
             unit.source_backend, "defines"
@@ -19232,6 +19351,7 @@ def translate_project(
                     variant,
                     preserve_source_suffix=(unit.relative_path, target)
                     in preserve_source_suffix,
+                    entry_point=selected_entry_point,
                 )
                 artifact = {
                     "source": unit.relative_path,
@@ -19260,7 +19380,11 @@ def translate_project(
                     "sourceHash": dict(unit.source_hash),
                     "sourceSizeBytes": unit.source_size_bytes,
                     "provenance": {
-                        "pipeline": "single-file-translate",
+                        "pipeline": (
+                            "entry-scoped-translate"
+                            if selected_entry_point is not None
+                            else "single-file-translate"
+                        ),
                         "intermediate": (
                             "crossgl"
                             if unit.source_backend not in {"cgl", "crossgl"}
@@ -19270,6 +19394,13 @@ def translate_project(
                     },
                     "requiredCapabilities": list(required_capabilities),
                 }
+                if selected_entry_point is not None:
+                    artifact["entryPoint"] = {
+                        "source": selected_entry_point,
+                        "target": (
+                            "main" if target == "opengl" else selected_entry_point
+                        ),
+                    }
                 if variant is not None:
                     artifact["variant"] = variant
                 if output_dir_blocked:
@@ -19443,6 +19574,8 @@ def translate_project(
                         "include_paths": include_paths,
                         "defines": translation_defines,
                     }
+                    if selected_entry_point is not None:
+                        translate_kwargs["entry_point"] = selected_entry_point
                     if translation_source_options:
                         translate_kwargs["source_options"] = translation_source_options
                     generated_source = translate(
@@ -19469,6 +19602,23 @@ def translate_project(
                         _remove_artifact_output_files(output_path)
                         artifact_records = [artifact]
                     else:
+                        if selected_entry_point is not None:
+                            reflected = reflect_target_host_interface(
+                                output_path,
+                                target=target,
+                            )
+                            reflected_entries = reflected.get("entryPoints", [])
+                            if len(reflected_entries) != 1:
+                                raise ValueError(
+                                    "Entry-scoped target artifact must expose exactly "
+                                    "one reflected entry point"
+                                )
+                            reflected_entry = reflected_entries[0]
+                            artifact["entryPoint"] = {
+                                "source": selected_entry_point,
+                                "target": reflected_entry.get("name"),
+                                "stage": reflected_entry.get("stage"),
+                            }
                         artifact["generatedHash"] = _source_hash(output_path)
                         artifact["generatedSizeBytes"] = output_path.stat().st_size
                         artifact["sourceMap"] = _artifact_source_map(
@@ -21024,6 +21174,8 @@ def _validate_artifacts(
             artifact_check["sourceBackend"] = artifact["sourceBackend"]
         if artifact.get("stage") is not None:
             artifact_check["stage"] = artifact["stage"]
+        if isinstance(artifact.get("entryPoint"), Mapping):
+            artifact_check["entryPoint"] = dict(artifact["entryPoint"])
         artifact_checks.append(artifact_check)
 
     for toolchain in toolchains:
@@ -33368,6 +33520,8 @@ def _inspection_failed_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
         failed["sourceBackend"] = artifact.get("sourceBackend")
     if "variant" in artifact:
         failed["variant"] = artifact.get("variant")
+    if isinstance(artifact.get("entryPoint"), Mapping):
+        failed["entryPoint"] = dict(artifact["entryPoint"])
     if "error" in artifact:
         failed["error"] = artifact.get("error")
     for field_name in (
@@ -34215,11 +34369,14 @@ def _project_config_for_scan_validation(
         return None
 
     source_overrides = project.get("sourceOverrides")
+    entry_point_selections = project.get("entryPointSelections", {})
     defines = project.get("defines")
     source_options = project.get("sourceOptions", {})
     if not _valid_non_empty_string_mapping(
         source_overrides
     ) or not _valid_string_mapping(defines):
+        return None
+    if not _valid_non_empty_string_mapping(entry_point_selections):
         return None
     if not _valid_source_options_mapping(source_options):
         return None
@@ -34276,6 +34433,7 @@ def _project_config_for_scan_validation(
         targets=tuple(targets),
         output_dir=_normalize_project_relative_path(output_dir),
         source_overrides=_normalize_project_relative_path_mapping(source_overrides),
+        entry_points=_normalize_project_relative_path_mapping(entry_point_selections),
         include_dirs=tuple(_normalize_project_relative_paths(include_dirs)),
         defines=dict(defines),
         source_options={
@@ -34451,6 +34609,65 @@ ArtifactIdentity = Tuple[str, str, str, Optional[str]]
 DeclaredArtifact = Tuple[int, Mapping[str, Any]]
 
 
+def _artifact_entry_point_source(record: Mapping[str, Any]) -> str | None:
+    entry_point = record.get("entryPoint")
+    if not isinstance(entry_point, Mapping):
+        return None
+    source = entry_point.get("source")
+    return str(source) if _is_non_empty_string(source) else None
+
+
+def _configured_entry_point_for_artifact(
+    record: Mapping[str, Any],
+    project: Mapping[str, Any] | None,
+) -> str | None:
+    source_path = record.get("source")
+    selections = (
+        project.get("entryPointSelections") if isinstance(project, Mapping) else None
+    )
+    if not _is_non_empty_string(source_path) or not isinstance(selections, Mapping):
+        return None
+    valid_selections = {
+        str(pattern): str(value)
+        for pattern, value in selections.items()
+        if _is_non_empty_string(pattern) and _is_non_empty_string(value)
+    }
+    return _entry_point_from_mapping(str(source_path), valid_selections)
+
+
+def _artifact_entry_point_contract_reasons(
+    prefix: str,
+    record: Mapping[str, Any],
+    *,
+    project: Mapping[str, Any] | None,
+) -> list[str]:
+    entry_point = record.get("entryPoint")
+    configured = _configured_entry_point_for_artifact(record, project)
+    if entry_point is None:
+        if configured is not None:
+            return [
+                f"{prefix}.entryPoint must be recorded when the source matches "
+                "project.entryPointSelections"
+            ]
+        return []
+    if not isinstance(entry_point, Mapping):
+        return [f"{prefix}.entryPoint must be an object"]
+    reasons = _unsupported_mapping_field_reasons(
+        f"{prefix}.entryPoint", entry_point, REPORT_ARTIFACT_ENTRY_POINT_FIELDS
+    )
+    for field_name in ("source", "target"):
+        if not _is_non_empty_string(entry_point.get(field_name)):
+            reasons.append(f"{prefix}.entryPoint.{field_name} must be a string")
+    if "stage" in entry_point and not _is_non_empty_string(entry_point.get("stage")):
+        reasons.append(f"{prefix}.entryPoint.stage must be a string")
+
+    if configured is not None and entry_point.get("source") != configured:
+        reasons.append(
+            f"{prefix}.entryPoint.source must match project.entryPointSelections"
+        )
+    return reasons
+
+
 def _artifact_identity(record: Mapping[str, Any]) -> ArtifactIdentity | None:
     source = record.get("source")
     target = record.get("target")
@@ -34481,6 +34698,7 @@ def _expected_artifact_identity(
     *,
     preserve_source_suffix: bool = False,
     stage: str | None = None,
+    entry_point: str | None = None,
 ) -> ArtifactIdentity | None:
     normalized_target = _normalized_targets([target])[0]
     output_base = project_output_path / normalized_target
@@ -34490,6 +34708,7 @@ def _expected_artifact_identity(
         source,
         normalized_target,
         preserve_source_suffix=preserve_source_suffix,
+        entry_point=entry_point,
     )
     if normalized_target == "webgl" and stage in WEBGL_PROJECT_GLSLANG_STAGE_BY_LABEL:
         expected_relative = _webgl_stage_relative_path(expected_relative, stage)
@@ -34532,6 +34751,28 @@ def _webgl_expected_stages_from_artifacts(
     )
 
 
+def _expected_entry_points_from_artifacts(
+    artifacts: Sequence[Mapping[str, Any]],
+    source: str,
+    target: str,
+    variant: str | None,
+) -> tuple[str | None, ...]:
+    entry_points = {
+        entry_point
+        for artifact in artifacts
+        if isinstance(artifact, Mapping)
+        and artifact.get("source") == source
+        and _is_non_empty_string(artifact.get("target"))
+        and _normalized_targets([str(artifact["target"])])[0] == target
+        and _artifact_variant_identity(artifact) == variant
+        for entry_point in (_artifact_entry_point_source(artifact),)
+        if entry_point is not None
+    }
+    if not entry_points:
+        return (None,)
+    return tuple(sorted(entry_points))
+
+
 def _expected_artifact_identities(
     root_path: Path,
     project_output_path: Path,
@@ -34553,21 +34794,25 @@ def _expected_artifact_identities(
             continue
         for target in _normalized_targets(targets):
             for variant in variants:
-                for stage in _webgl_expected_stages_from_artifacts(
+                for entry_point in _expected_entry_points_from_artifacts(
                     artifacts, source, target, variant
                 ):
-                    identity = _expected_artifact_identity(
-                        root_path,
-                        project_output_path,
-                        source,
-                        target,
-                        variant,
-                        preserve_source_suffix=(source, target)
-                        in preserve_source_suffix,
-                        stage=stage,
-                    )
-                    if identity is not None:
-                        expected_identities.add(identity)
+                    for stage in _webgl_expected_stages_from_artifacts(
+                        artifacts, source, target, variant
+                    ):
+                        identity = _expected_artifact_identity(
+                            root_path,
+                            project_output_path,
+                            source,
+                            target,
+                            variant,
+                            preserve_source_suffix=(source, target)
+                            in preserve_source_suffix,
+                            stage=stage,
+                            entry_point=entry_point,
+                        )
+                        if identity is not None:
+                            expected_identities.add(identity)
     return expected_identities
 
 
@@ -37392,6 +37637,33 @@ def _project_metadata_contract_reasons(
                 f"({_value_mismatch_context(source_override_count, len(source_overrides))})"
             )
 
+    entry_point_selections = project.get("entryPointSelections")
+    entry_point_selections_are_mapping = isinstance(entry_point_selections, Mapping)
+    if _optional_project_field(
+        project, "entryPointSelections", required=require_full_metadata
+    ):
+        reasons.extend(
+            _non_empty_string_mapping_contract_reasons(
+                "project.entryPointSelections", entry_point_selections
+            )
+        )
+    if _optional_project_field(
+        project, "entryPointSelectionCount", required=require_full_metadata
+    ):
+        count = project.get("entryPointSelectionCount")
+        if not _is_non_negative_int(count):
+            reasons.append(
+                "project.entryPointSelectionCount must be a non-negative integer"
+            )
+        elif entry_point_selections_are_mapping and count != len(
+            entry_point_selections
+        ):
+            reasons.append(
+                "project.entryPointSelectionCount must match "
+                "project.entryPointSelections "
+                f"({_value_mismatch_context(count, len(entry_point_selections))})"
+            )
+
     source_options = project.get("sourceOptions")
     source_options_is_mapping = isinstance(source_options, Mapping)
     if _optional_project_field(
@@ -37802,6 +38074,9 @@ def _validation_artifact_contract_reasons(
                 require_registered=True,
             )
         )
+    reasons.extend(
+        _artifact_entry_point_contract_reasons(prefix, artifact, project=None)
+    )
     identity = _artifact_identity(artifact)
     if (
         identity is not None
@@ -37831,6 +38106,24 @@ def _validation_artifact_contract_reasons(
         reasons.append(
             f"{prefix}.sourceBackend must match "
             f"report.artifacts[{referenced_artifact[0]}].sourceBackend"
+        )
+    if (
+        "entryPoint" not in artifact
+        and referenced_artifact is not None
+        and isinstance(referenced_artifact[1].get("entryPoint"), Mapping)
+    ):
+        reasons.append(
+            f"{prefix}.entryPoint must be recorded when "
+            f"report.artifacts[{referenced_artifact[0]}].entryPoint is recorded"
+        )
+    if (
+        "entryPoint" in artifact
+        and referenced_artifact is not None
+        and artifact.get("entryPoint") != referenced_artifact[1].get("entryPoint")
+    ):
+        reasons.append(
+            f"{prefix}.entryPoint must match "
+            f"report.artifacts[{referenced_artifact[0]}].entryPoint"
         )
     source_hash_status = artifact.get("sourceHashStatus")
     if require_status_fields and "sourceHashStatus" not in artifact:
@@ -38095,6 +38388,7 @@ def _toolchain_run_contract_reasons(
                 require_registered=True,
             )
         )
+    reasons.extend(_artifact_entry_point_contract_reasons(prefix, run, project=None))
     identity = _artifact_identity(run)
     if (
         identity is not None
@@ -38124,6 +38418,24 @@ def _toolchain_run_contract_reasons(
         reasons.append(
             f"{prefix}.sourceBackend must match "
             f"report.artifacts[{referenced_artifact[0]}].sourceBackend"
+        )
+    if (
+        "entryPoint" not in run
+        and referenced_artifact is not None
+        and isinstance(referenced_artifact[1].get("entryPoint"), Mapping)
+    ):
+        reasons.append(
+            f"{prefix}.entryPoint must be recorded when "
+            f"report.artifacts[{referenced_artifact[0]}].entryPoint is recorded"
+        )
+    if (
+        "entryPoint" in run
+        and referenced_artifact is not None
+        and run.get("entryPoint") != referenced_artifact[1].get("entryPoint")
+    ):
+        reasons.append(
+            f"{prefix}.entryPoint must match "
+            f"report.artifacts[{referenced_artifact[0]}].entryPoint"
         )
     if (
         referenced_artifact is not None
@@ -40328,6 +40640,7 @@ def _report_contract_diagnostics(path: Path, report: Any) -> list[ProjectDiagnos
                         normalized_target,
                         preserve_source_suffix=(source, normalized_target)
                         in preserve_source_suffix,
+                        entry_point=_artifact_entry_point_source(artifact),
                     )
                     if normalized_target == "webgl" and _is_non_empty_string(
                         artifact.get("stage")
@@ -40369,6 +40682,13 @@ def _report_contract_diagnostics(path: Path, report: Any) -> list[ProjectDiagnos
                 reasons.append(
                     f"artifacts[{index}].status must be translated or failed"
                 )
+            reasons.extend(
+                _artifact_entry_point_contract_reasons(
+                    f"artifacts[{index}]",
+                    artifact,
+                    project=project if isinstance(project, Mapping) else None,
+                )
+            )
             if "error" in artifact or (has_summary and status == "failed"):
                 if not _is_non_empty_string(artifact.get("error")):
                     reasons.append(f"artifacts[{index}].error must be a string")
@@ -40825,6 +41145,8 @@ def _run_toolchain_smoke(
                     run["stage"] = artifact["stage"]
                 if artifact.get("variant") is not None:
                     run["variant"] = artifact["variant"]
+                if isinstance(artifact.get("entryPoint"), Mapping):
+                    run["entryPoint"] = dict(artifact["entryPoint"])
                 runs.append(run)
                 if returncode != 0:
                     break

--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -43,6 +43,7 @@ from ..ast import (
     ReferenceType,
     ResourceMemoryQualifierNode,
     ReturnNode,
+    StageMap,
     StructMemberNode,
     StructNode,
     SwitchNode,
@@ -327,6 +328,28 @@ class OpenGLTemplateTypeError(ValueError):
         super().__init__(message)
         self.unresolved_parameter = unresolved_parameter
         self.enclosing_generated_type = enclosing_type
+
+
+class OpenGLEntryPointSelectionError(ValueError):
+    """Raised when a requested standalone OpenGL entry cannot be selected."""
+
+    project_diagnostic_code = "project.translate.opengl-entry-point-unavailable"
+    missing_capabilities = ("artifact.entry-point-selection",)
+
+    def __init__(
+        self,
+        message,
+        *,
+        entry_point=None,
+        available_entry_points=None,
+        reason=None,
+        source_location=None,
+    ):
+        super().__init__(message)
+        self.entry_point = entry_point
+        self.available_entry_points = tuple(available_entry_points or ())
+        self.reason = reason
+        self.source_location = source_location
 
 
 class OpenGLMappedOverloadError(ValueError):
@@ -2311,6 +2334,143 @@ class GLSLCodeGen:
     def generate(self, ast):
         """Generate complete GLSL source for a CrossGL AST."""
         return self.generate_program(ast)
+
+    def generate_entry(self, ast, entry_point):
+        """Generate one independently loadable GLSL stage entry artifact."""
+        scoped_ast = self.entry_scoped_ast(ast, entry_point)
+        return self.generate_program(scoped_ast)
+
+    def entry_scoped_ast(self, ast, entry_point):
+        if not isinstance(entry_point, str) or not entry_point.strip():
+            raise OpenGLEntryPointSelectionError(
+                "OpenGL entry-point selection requires a non-empty source entry name",
+                entry_point=entry_point,
+                reason="invalid-name",
+            )
+        entry_point = entry_point.strip()
+        stage_entry_types = self.combined_stage_entry_types()
+        entries = collect_stage_entry_records(ast, None, stage_entry_types)
+        available = sorted(
+            {
+                str(getattr(function, "name", ""))
+                for _entry_id, _stage_name, function in entries
+                if getattr(function, "name", None)
+            }
+        )
+        matches = [
+            (entry_id, stage_name, function)
+            for entry_id, stage_name, function in entries
+            if getattr(function, "name", None) == entry_point
+        ]
+        if not matches:
+            raise OpenGLEntryPointSelectionError(
+                f"OpenGL source entry point '{entry_point}' was not found",
+                entry_point=entry_point,
+                available_entry_points=available,
+                reason="not-found",
+            )
+        if len(matches) != 1:
+            raise OpenGLEntryPointSelectionError(
+                f"OpenGL source entry point '{entry_point}' is ambiguous",
+                entry_point=entry_point,
+                available_entry_points=available,
+                reason="ambiguous",
+            )
+
+        _selected_id, selected_stage_name, selected_function = matches[0]
+        selected_stage = next(
+            (
+                (stage_type, stage)
+                for stage_type, stage in getattr(ast, "stages", {}).items()
+                if getattr(stage, "entry_point", None) is selected_function
+            ),
+            None,
+        )
+        scoped_ast = deepcopy(ast)
+        selected_copy_function = None
+        scoped_ast.functions = [
+            function
+            for function in getattr(scoped_ast, "functions", []) or []
+            if function_stage_name(function) not in stage_entry_types
+            or (
+                selected_stage is None
+                and function_stage_name(function) == selected_stage_name
+                and getattr(function, "name", None) == entry_point
+            )
+        ]
+        selected_stages = StageMap()
+        if selected_stage is not None:
+            stage_type, stage = selected_stage
+            selected_stage_copy = deepcopy(stage)
+            selected_stages.append(stage_type, selected_stage_copy)
+            selected_copy_function = selected_stage_copy.entry_point
+        else:
+            selected_copy_function = next(
+                (
+                    function
+                    for function in scoped_ast.functions
+                    if function_stage_name(function) == selected_stage_name
+                    and getattr(function, "name", None) == entry_point
+                ),
+                None,
+            )
+        scoped_ast.stages = selected_stages
+        if selected_copy_function is None:
+            raise OpenGLEntryPointSelectionError(
+                f"OpenGL source entry point '{entry_point}' could not be copied",
+                entry_point=entry_point,
+                available_entry_points=available,
+                reason="copy-failed",
+            )
+
+        reachable_names = self.entry_reachable_function_names(
+            scoped_ast,
+            selected_copy_function,
+        )
+        scoped_ast.functions = [
+            function
+            for function in getattr(scoped_ast, "functions", []) or []
+            if function is selected_copy_function
+            or getattr(function, "name", None) in reachable_names
+        ]
+        for _stage_type, stage in scoped_ast.stages.items():
+            stage.local_functions = [
+                function
+                for function in getattr(stage, "local_functions", []) or []
+                if getattr(function, "name", None) in reachable_names
+            ]
+        return scoped_ast
+
+    def entry_reachable_function_names(self, ast, entry_function):
+        functions = list(getattr(ast, "functions", []) or [])
+        for _stage_type, stage in getattr(ast, "stages", {}).items():
+            functions.extend(getattr(stage, "local_functions", []) or [])
+        functions_by_name = {}
+        for function in functions:
+            name = getattr(function, "name", None)
+            if name:
+                functions_by_name.setdefault(name, []).append(function)
+
+        reachable_names = set()
+        pending = [entry_function]
+        visited = set()
+        while pending:
+            function = pending.pop()
+            if id(function) in visited:
+                continue
+            visited.add(id(function))
+            for node in self.walk_ast(getattr(function, "body", [])):
+                if not isinstance(node, FunctionCallNode):
+                    continue
+                name = self.function_call_name(node)
+                if not name or name in reachable_names:
+                    continue
+                candidates = functions_by_name.get(name, ())
+                if not candidates:
+                    continue
+                reachable_names.add(name)
+                pending.extend(candidates)
+        return reachable_names
 
     def generate_stage(self, ast, shader_type):
         """Generate GLSL source for a single requested shader stage."""

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -84,9 +84,12 @@ The current harness verifies:
   frontier when SPIR-V tools are available. Vulkan atomic-fence feature work is
   deferred; the separate `fence.metal` contract check prevents generated
   barriers from being mistaken for semantic support;
-- OpenGL artifact generation for `arange.metal`, including deterministic
-  separation of the source `float` and `bfloat16_t` helper declarations after
-  both map to GLSL `float` and source-typed call rewriting coverage;
+- entry-scoped OpenGL packaging for the materialized `arangeuint32` compute
+  entry from `arange.metal`. Project configuration selects the source entry,
+  emits it at the deterministic `arange/arangeuint32.glsl` path as OpenGL
+  `main`, and records the source-to-target entry identity in the portability
+  report. The standalone artifact exposes only the `start`, `step`, and `out`
+  resources and preserves the source arithmetic without an MLX source rewrite;
 - OpenGL artifact generation for the clean eight-source `arg_reduce.metal`,
   `binary_two.metal`, `logsumexp.metal`, `rms_norm.metal`, `rope.metal`,
   `scaled_dot_product_attention.metal`, `softmax.metal`, and `ternary.metal`
@@ -114,6 +117,10 @@ The current harness verifies:
 - on Linux CI, native Vulkan execution and readback for the generated MLX
   `arange.metal` unsigned 32-bit, signed 32-bit, and floating-point entry points
   through the optional Vulkan compute runtime and Mesa Vulkan software driver.
+- on Linux CI, native OpenGL 4.3 execution and readback for the selected
+  `arangeuint32` artifact through ModernGL and Mesa EGL. Four invocations use
+  `start = 300` and `step = 17`; the required zero-tolerance comparison is
+  `[300, 317, 334, 351]`.
 
 Pull requests run the 12-source pinned reduced scope: 11 clean frontier sources
 and the explicitly blocked `fence.metal` contract source. They also run the
@@ -158,11 +165,12 @@ reference-accessor fixture is not included in those runtime manifests; its
 scope ends at generated-source inspection and native compiler validation. The
 reduced arange fixtures select the translated artifact by source and target,
 then select `CSMain`, `main`, or `arangeuint32` independently for DirectX,
-OpenGL, or Vulkan dispatch. The aggregate DirectX and OpenGL artifacts currently
-expose their first `uint8` specialization through `CSMain` and `main`; per-entry
-target packaging remains tracked in CrossGL/crosstl#1523. Vulkan execution
-selects `arangeuint32`, `arangeint32`, and `arangefloat32` explicitly, and its
-unsigned fixture uses values above the 8-bit range to detect entry-point drift.
+OpenGL, or Vulkan dispatch. OpenGL project translation packages source entry
+`arangeuint32` as a standalone `main` artifact with an entry-scoped reflected
+interface; its unsigned fixture uses values above the 8-bit range to detect
+entry drift. DirectX still exercises the aggregate artifact's first `uint8`
+entry. Vulkan execution selects `arangeuint32`, `arangeint32`, and
+`arangefloat32` explicitly and uses the same wide unsigned probe.
 Plans report remaining non-blocking platform, layout, and entry-point ownership
 warnings. The reduced fixture execution
 report exercises the project runner and adapter contract with reference
@@ -207,18 +215,19 @@ python demos/integrations/mlx/run_mlx_porting.py \
   --summary /tmp/mlx/.crosstl-mlx-porting/full-corpus-summary.json
 ```
 
-On Linux, install SPIR-V tools and the Vulkan runtime dependencies to require
-OpenGL compilation and validation for the reference-accessor fixture as well as
-Vulkan validation and native execution of the generated MLX `arange` artifact:
+On Linux, install the OpenGL, SPIR-V, and Vulkan runtime dependencies to require
+OpenGL compilation and native execution as well as Vulkan validation and native
+execution of the generated MLX `arange` artifacts:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y glslang-tools libvulkan1 mesa-vulkan-drivers spirv-tools vulkan-tools
-python -m pip install vulkan==1.3.275.1
+sudo apt-get install -y glslang-tools libegl1 libgl1-mesa-dri libglx-mesa0 mesa-vulkan-drivers spirv-tools vulkan-tools
+python -m pip install moderngl==5.12.0 vulkan==1.3.275.1
 python demos/integrations/mlx/run_mlx_porting.py \
   --mlx-root /tmp/mlx \
   --require-opengl-frontier-toolchain \
   --require-opengl-gemv-toolchain \
+  --require-opengl-native-runtime \
   --require-vulkan-gemv-toolchain \
   --require-vulkan-toolchain \
   --require-vulkan-native-runtime

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -515,11 +515,17 @@
         "arangefloat32"
       ]
     },
+    "native_opengl_execution": {
+      "required_on_linux_ci": true,
+      "source_entry_point": "arangeuint32",
+      "target_entry_point": "main",
+      "expected_output": [300, 317, 334, 351]
+    },
     "target_specializations": {
       "directx": "uint8 via CSMain",
-      "opengl": "uint8 via main",
+      "opengl": "entry-scoped uint32 via main",
       "vulkan": "uint32, int32, and float32 via named entry points",
-      "per_entry_packaging_tracked_by": "https://github.com/CrossGL/crosstl/issues/1523"
+      "remaining_entry_packaging_scope_tracked_by": "https://github.com/CrossGL/crosstl/issues/1523"
     }
   },
   "full_corpus_scout": {

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -231,7 +231,7 @@ RUNTIME_READINESS_ENTRY_POINTS = {
 }
 RUNTIME_READINESS_DEFAULT_VARIANTS = {
     "directx": "uint8",
-    "opengl": "uint8",
+    "opengl": "uint32",
     "vulkan": "uint32",
 }
 ARANGE_RUNTIME_VARIANTS = {
@@ -643,6 +643,7 @@ def _write_project_config(
     specialization_constants: Mapping[str, bool | int | float] | None = None,
     metal_source_options: Mapping[str, int] | None = None,
     metal_target_options: Mapping[str, Mapping[str, int]] | None = None,
+    entry_points: Mapping[str, str] | None = None,
 ) -> None:
     include_values = [include] if isinstance(include, str) else list(include)
     include_list = ", ".join(json.dumps(value) for value in include_values)
@@ -659,6 +660,11 @@ def _write_project_config(
         '"**/*.metal" = "metal"',
         "",
     ]
+    if entry_points:
+        lines.append("[project.entry_points]")
+        for source, entry_point in entry_points.items():
+            lines.append(f"{json.dumps(source)} = {json.dumps(entry_point)}")
+        lines.append("")
     if specialization_constants:
         lines.append("[project.specialization_constants]")
         for selector, value in specialization_constants.items():
@@ -2322,83 +2328,6 @@ def _translate_directx_vulkan_frontier(
     }
 
 
-def _require_arange_opengl_scalar_coercions(generated: str) -> None:
-    boolean_wrappers = (
-        (
-            "simd_shuffle_down(bool, uint)",
-            r"\bbool\s+simd_shuffle_down\s*\(\s*bool\s+data\s*,\s*uint\s+delta\s*\)\s*\{(?P<body>.*?)\}",
-            "subgroupShuffleDown(uint(data),delta)",
-        ),
-        (
-            "simd_shuffle_up(bool, uint)",
-            r"\bbool\s+simd_shuffle_up\s*\(\s*bool\s+data\s*,\s*uint\s+delta\s*\)\s*\{(?P<body>.*?)\}",
-            "subgroupShuffleUp(uint(data),delta)",
-        ),
-        (
-            "simd_shuffle_and_fill_up(bool, bool, uint)",
-            r"\bbool\s+simd_shuffle_and_fill_up\s*\(\s*bool\s+data\s*,\s*bool\s+filling\s*,\s*uint\s+delta\s*\)\s*\{(?P<body>.*?)\}",
-            "crossglWaveShuffleAndFillUp(uint(data),uint(filling),delta)",
-        ),
-        (
-            "simd_shuffle(bool, uint)",
-            r"\bbool\s+simd_shuffle\s*\(\s*bool\s+data\s*,\s*uint\s+lane\s*\)\s*\{(?P<body>.*?)\}",
-            "subgroupShuffle(uint(data),lane)",
-        ),
-    )
-    for signature, pattern, call in boolean_wrappers:
-        match = re.search(pattern, generated, flags=re.DOTALL)
-        _require(
-            match is not None,
-            f"OpenGL arange artifact is missing {signature}",
-        )
-        body = re.sub(r"\s+", "", match.group("body"))
-        return_pattern = rf"return\(*{re.escape(call)}!=(?:0u|uint\(0\))\)*;"
-        _require(
-            re.search(return_pattern, body) is not None,
-            (
-                "OpenGL arange artifact did not preserve the numeric-to-boolean "
-                f"scalar coercion in {signature}"
-            ),
-        )
-
-    signed_assignments = {
-        "int8": (
-            "arangeint8_out",
-            r"bitfieldExtract\(int\(.*uint\(arangeint8_start_Args_start\).*index\*uint\(arangeint8_step_Args_step\).*\),0,8\)",
-        ),
-        "int16": (
-            "arangeint16_out",
-            r"bitfieldExtract\(int\(.*uint\(arangeint16_start_Args_start\).*index\*uint\(arangeint16_step_Args_step\).*\),0,16\)",
-        ),
-        "int32": (
-            "arangeint32_out",
-            r"int\(.*uint\(arangeint32_start_Args_start\).*index\*uint\(arangeint32_step_Args_step\).*\)",
-        ),
-        "int64": (
-            "arangeint64_out",
-            r"\(*arangeint64_start_Args_start\+\(int64_t\(index\)\*arangeint64_step_Args_step\)\)*",
-        ),
-    }
-    for source_type, (output_name, expression_pattern) in signed_assignments.items():
-        assignment = re.search(
-            rf"\b{output_name}\s*\[\s*index\s*\]\s*=\s*(?P<expression>.*?);",
-            generated,
-            flags=re.DOTALL,
-        )
-        _require(
-            assignment is not None,
-            f"OpenGL arange artifact is missing the signed {source_type} assignment",
-        )
-        expression = re.sub(r"\s+", "", assignment.group("expression"))
-        _require(
-            re.fullmatch(expression_pattern, expression) is not None,
-            (
-                "OpenGL arange artifact did not preserve the signed "
-                f"{source_type} arange scalar coercion"
-            ),
-        )
-
-
 def _check_arange_opengl(
     mlx_root: Path,
     work_dir: Path,
@@ -2414,6 +2343,7 @@ def _check_arange_opengl(
         include=MLX_ARANGE_SOURCE,
         targets=("opengl",),
         output_dir=_relpath(work_dir / "out-arange-opengl", mlx_root),
+        entry_points={MLX_ARANGE_SOURCE: "arangeuint32"},
     )
     result = _run_command(
         "translate-arange-opengl",
@@ -2479,33 +2409,37 @@ def _check_arange_opengl(
         "OpenGL arange artifact retained a Metal system preprocessor line",
     )
     _require(
-        "float log1p(float" not in generated,
-        "OpenGL arange artifact retained a collapsed log1p target signature",
+        artifact.get("entryPoint")
+        == {"source": "arangeuint32", "target": "main", "stage": "compute"},
+        "OpenGL arange artifact did not record the selected compute entry",
     )
     _require(
-        "float log1p__metal_overload_1(float" in generated
-        and "float log1p__metal_overload_2(float" in generated
-        and "log1p__metal_overload_1(r)" in generated,
-        "OpenGL arange artifact did not resolve the mapped log1p collision",
+        generated.count("void main()") == 1 and "compute_main" not in generated,
+        "OpenGL arange artifact is not independently loadable through one main entry",
+    )
+    resource_bindings = re.findall(
+        r"layout\s*\(\s*std(?:140|430)\s*,\s*binding\s*=\s*(\d+)\s*\)\s*"
+        r"(?:uniform|buffer)\b",
+        generated,
     )
     _require(
-        "return {" not in generated,
-        "OpenGL arange artifact retained an untyped aggregate return",
+        sorted(int(binding) for binding in resource_bindings) == [0, 1, 2],
+        "OpenGL arange artifact must expose only start, step, and output resources",
+    )
+    normalized_source = re.sub(r"\s+", "", generated)
+    _require(
+        "out_[index]=(start+(index*step));" in normalized_source,
+        "OpenGL arange artifact did not preserve uint32 arange data flow",
     )
     _require(
-        "return complex64_t(x, theta);" in generated
-        and (
-            "return complex64_t((0.5 * log1p__metal_overload_1(r)), theta);"
-            in generated
-        )
-        and "return complex64_t(log(z0), theta);" in generated,
-        "OpenGL arange artifact did not lower aggregate complex returns",
+        "arangeuint8" not in generated and "arangefloat" not in generated,
+        "OpenGL arange artifact retained unrelated materialized entries",
     )
-    _require_arange_opengl_scalar_coercions(generated)
     _require(
-        "subgroupShuffleUp(value, delta);" in generated
-        and "return gl_SubgroupInvocationID >= delta ? shuffled : fill;" in generated,
-        "OpenGL arange artifact did not preserve shuffle-and-fill lane semantics",
+        "log1p__metal_overload_" not in generated
+        and "subgroupShuffle" not in generated
+        and "complex64_t probe(" not in generated,
+        "OpenGL arange artifact retained unrelated helper dependencies",
     )
     native_validation = _validate_arange_opengl(
         mlx_root,
@@ -2520,10 +2454,11 @@ def _check_arange_opengl(
         "source": MLX_ARANGE_SOURCE,
         "target": "opengl",
         "metalIncludesFiltered": True,
-        "mappedOverloadCollisionResolved": True,
-        "aggregateInitializerLowered": True,
-        "scalarCoercionLowered": True,
-        "shuffleAndFillLowered": True,
+        "selectedEntryPoint": "arangeuint32",
+        "targetEntryPoint": "main",
+        "interfaceResourceCount": 3,
+        "standaloneArtifact": True,
+        "arangeDataFlowPreserved": True,
         **native_validation,
         "trackedIssues": list(OPENGL_ARANGE_VALIDATION_TRACKED_ISSUES),
     }
@@ -3540,14 +3475,15 @@ def _runtime_report_results_for_target(
     return results
 
 
-def _require_vulkan_native_runtime_results(
+def _require_native_runtime_results(
     runtime_report: Mapping[str, Any],
+    target: str,
 ) -> None:
-    vulkan_results = _runtime_report_results_for_target(runtime_report, "vulkan")
+    target_results = _runtime_report_results_for_target(runtime_report, target)
     _require(
-        bool(vulkan_results)
-        and all(result.get("status") == "passed" for result in vulkan_results),
-        "Vulkan native runtime execution was required for every MLX arange fixture",
+        bool(target_results)
+        and all(result.get("status") == "passed" for result in target_results),
+        f"{target} native runtime execution was required for every MLX arange fixture",
     )
 
 
@@ -3637,7 +3573,7 @@ def _execute_native_runtime_fixtures_for_report(
     name: str,
     runtime_artifact_manifest_path: Path,
     targets: Sequence[str],
-    require_vulkan_native_runtime: bool,
+    required_native_runtime_targets: Sequence[str] = (),
 ) -> dict[str, Any]:
     metadata_path = report_dir / f"{name}.native-runtime-execution-metadata.json"
     manifest_path = report_dir / f"{name}.native-runtime-execution-manifest.json"
@@ -3684,8 +3620,8 @@ def _execute_native_runtime_fixtures_for_report(
     passed_count = int(summary.get("passedCount", 0))
     unavailable_count = int(summary.get("unavailableCount", 0))
     skipped_count = int(summary.get("skippedCount", 0))
-    if require_vulkan_native_runtime:
-        _require_vulkan_native_runtime_results(runtime_report)
+    for target in required_native_runtime_targets:
+        _require_native_runtime_results(runtime_report, target)
     status = "passed"
     if failed_count:
         status = "blocked-by-tracked-issues"
@@ -3716,7 +3652,7 @@ def _plan_runtime_readiness_for_report(
     name: str,
     artifact_report: Path,
     targets: Sequence[str],
-    require_vulkan_native_runtime: bool,
+    required_native_runtime_targets: Sequence[str] = (),
 ) -> dict[str, Any]:
     _require(
         artifact_report.is_file(),
@@ -3757,7 +3693,7 @@ def _plan_runtime_readiness_for_report(
         name=name,
         runtime_artifact_manifest_path=runtime_artifact_manifest_path,
         targets=targets,
-        require_vulkan_native_runtime=require_vulkan_native_runtime,
+        required_native_runtime_targets=required_native_runtime_targets,
     )
 
     runtime_artifact_diagnostics_by_code = _diagnostics_by_code(
@@ -3845,6 +3781,7 @@ def _plan_reduced_runtime_readiness(
     report_dir: Path,
     *,
     require_vulkan_native_runtime: bool,
+    require_opengl_native_runtime: bool,
 ) -> dict[str, Any]:
     reports = [
         _plan_runtime_readiness_for_report(
@@ -3853,7 +3790,9 @@ def _plan_reduced_runtime_readiness(
             name="directx-vulkan-runtime-readiness",
             artifact_report=report_dir / "directx-vulkan-frontier.json",
             targets=("directx", "vulkan"),
-            require_vulkan_native_runtime=require_vulkan_native_runtime,
+            required_native_runtime_targets=(
+                ("vulkan",) if require_vulkan_native_runtime else ()
+            ),
         ),
         _plan_runtime_readiness_for_report(
             mlx_root=mlx_root,
@@ -3861,7 +3800,9 @@ def _plan_reduced_runtime_readiness(
             name="opengl-runtime-readiness",
             artifact_report=report_dir / "arange-opengl.json",
             targets=("opengl",),
-            require_vulkan_native_runtime=False,
+            required_native_runtime_targets=(
+                ("opengl",) if require_opengl_native_runtime else ()
+            ),
         ),
     ]
     status = (
@@ -4198,6 +4139,9 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
     require_opengl_gemv_toolchain = bool(
         getattr(args, "require_opengl_gemv_toolchain", False)
     )
+    require_opengl_native_runtime = bool(
+        getattr(args, "require_opengl_native_runtime", False)
+    )
     require_vulkan_gemv_toolchain = bool(
         getattr(args, "require_vulkan_gemv_toolchain", False)
     )
@@ -4208,6 +4152,10 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
     _require(
         not require_opengl_gemv_toolchain or args.mode == REDUCED_FRONTIER_MODE,
         "--require-opengl-gemv-toolchain is only valid in reduced-frontier mode",
+    )
+    _require(
+        not require_opengl_native_runtime or args.mode == REDUCED_FRONTIER_MODE,
+        "--require-opengl-native-runtime is only valid in reduced-frontier mode",
     )
     _require(
         not require_vulkan_gemv_toolchain or args.mode == REDUCED_FRONTIER_MODE,
@@ -4327,6 +4275,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
                 mlx_root,
                 report_dir,
                 require_vulkan_native_runtime=args.require_vulkan_native_runtime,
+                require_opengl_native_runtime=require_opengl_native_runtime,
             )
         )
     elif args.mode == FULL_CORPUS_MODE:
@@ -4386,6 +4335,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "openglFrontierToolchainRequired": require_opengl_frontier_toolchain,
             "openglGemvToolchainRequired": require_opengl_gemv_toolchain,
+            "openglNativeRuntimeRequired": require_opengl_native_runtime,
             "vulkanGemvToolchainRequired": require_vulkan_gemv_toolchain,
             "runtimeParityClaimed": False,
         },
@@ -4445,6 +4395,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--require-vulkan-native-runtime",
         action="store_true",
         help="Fail unless the MLX-generated Vulkan arange fixture executes natively.",
+    )
+    parser.add_argument(
+        "--require-opengl-native-runtime",
+        action="store_true",
+        help=(
+            "Fail unless the selected MLX OpenGL arangeuint32 artifact executes "
+            "natively and passes exact output comparison."
+        ),
     )
     parser.add_argument(
         "--require-opengl-frontier-toolchain",

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -25,8 +25,8 @@ Use the project pipeline as an audit-first migration workflow:
    diagnostics before writing translated artifacts.
 2. Add or refine ``crosstl.toml`` so repository-relative source roots,
    include/exclude patterns, source overrides, include directories, defines,
-   named variants, output directory, targets, and optional external corpus
-   manifest are explicit.
+   named variants, optional entry-point selections, output directory, targets,
+   and optional external corpus manifest are explicit.
 3. Run ``translate-project`` into a separate output directory and keep the
    generated portability report with the translated artifacts.
 4. Run ``validate-project`` on the generated report. Use the JSON output for
@@ -105,6 +105,10 @@ Use these report fields to decide the next action:
    * - ``artifactMatrix``
      - Confirm the expected unit, target, and named-variant artifact plan before
        translation, then identify missing or extra artifacts after translation.
+   * - ``project.entryPointSelections`` and ``artifacts[].entryPoint``
+     - Confirm that a requested materialized source entry was packaged under its
+       deterministic entry path and identify the reflected target entry and
+       stage.
    * - ``validation``
      - Check current source hashes and byte sizes, generated artifact hashes
        and byte sizes, source maps, source remaps, optional toolchain
@@ -178,6 +182,7 @@ error diagnostics.
 ``--validate`` records artifact existence, source and generated hash checks,
 source-map and source-remap status, and configured toolchain availability
 without invoking external compiler tools.
+
 Embedded toolchain availability records name the configured validation hook
 tools for each target; paths and availability remain environment-specific.
 ``--run-toolchains`` implies artifact validation and records any available
@@ -191,6 +196,36 @@ builtins, defaulting to compute for generic ``.glsl`` outputs.
 Vulkan smoke checks validate binary ``.spv`` artifacts with ``spirv-val`` and
 assemble textual ``.spvasm`` artifacts with ``spirv-as -o`` pointed at the
 platform null device.
+
+Entry-Scoped OpenGL Artifacts
+-----------------------------
+
+Repositories can request a standalone artifact for one materialized source
+entry by adding a repository-relative selector table to ``crosstl.toml``:
+
+.. code-block:: toml
+
+   [project]
+   include = ["kernels/arange.metal"]
+   include_dirs = ["."]
+   targets = ["opengl"]
+   output_dir = "crosstl-out"
+
+   [project.entry_points]
+   "kernels/arange.metal" = "arangeuint32"
+
+For OpenGL compute output, the selected source entry is emitted as target entry
+``main``. A source such as ``kernels/arange.metal`` produces
+``crosstl-out/opengl/kernels/arange/arangeuint32.glsl``. The portability report
+records the source entry, target entry, and reflected stage on the artifact;
+embedded validation records carry the same identity. Runtime artifact manifests
+then reflect only the selected stage interface from that standalone output.
+
+Selection is exact after source materialization. Missing or ambiguous entries
+fail with structured diagnostics and no target file. Targets that do not yet
+implement standalone entry generation also fail explicitly instead of pruning
+an aggregate artifact. When ``project.entry_points`` is absent, project
+translation keeps the existing aggregate output path and behavior.
 
 Project scan, report, and translation commands also accept repeatable
 ``--source-root``, ``--include-dir``, ``--define``, and ``--source-override``

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -23,7 +23,7 @@ implicitly supported.
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1275", "347", "Microsoft Learn HLSL reference; HLSL specification project"
-   "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_translator/test_codegen/test_GLSL_storage_pointer_codegen.py, tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py, tests/test_backend/test_GLSL", "1411", "249", "GLSL 4.60 specification; OpenGL registry"
+   "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_translator/test_codegen/test_GLSL_storage_pointer_codegen.py, tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py, tests/test_backend/test_GLSL", "1413", "249", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_webgl_codegen.py", "40", "38", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "104", "70", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "1432", "548", "Apple Metal resources; Metal Shading Language specification"
@@ -37,17 +37,17 @@ implicitly supported.
 .. csv-table:: Summary by backend
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "68", "0", "2", "0", "0", "0"
-   "OpenGL / GLSL", "68", "0", "2", "0", "0", "0"
-   "WebGL / GLSL ES", "38", "0", "23", "9", "0", "0"
-   "WebGPU / WGSL", "42", "0", "21", "7", "0", "0"
-   "Metal", "66", "0", "4", "0", "0", "0"
-   "Vulkan SPIR-V", "68", "0", "2", "0", "0", "0"
-   "CUDA", "62", "0", "8", "0", "0", "0"
-   "HIP", "62", "0", "8", "0", "0", "0"
-   "Mojo", "64", "0", "6", "0", "0", "0"
-   "Rust", "65", "0", "5", "0", "0", "0"
-   "Slang", "66", "0", "4", "0", "0", "0"
+   "DirectX / HLSL", "68", "0", "2", "1", "0", "0"
+   "OpenGL / GLSL", "69", "0", "2", "0", "0", "0"
+   "WebGL / GLSL ES", "38", "0", "23", "10", "0", "0"
+   "WebGPU / WGSL", "42", "0", "21", "8", "0", "0"
+   "Metal", "66", "0", "4", "1", "0", "0"
+   "Vulkan SPIR-V", "68", "0", "2", "1", "0", "0"
+   "CUDA", "62", "0", "8", "1", "0", "0"
+   "HIP", "62", "0", "8", "1", "0", "0"
+   "Mojo", "64", "0", "6", "1", "0", "0"
+   "Rust", "65", "0", "5", "1", "0", "0"
+   "Slang", "66", "0", "4", "1", "0", "0"
 
 Graphics Backend Focus
 ----------------------
@@ -58,9 +58,9 @@ scope for graphics backend completion work.
 .. csv-table:: Graphics backend status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "68", "0", "2", "0", "0", "0"
-   "OpenGL / GLSL", "68", "0", "2", "0", "0", "0"
-   "Metal", "66", "0", "4", "0", "0", "0"
+   "DirectX / HLSL", "68", "0", "2", "1", "0", "0"
+   "OpenGL / GLSL", "69", "0", "2", "0", "0", "0"
+   "Metal", "66", "0", "4", "1", "0", "0"
 
 .. csv-table:: DirectX/OpenGL/Metal actionable backlog
    :header: "Backend", "Category", "Feature", "Status", "Notes"
@@ -75,17 +75,17 @@ inspection, diagnostics, validation, and corpus-coverage rows.
 .. csv-table:: Project-porting status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "25", "0", "1", "0", "0", "0"
-   "OpenGL / GLSL", "25", "0", "1", "0", "0", "0"
-   "WebGL / GLSL ES", "25", "0", "1", "0", "0", "0"
-   "WebGPU / WGSL", "25", "0", "1", "0", "0", "0"
-   "Metal", "25", "0", "1", "0", "0", "0"
-   "Vulkan SPIR-V", "25", "0", "1", "0", "0", "0"
-   "CUDA", "25", "0", "1", "0", "0", "0"
-   "HIP", "25", "0", "1", "0", "0", "0"
-   "Mojo", "25", "0", "1", "0", "0", "0"
-   "Rust", "25", "0", "1", "0", "0", "0"
-   "Slang", "25", "0", "1", "0", "0", "0"
+   "DirectX / HLSL", "25", "0", "1", "1", "0", "0"
+   "OpenGL / GLSL", "26", "0", "1", "0", "0", "0"
+   "WebGL / GLSL ES", "25", "0", "1", "1", "0", "0"
+   "WebGPU / WGSL", "25", "0", "1", "1", "0", "0"
+   "Metal", "25", "0", "1", "1", "0", "0"
+   "Vulkan SPIR-V", "25", "0", "1", "1", "0", "0"
+   "CUDA", "25", "0", "1", "1", "0", "0"
+   "HIP", "25", "0", "1", "1", "0", "0"
+   "Mojo", "25", "0", "1", "1", "0", "0"
+   "Rust", "25", "0", "1", "1", "0", "0"
+   "Slang", "25", "0", "1", "1", "0", "0"
 
 .. csv-table:: Project-porting actionable backlog
    :header: "Backend", "Feature", "Status", "Current gap", "Next scope"
@@ -183,6 +183,7 @@ Each category below uses the status codes from the legend.
    "Project include resolution", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Macro and define variants", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Batch project translation", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Entry-scoped project artifacts", "R", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
    "Optional validation hooks", "D", "D", "D", "D", "D", "D", "D", "D", "D", "D", "D"
    "Migration action report", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime integration planning", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"

--- a/support/features.json
+++ b/support/features.json
@@ -7190,6 +7190,97 @@
       }
     },
     {
+      "id": "project.entry_scoped_artifacts",
+      "category": "project",
+      "name": "Entry-scoped project artifacts",
+      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "support": {
+        "directx": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "opengl": {
+          "status": "supported",
+          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "evidence": [
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
+          ]
+        },
+        "metal": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "vulkan": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "cuda": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "hip": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "mojo": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "rust": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "slang": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        },
+        "webgl": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. WebGL2 does not support compute artifacts.",
+          "evidence": [
+            "tests/test_translator/test_codegen/test_webgl_codegen.py::def test_webgl_codegen_rejects_non_webgl_stages"
+          ]
+        },
+        "wgsl": {
+          "status": "validated_rejection",
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ]
+        }
+      }
+    },
+    {
       "id": "project.validation_hooks",
       "category": "project",
       "name": "Optional validation hooks",

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -2324,6 +2324,41 @@
     },
     {
       "category": "project",
+      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "id": "project.entry_scoped_artifacts",
+      "name": "Entry-scoped project artifacts",
+      "support": {
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
+          ],
+          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Validate report metadata, artifact records, failed artifacts, translated artifact existence, optional external toolchain availability, and opt-in toolchain smoke failures for project outputs.",
       "id": "project.validation_hooks",
       "name": "Optional validation hooks",
@@ -4426,7 +4461,7 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 70,
+    "feature_count": 71,
     "status_counts": {
       "directx": {
         "diagnostic": 2,
@@ -4434,7 +4469,7 @@
         "supported": 68,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "metal": {
         "diagnostic": 4,
@@ -4442,12 +4477,12 @@
         "supported": 66,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 68,
+        "supported": 69,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -2217,6 +2217,97 @@
     },
     {
       "category": "project",
+      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "id": "project.entry_scoped_artifacts",
+      "name": "Entry-scoped project artifacts",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
+          ],
+          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_translator/test_codegen/test_webgl_codegen.py::def test_webgl_codegen_rejects_non_webgl_stages"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. WebGL2 does not support compute artifacts.",
+          "status": "validated_rejection"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Validate report metadata, artifact records, failed artifacts, translated artifact existence, optional external toolchain availability, and opt-in toolchain smoke failures for project outputs.",
       "id": "project.validation_hooks",
       "name": "Optional validation hooks",
@@ -9375,7 +9466,7 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 26,
+    "feature_count": 27,
     "status_counts": {
       "cuda": {
         "diagnostic": 1,
@@ -9383,7 +9474,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "directx": {
         "diagnostic": 1,
@@ -9391,7 +9482,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "hip": {
         "diagnostic": 1,
@@ -9399,7 +9490,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "metal": {
         "diagnostic": 1,
@@ -9407,7 +9498,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "mojo": {
         "diagnostic": 1,
@@ -9415,12 +9506,12 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "opengl": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -9431,7 +9522,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "slang": {
         "diagnostic": 1,
@@ -9439,7 +9530,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "vulkan": {
         "diagnostic": 1,
@@ -9447,7 +9538,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "webgl": {
         "diagnostic": 1,
@@ -9455,7 +9546,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "wgsl": {
         "diagnostic": 1,
@@ -9463,7 +9554,7 @@
         "supported": 25,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       }
     }
   },

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -247,7 +247,7 @@
           "tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py",
           "tests/test_backend/test_GLSL"
         ],
-        "test_count": 1411
+        "test_count": 1413
       },
       "translator_codegen": {
         "exists": true,
@@ -8622,6 +8622,97 @@
     },
     {
       "category": "project",
+      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "id": "project.entry_scoped_artifacts",
+      "name": "Entry-scoped project artifacts",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
+            "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
+          ],
+          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_translator/test_codegen/test_webgl_codegen.py::def test_webgl_codegen_rejects_non_webgl_stages"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. WebGL2 does not support compute artifacts.",
+          "status": "validated_rejection"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_translator/test_project_translation.py::def test_translate_project_reports_entry_selection_for_unsupported_target"
+          ],
+          "notes": "Project configuration and reporting preserve the requested entry identity, deterministic output path, provenance, and structured unsupported-target diagnostic without emitting a misleading pruned artifact. Target-specific standalone generation is not implemented yet.",
+          "status": "validated_rejection"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Validate report metadata, artifact records, failed artifacts, translated artifact existence, optional external toolchain availability, and opt-in toolchain smoke failures for project outputs.",
       "id": "project.validation_hooks",
       "name": "Optional validation hooks",
@@ -15784,7 +15875,7 @@
   "summary": {
     "backend_count": 11,
     "backlog_count": 0,
-    "feature_count": 70,
+    "feature_count": 71,
     "status_counts": {
       "cuda": {
         "diagnostic": 8,
@@ -15792,7 +15883,7 @@
         "supported": 62,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "directx": {
         "diagnostic": 2,
@@ -15800,7 +15891,7 @@
         "supported": 68,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "hip": {
         "diagnostic": 8,
@@ -15808,7 +15899,7 @@
         "supported": 62,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "metal": {
         "diagnostic": 4,
@@ -15816,7 +15907,7 @@
         "supported": 66,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "mojo": {
         "diagnostic": 6,
@@ -15824,12 +15915,12 @@
         "supported": 64,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 68,
+        "supported": 69,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -15840,7 +15931,7 @@
         "supported": 65,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "slang": {
         "diagnostic": 4,
@@ -15848,7 +15939,7 @@
         "supported": 66,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "vulkan": {
         "diagnostic": 2,
@@ -15856,7 +15947,7 @@
         "supported": 68,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 0
+        "validated_rejection": 1
       },
       "webgl": {
         "diagnostic": 23,
@@ -15864,7 +15955,7 @@
         "supported": 38,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 9
+        "validated_rejection": 10
       },
       "wgsl": {
         "diagnostic": 21,
@@ -15872,7 +15963,7 @@
         "supported": 42,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 7
+        "validated_rejection": 8
       }
     }
   }

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2158,11 +2158,15 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "--require-opengl-gemv-toolchain" in mlx_porting
     assert "--require-vulkan-gemv-toolchain" in mlx_porting
     assert "--require-vulkan-native-runtime" in mlx_porting
+    assert "--require-opengl-native-runtime" in mlx_porting
     assert "Install Windows DirectX Shader Compiler" in mlx_porting
     assert "DirectXShaderCompiler/releases/download/v1.9.2602.24" in mlx_porting
     assert "dxc --version" in mlx_porting
     assert "glslang-tools" in mlx_porting
     assert "glslangValidator --version" in mlx_porting
+    assert "moderngl==5.12.0" in mlx_porting
+    assert "libegl1" in mlx_porting
+    assert "libgl1-mesa-dri" in mlx_porting
     assert "Validate OpenGL lowering contracts" in mlx_porting
     assert "opengl_lowers_expected_scalar_and_vector_conversions" in mlx_porting
     assert "opengl_preserves_metal_arithmetic_conversion_order" in mlx_porting
@@ -2204,7 +2208,7 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "OpenGL frontier toolchain must validate every source path" in mlx_porting
     assert "mlx/backend/metal/kernels/binary_two.metal" in mlx_porting
     assert "mesa-vulkan-drivers" in mlx_porting
-    assert "python -m pip install vulkan==1.3.275.1" in mlx_porting
+    assert "vulkan==1.3.275.1" in mlx_porting
     assert "vulkaninfo --summary" in mlx_porting
     assert "mlx-full-corpus-scout:" in mlx_porting
     assert "MLX full-corpus artifact scout" in mlx_porting

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -1076,7 +1076,7 @@ def test_runtime_readiness_uses_runtime_artifact_manifest_metadata(
         name="directx-runtime-readiness",
         artifact_report=artifact_report,
         targets=("directx",),
-        require_vulkan_native_runtime=False,
+        required_native_runtime_targets=(),
     )
 
     assert build_calls == [artifact_report]
@@ -1634,13 +1634,14 @@ def test_runtime_report_target_selection_returns_every_fixture_result():
     )
 
 
-def test_required_vulkan_runtime_rejects_any_failed_numeric_variant():
+@pytest.mark.parametrize("target", ("opengl", "vulkan"))
+def test_required_native_runtime_rejects_any_failed_numeric_variant(target):
     module = _load_harness()
     runtime_report = {
         "results": [
             {
                 "status": status,
-                "fixture": {"selector": {"target": "vulkan"}},
+                "fixture": {"selector": {"target": target}},
             }
             for status in ("passed", "passed", "runtime-failed")
         ]
@@ -1650,14 +1651,14 @@ def test_required_vulkan_runtime_rejects_any_failed_numeric_variant():
         module.PortingCheckError,
         match="every MLX arange fixture",
     ):
-        module._require_vulkan_native_runtime_results(runtime_report)
+        module._require_native_runtime_results(runtime_report, target)
 
 
 @pytest.mark.parametrize(
     ("target", "entry_point", "dtype"),
     (
         ("directx", "CSMain", "uint8"),
-        ("opengl", "main", "uint8"),
+        ("opengl", "main", "uint32"),
         ("vulkan", "arangeuint32", "uint32"),
     ),
 )
@@ -2160,7 +2161,7 @@ def _prepare_arange_opengl_check(module, tmp_path, generated):
     config_dir = work_dir / "configs"
     report_dir = work_dir / "reports"
     log_dir = work_dir / "logs"
-    generated_path = work_dir / "out" / "opengl" / "arange.glsl"
+    generated_path = work_dir / "out" / "opengl" / "arange" / "arangeuint32.glsl"
     for path in (config_dir, report_dir, log_dir, generated_path.parent):
         path.mkdir(parents=True, exist_ok=True)
     generated_path.write_text(generated, encoding="utf-8")
@@ -2172,6 +2173,11 @@ def _prepare_arange_opengl_check(module, tmp_path, generated):
                 "target": "opengl",
                 "path": generated_path.relative_to(mlx_root).as_posix(),
                 "status": "translated",
+                "entryPoint": {
+                    "source": "arangeuint32",
+                    "target": "main",
+                    "stage": "compute",
+                },
             }
         ],
     }
@@ -2184,56 +2190,19 @@ def _prepare_arange_opengl_check(module, tmp_path, generated):
 
 def _arange_opengl_frontier_source():
     return """
-    float log1p__metal_overload_1(float value) { return value; }
-    float log1p__metal_overload_2(float value) { return value; }
-    uint crossglWaveShuffleAndFillUp(uint value, uint fill, uint delta) {
-        uint shuffled = subgroupShuffleUp(value, delta);
-        return gl_SubgroupInvocationID >= delta ? shuffled : fill;
-    }
+    #version 450 core
     struct complex64_t { float real; float imag; };
-    bool simd_shuffle_down(bool data, uint delta) {
-        return (subgroupShuffleDown(uint(data), delta) != 0u);
-    }
-    bool simd_shuffle_up(bool data, uint delta) {
-        return (subgroupShuffleUp(uint(data), delta) != 0u);
-    }
-    bool simd_shuffle_and_fill_up(bool data, bool filling, uint delta) {
-        return (
-            crossglWaveShuffleAndFillUp(uint(data), uint(filling), delta) != 0u
-        );
-    }
-    bool simd_shuffle(bool data, uint lane) {
-        return (subgroupShuffle(uint(data), lane) != 0u);
-    }
-    void signed_arange_coercions(uint index) {
-        arangeint8_out[index] = bitfieldExtract(
-            int((uint(arangeint8_start_Args_start) +
-                 (index * uint(arangeint8_step_Args_step)))),
-            0,
-            8
-        );
-        arangeint16_out[index] = bitfieldExtract(
-            int((uint(arangeint16_start_Args_start) +
-                 (index * uint(arangeint16_step_Args_step)))),
-            0,
-            16
-        );
-        arangeint32_out[index] = int(
-            (uint(arangeint32_start_Args_start) +
-             (index * uint(arangeint32_step_Args_step)))
-        );
-        arangeint64_out[index] = (
-            arangeint64_start_Args_start +
-            (int64_t(index) * arangeint64_step_Args_step)
-        );
-    }
-    complex64_t probe(float x, float theta, float r, float z0) {
-        log1p__metal_overload_1(r);
-        if (x > 0.0) { return complex64_t(x, theta); }
-        if (r > 0.0) {
-            return complex64_t((0.5 * log1p__metal_overload_1(r)), theta);
-        }
-        return complex64_t(log(z0), theta);
+    layout(std430, binding = 2) buffer out_Buffer { uint out_[]; };
+    layout(std140, binding = 0) uniform arangeuint32_start_Args {
+        uint start;
+    };
+    layout(std140, binding = 1) uniform arangeuint32_step_Args {
+        uint step;
+    };
+    layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+    void main() {
+        uint index = uint(gl_GlobalInvocationID.x);
+        out_[index] = (start + (index * step));
     }
     """
 
@@ -2947,9 +2916,14 @@ def test_arange_opengl_check_confirms_native_validation(
 
     result = module._check_arange_opengl(*paths, "python")
 
-    assert result["aggregateInitializerLowered"] is True
-    assert result["scalarCoercionLowered"] is True
-    assert result["shuffleAndFillLowered"] is True
+    config = (paths[2] / "arange-opengl.toml").read_text(encoding="utf-8")
+    assert "[project.entry_points]" in config
+    assert f'"{module.MLX_ARANGE_SOURCE}" = "arangeuint32"' in config
+    assert result["selectedEntryPoint"] == "arangeuint32"
+    assert result["targetEntryPoint"] == "main"
+    assert result["interfaceResourceCount"] == 3
+    assert result["standaloneArtifact"] is True
+    assert result["arangeDataFlowPreserved"] is True
     assert result["nativeValidationAttempted"] is True
     assert result["nativeValidationBlockerConfirmed"] is False
     assert result["nativeValidationStatus"] == "validated"
@@ -2997,60 +2971,19 @@ def test_arange_opengl_check_reports_unavailable_validator(
     assert result["trackedIssues"] == []
 
 
-@pytest.mark.parametrize(
-    ("resolved_marker", "invalid_marker"),
-    (
-        (
-            "subgroupShuffleDown(uint(data), delta) != 0u",
-            "subgroupShuffleDown(uint(data), delta)",
-        ),
-        (
-            "subgroupShuffleUp(uint(data), delta) != 0u",
-            "subgroupShuffleUp(uint(data), delta)",
-        ),
-        (
-            "crossglWaveShuffleAndFillUp(uint(data), uint(filling), delta) != 0u",
-            "crossglWaveShuffleAndFillUp(uint(data), uint(filling), delta)",
-        ),
-        (
-            "subgroupShuffle(uint(data), lane) != 0u",
-            "subgroupShuffle(uint(data), lane)",
-        ),
-        (
-            "uint(arangeint8_start_Args_start)",
-            "arangeint8_start_Args_start",
-        ),
-        (
-            "uint(arangeint16_start_Args_start)",
-            "arangeint16_start_Args_start",
-        ),
-        (
-            "uint(arangeint32_start_Args_start)",
-            "arangeint32_start_Args_start",
-        ),
-        ("int64_t(index)", "index"),
-    ),
-)
-def test_arange_opengl_check_requires_scalar_coercions_before_validation(
-    tmp_path,
-    monkeypatch,
-    resolved_marker,
-    invalid_marker,
-):
+def test_arange_opengl_check_requires_selected_entry_metadata(tmp_path, monkeypatch):
     module = _load_harness()
-    generated = _arange_opengl_frontier_source()
-    assert resolved_marker in generated
     paths = _prepare_arange_opengl_check(
         module,
         tmp_path,
-        generated.replace(resolved_marker, invalid_marker, 1),
+        _arange_opengl_frontier_source(),
     )
-    commands = []
+    report_path = paths[3] / "arange-opengl.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["artifacts"][0].pop("entryPoint")
+    report_path.write_text(json.dumps(report), encoding="utf-8")
 
     def fake_run_command(name, command, *, log_dir, **_kwargs):
-        commands.append(name)
-        if name == "validate-arange-opengl":
-            pytest.fail("native validation ran before scalar coercion checks passed")
         stdout_path = log_dir / f"{name}.stdout"
         stderr_path = log_dir / f"{name}.stderr"
         stdout_path.write_text("", encoding="utf-8")
@@ -3058,65 +2991,13 @@ def test_arange_opengl_check_requires_scalar_coercions_before_validation(
         return module.CommandResult(name, list(command), 0, stdout_path, stderr_path)
 
     monkeypatch.setattr(module, "_run_command", fake_run_command)
-    monkeypatch.setattr(module.shutil, "which", lambda _name: "/tools/glslangValidator")
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
 
-    with pytest.raises(module.PortingCheckError, match="scalar coercion"):
-        module._check_arange_opengl(*paths, "python")
-
-    assert commands == ["translate-arange-opengl"]
-
-
-@pytest.mark.parametrize(
-    "diagnostic",
-    (
-        "ERROR: return type does not match the function return type",
-        "ERROR: cannot convert from uint to bool",
-        (
-            "ERROR: arange.glsl:301: 'simd_shuffle_down' : "
-            "no matching overloaded function found\n"
-            "ERROR: return type does not match the function return type"
-        ),
-    ),
-)
-def test_arange_opengl_check_rejects_native_failure_after_frontier_resolved(
-    tmp_path,
-    monkeypatch,
-    diagnostic,
-):
-    module = _load_harness()
-    paths = _prepare_arange_opengl_check(
-        module,
-        tmp_path,
-        _arange_opengl_frontier_source(),
-    )
-
-    def fake_run_command(name, command, *, log_dir, **_kwargs):
-        stdout_path = log_dir / f"{name}.stdout"
-        stderr_path = log_dir / f"{name}.stderr"
-        stdout_path.write_text(
-            diagnostic if name == "validate-arange-opengl" else "",
-            encoding="utf-8",
-        )
-        stderr_path.write_text("", encoding="utf-8")
-        return module.CommandResult(
-            name,
-            list(command),
-            2 if name == "validate-arange-opengl" else 0,
-            stdout_path,
-            stderr_path,
-        )
-
-    monkeypatch.setattr(module, "_run_command", fake_run_command)
-    monkeypatch.setattr(module.shutil, "which", lambda _name: "/tools/glslangValidator")
-
-    with pytest.raises(
-        module.PortingCheckError,
-        match="failed without a tracked validation issue",
-    ):
+    with pytest.raises(module.PortingCheckError, match="selected compute entry"):
         module._check_arange_opengl(*paths, "python")
 
 
-def test_arange_opengl_check_rejects_unrelated_overload_diagnostic(
+def test_arange_opengl_check_rejects_native_failure(
     tmp_path,
     monkeypatch,
 ):
@@ -3132,8 +3013,7 @@ def test_arange_opengl_check_rejects_unrelated_overload_diagnostic(
         stderr_path = log_dir / f"{name}.stderr"
         stdout_path.write_text(
             (
-                "ERROR: arange.glsl:301: 'unrelated_helper' : "
-                "no matching overloaded function found"
+                "ERROR: compute shader compilation failed"
                 if name == "validate-arange-opengl"
                 else ""
             ),
@@ -3158,14 +3038,15 @@ def test_arange_opengl_check_rejects_unrelated_overload_diagnostic(
         module._check_arange_opengl(*paths, "python")
 
 
-def test_arange_opengl_check_rejects_untyped_aggregate_return(
+def test_arange_opengl_check_rejects_extra_entry_resource(
     tmp_path,
     monkeypatch,
 ):
     module = _load_harness()
     generated = _arange_opengl_frontier_source().replace(
-        "return complex64_t(x, theta);",
-        "return { x, theta };",
+        "layout(local_size_x",
+        "layout(std430, binding = 4) buffer extra_Buffer { uint extra_[]; };\n"
+        "layout(local_size_x",
     )
     paths = _prepare_arange_opengl_check(module, tmp_path, generated)
 
@@ -3187,7 +3068,7 @@ def test_arange_opengl_check_rejects_untyped_aggregate_return(
 
     with pytest.raises(
         module.PortingCheckError,
-        match="retained an untyped aggregate return",
+        match="only start, step, and output resources",
     ):
         module._check_arange_opengl(*paths, "python")
 
@@ -3219,7 +3100,7 @@ def test_runtime_readiness_reports_tracked_plan_resource_blockers(
         name="opengl-runtime-readiness",
         artifact_report=artifact_report,
         targets=("opengl",),
-        require_vulkan_native_runtime=False,
+        required_native_runtime_targets=(),
     )
 
     assert result["status"] == "blocked-by-tracked-issues"
@@ -3247,6 +3128,7 @@ def test_runtime_readiness_reports_tracked_plan_resource_blockers(
 
 def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
     module = _load_harness()
+    calls = []
     reports = [
         {
             "name": "directx-vulkan-runtime-readiness",
@@ -3320,18 +3202,25 @@ def test_reduced_runtime_readiness_aggregates_fixture_execution(monkeypatch):
         },
     ]
 
+    def fake_plan_runtime_readiness(**kwargs):
+        calls.append(kwargs)
+        return reports.pop(0)
+
     monkeypatch.setattr(
         module,
         "_plan_runtime_readiness_for_report",
-        lambda **kwargs: reports.pop(0),
+        fake_plan_runtime_readiness,
     )
 
     result = module._plan_reduced_runtime_readiness(
         Path("/tmp/mlx"),
         Path("/tmp/reports"),
-        require_vulkan_native_runtime=False,
+        require_vulkan_native_runtime=True,
+        require_opengl_native_runtime=True,
     )
 
+    assert calls[0]["required_native_runtime_targets"] == ("vulkan",)
+    assert calls[1]["required_native_runtime_targets"] == ("opengl",)
     assert result["status"] == "blocked-by-tracked-issues"
     assert result["runtimeFixtureExecutionIncluded"] is True
     assert result["runtimeFixtureExecutionByStatus"] == {
@@ -4134,13 +4023,19 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
             "status": "passed",
         },
     )
+    runtime_requirements = []
+
+    def fake_runtime_readiness(*args, **kwargs):
+        runtime_requirements.append(kwargs)
+        return {
+            "name": "runtime-readiness",
+            "status": "blocked-by-tracked-issues",
+        }
+
     monkeypatch.setattr(
         module,
         "_plan_reduced_runtime_readiness",
-        lambda *args, **kwargs: {
-            "name": "runtime-readiness",
-            "status": "blocked-by-tracked-issues",
-        },
+        fake_runtime_readiness,
     )
     monkeypatch.setattr(
         module,
@@ -4157,6 +4052,7 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
             require_directx_toolchain=False,
             require_vulkan_toolchain=False,
             require_vulkan_native_runtime=False,
+            require_opengl_native_runtime=True,
             require_opengl_frontier_toolchain=True,
             require_opengl_gemv_toolchain=True,
             require_vulkan_gemv_toolchain=True,
@@ -4179,8 +4075,15 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
     ]
     assert reference_accessor_requirements == [(False, True)]
     assert opengl_frontier_requirements == [True]
+    assert runtime_requirements == [
+        {
+            "require_vulkan_native_runtime": False,
+            "require_opengl_native_runtime": True,
+        }
+    ]
     assert result["scope"]["openglFrontierToolchainRequired"] is True
     assert result["scope"]["openglGemvToolchainRequired"] is True
+    assert result["scope"]["openglNativeRuntimeRequired"] is True
     assert result["scope"]["vulkanGemvToolchainRequired"] is True
     assert result["scope"]["runtimeReadinessIncluded"] is True
     assert result["scope"]["runtimeFixtureExecutionIncluded"] is True

--- a/tests/test_translator/test_codegen/test_GLSL_codegen.py
+++ b/tests/test_translator/test_codegen/test_GLSL_codegen.py
@@ -41,6 +41,7 @@ from crosstl.translator.codegen.GLSL_codegen import (
     OpenGLCompileTimeGlobalError,
     OpenGLCompoundAssignmentError,
     OpenGLCooperativeMatrixError,
+    OpenGLEntryPointSelectionError,
     OpenGLFixedArrayResourceError,
     OpenGLForInIterableError,
     OpenGLGlobalInitializerError,
@@ -35270,6 +35271,79 @@ def test_glsl_subgroup_ops_combined_with_texture_gather():
     assert "linearSampler" not in generated
     assert "WaveActiveSum" not in generated
     assert "WaveGetLaneCount" not in generated
+
+
+ENTRY_SCOPED_COMPUTE_SOURCE = """
+shader EntryScopedCompute {
+    uint selected_helper(uint value) {
+        return value + 1u;
+    }
+
+    uint unrelated_helper(uint value) {
+        return value * 9u;
+    }
+
+    compute first {
+        void main(
+            constant uint& start @buffer(0),
+            constant uint& step @buffer(1),
+            RWStructuredBuffer<uint> out_ @buffer(2),
+            uint index @gl_GlobalInvocationID
+        ) {
+            out_[index] = unrelated_helper(start + index * step);
+        }
+    }
+
+    compute second {
+        void main(
+            constant uint& start @buffer(0),
+            constant uint& step @buffer(1),
+            RWStructuredBuffer<uint> out_ @buffer(2),
+            uint index @gl_GlobalInvocationID
+        ) {
+            out_[index] = selected_helper(start + index * step);
+        }
+    }
+}
+"""
+
+
+def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers(
+    tmp_path,
+):
+    ast = parse_code(tokenize_code(ENTRY_SCOPED_COMPUTE_SOURCE))
+
+    generated = GLSLCodeGen().generate_entry(ast, "second")
+
+    assert generated.count("void main()") == 1
+    assert "void compute_main" not in generated
+    assert "selected_helper" in generated
+    assert "unrelated_helper" not in generated
+    assert "first_Args" not in generated
+    assert "second_start_Args" in generated
+    assert "second_step_Args" in generated
+    assert generated.count("buffer out_Buffer") == 1
+    assert_glsl_compute_validates_if_available(
+        generated,
+        tmp_path,
+        "entry-scoped-compute",
+        spirv_target="spirv1.3",
+        validate_spirv=True,
+    )
+
+
+def test_opengl_entry_scoped_generation_reports_available_entries():
+    ast = parse_code(tokenize_code(ENTRY_SCOPED_COMPUTE_SOURCE))
+
+    with pytest.raises(
+        OpenGLEntryPointSelectionError,
+        match="source entry point 'missing' was not found",
+    ) as error:
+        GLSLCodeGen().generate_entry(ast, "missing")
+
+    assert error.value.reason == "not-found"
+    assert error.value.entry_point == "missing"
+    assert error.value.available_entry_points == ("first", "second")
 
 
 if __name__ == "__main__":

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -381,6 +381,40 @@ SIMPLE_CROSSL = textwrap.dedent("""
     }
     """).strip()
 
+ENTRY_SCOPED_COMPUTE_CROSSL = textwrap.dedent("""
+    shader EntryScopedCompute {
+        uint selected_helper(uint value) {
+            return value + 1u;
+        }
+
+        uint unrelated_helper(uint value) {
+            return value * 9u;
+        }
+
+        compute first {
+            void main(
+                constant uint& start @buffer(0),
+                constant uint& step @buffer(1),
+                RWStructuredBuffer<uint> out_ @buffer(2),
+                uint index @gl_GlobalInvocationID
+            ) {
+                out_[index] = unrelated_helper(start + index * step);
+            }
+        }
+
+        compute second {
+            void main(
+                constant uint& start @buffer(0),
+                constant uint& step @buffer(1),
+                RWStructuredBuffer<uint> out_ @buffer(2),
+                uint index @gl_GlobalInvocationID
+            ) {
+                out_[index] = selected_helper(start + index * step);
+            }
+        }
+    }
+    """).strip()
+
 DIRECTX_GRAPHICS_CROSSL = textwrap.dedent("""
     shader ProjectDirectXGraphics {
         struct VSInput {
@@ -832,6 +866,259 @@ def test_translate_project_accepts_path_like_output_dir(tmp_path):
     assert payload["project"]["outputDir"] == str((repo / "translated").resolve())
     assert payload["summary"]["translatedCount"] == 1
     assert (repo / "translated" / "cgl" / "simple.cgl").exists()
+
+
+def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            include = ["multi.cgl"]
+            targets = ["opengl"]
+            output_dir = "out"
+
+            [project.entry_points]
+            "multi.cgl" = "second"
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+
+    config = load_project_config(repo)
+    report = translate_project(config, format_output=False, validate=True)
+    payload = report.to_json()
+    artifact = payload["artifacts"][0]
+    artifact_path = repo / artifact["path"]
+    generated = artifact_path.read_text(encoding="utf-8")
+
+    assert config.entry_points == {"multi.cgl": "second"}
+    assert payload["project"]["entryPointSelections"] == {"multi.cgl": "second"}
+    assert payload["project"]["entryPointSelectionCount"] == 1
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["artifactMatrix"]["complete"] is True
+    assert artifact["path"] == "out/opengl/multi/second.glsl"
+    assert artifact["entryPoint"] == {
+        "source": "second",
+        "target": "main",
+        "stage": "compute",
+    }
+    assert artifact["provenance"]["pipeline"] == "entry-scoped-translate"
+    assert artifact["sourceMap"]["generated"]["file"] == artifact["path"]
+    assert artifact["sourceRemap"]["generatedFile"] == artifact["path"]
+    assert payload["validation"]["artifacts"][0]["entryPoint"] == artifact["entryPoint"]
+    assert generated.count("void main()") == 1
+    assert "void compute_main" not in generated
+    assert "selected_helper" in generated
+    assert "unrelated_helper" not in generated
+    assert "first_Args" not in generated
+    assert_compute_glsl_validates_if_available(generated, tmp_path)
+
+    report_path = repo / "report.json"
+    report.write_json(report_path)
+    validation = validate_project_report(report_path)
+    assert validation["success"] is True
+    manifest = build_runtime_artifact_manifest(report_path)
+    runtime_artifact = manifest["artifacts"][0]
+    assert runtime_artifact["entryPoints"] == [
+        {
+            "name": "main",
+            "stage": "compute",
+            "executionConfig": {
+                "local_size_x": 1,
+                "local_size_y": 1,
+                "local_size_z": 1,
+            },
+        }
+    ]
+    assert runtime_artifact["hostInterface"]["resourceCount"] == 3
+    assert {
+        resource["binding"] for resource in runtime_artifact["resourceBindings"]
+    } == {0, 1, 2}
+
+
+@pytest.mark.parametrize(
+    "entry_points",
+    (
+        pytest.param(
+            {"multi.cgl": "second", "*.cgl": "first"},
+            id="exact-selector-first",
+        ),
+        pytest.param(
+            {"*.cgl": "first", "multi.cgl": "second"},
+            id="glob-selector-first",
+        ),
+    ),
+)
+def test_translate_project_entry_selection_prefers_exact_path_over_glob(
+    tmp_path,
+    entry_points,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    config = project_api.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=("opengl",),
+        output_dir="out",
+        entry_points=entry_points,
+    )
+
+    report = translate_project(config, format_output=False)
+    payload = report.to_json()
+    artifact = payload["artifacts"][0]
+
+    assert artifact["path"] == "out/opengl/multi/second.glsl"
+    assert artifact["entryPoint"]["source"] == "second"
+    report_path = repo / "report.json"
+    report.write_json(report_path)
+    assert validate_project_report(report_path)["success"] is True
+
+
+def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+
+    payload = translate_project(
+        repo,
+        targets=["opengl"],
+        output_dir="out",
+        format_output=False,
+    ).to_json()
+    artifact = payload["artifacts"][0]
+    generated = (repo / artifact["path"]).read_text(encoding="utf-8")
+
+    assert artifact["path"] == "out/opengl/multi.glsl"
+    assert "entryPoint" not in artifact
+    assert artifact["provenance"]["pipeline"] == "single-file-translate"
+    assert "void main()" in generated
+    assert "void compute_main()" in generated
+    assert "selected_helper" in generated
+    assert "unrelated_helper" in generated
+
+
+def test_translate_project_reports_missing_selected_opengl_entry(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    config = project_api.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=("opengl",),
+        output_dir="out",
+        entry_points={"multi.cgl": "missing"},
+    )
+
+    payload = translate_project(config, format_output=False).to_json()
+    artifact = payload["artifacts"][0]
+
+    assert artifact["status"] == "failed"
+    assert artifact["entryPoint"] == {"source": "missing", "target": "main"}
+    assert artifact["path"] == "out/opengl/multi/missing.glsl"
+    assert not (repo / artifact["path"]).exists()
+    diagnostic = next(
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] == "project.translate.opengl-entry-point-unavailable"
+    )
+    assert diagnostic["severity"] == "error"
+    assert diagnostic["missingCapabilities"] == ["artifact.entry-point-selection"]
+
+
+@pytest.mark.parametrize(
+    "target",
+    (
+        "cuda",
+        "directx",
+        "hip",
+        "metal",
+        "mojo",
+        "rust",
+        "slang",
+        "vulkan",
+        "wgsl",
+    ),
+)
+def test_translate_project_reports_entry_selection_for_unsupported_target(
+    tmp_path, target
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    config = project_api.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=(target,),
+        output_dir="out",
+        entry_points={"multi.cgl": "second"},
+    )
+
+    payload = translate_project(config, format_output=False).to_json()
+    artifact = payload["artifacts"][0]
+
+    assert artifact["status"] == "failed"
+    assert artifact["path"].startswith(f"out/{target}/multi/second")
+    assert artifact["entryPoint"] == {"source": "second", "target": "second"}
+    diagnostic = next(
+        diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] == "project.translate.entry-point-target-unsupported"
+    )
+    assert diagnostic["missingCapabilities"] == ["artifact.entry-point-selection"]
+
+
+def test_validate_project_report_requires_configured_entry_point_metadata(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    config = project_api.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=("opengl",),
+        output_dir="out",
+        entry_points={"multi.cgl": "second"},
+    )
+    payload = translate_project(config, format_output=False, validate=True).to_json()
+    payload["artifacts"][0].pop("entryPoint")
+    payload["validation"]["artifacts"][0].pop("entryPoint")
+    for run in payload["validation"].get("toolchainRuns", []):
+        run.pop("entryPoint", None)
+    report_path = repo / "out" / "missing-entry-point-report.json"
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    validation = validate_project_report(report_path)
+
+    assert validation["success"] is False
+    diagnostic = validation["diagnostics"][0]
+    assert diagnostic["code"] == "project.validate.invalid-report"
+    assert (
+        "artifacts[0].entryPoint must be recorded when the source matches "
+        "project.entryPointSelections"
+    ) in diagnostic["message"]
 
 
 def test_translate_project_glslang_spec_constant_vertex_to_directx(tmp_path):
@@ -19620,6 +19907,7 @@ def test_translate_project_emits_closed_portability_report_schema(tmp_path):
         "templateMaterialization",
         "specializationConstants",
         "specializationMaterialization",
+        "entryPoint",
     }
     assert artifact["requiredCapabilities"] == []
     assert set(artifact["sourceHash"]) == project_pipeline.REPORT_HASH_FIELDS


### PR DESCRIPTION
## Summary

- add repository-relative `[project.entry_points]` selectors with deterministic exact-path and glob precedence
- emit a standalone OpenGL artifact for one selected materialized source entry, retaining only its stage interface and reachable helpers
- record source and target entry identity, stage, deterministic output path, provenance, source mapping, validation, and reflected runtime interface metadata
- reject missing, ambiguous, or unsupported-target selections with structured diagnostics and no misleading pruned artifact
- preserve aggregate project output unchanged when no entry is selected

## MLX impact

At MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`, the project harness selects `arangeuint32` from `arange.metal` and emits `arange/arangeuint32.glsl` as a standalone OpenGL `main` artifact. Its reflected interface contains only `start`, `step`, and `out`.

Linux CI loads the generated artifact through ModernGL and Mesa EGL, dispatches four invocations with `start = 300` and `step = 17`, reads back `[300, 317, 334, 351]`, and requires zero mismatches.

## Validation

- focused entry artifact and MLX tests (`91 passed`)
- full project translation suite (`1090 passed`)
- broader translator and package suites (`1395 passed, 6 skipped`)
- support tooling tests (`132 passed`)
- native Mesa OpenGL dispatch and readback with zero mismatches
- support matrix check and support issue dry-run (`0` desired issues)
- `pre-commit run --all-files`

This is the OpenGL compute slice of #1523. DirectX, Vulkan, and other target packages remain explicit unsupported-target diagnostics, and this change does not integrate the MLX host runtime or claim full numerical parity.

Closes #1723
Refs #1523
Refs #1462
