### PR TITLE
Apply project test-runner environments during execution

### DIFF
--- a/crosstl/project/test_runner.py
+++ b/crosstl/project/test_runner.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import time
 from collections import Counter
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -51,15 +52,28 @@ def build_project_test_runner_plan(
     artifact_payload, artifact_source = _load_json_payload(
         artifact_report, label="artifact report"
     )
-    runtime_plan = (
-        plan_runtime_test_manifest(
-            artifact_payload,
-            manifest,
-            project_root=project_root,
-        )
-        if manifest is not None
-        else _empty_runtime_plan(artifact_payload, artifact_source, project_root)
+    plan_environment = _environment_setup(
+        environment if environment is not None else {}
     )
+    if project_root is not None:
+        root_path = Path(os.fspath(project_root)).resolve()
+        _resolve_working_directory(
+            root_path,
+            root_path,
+            plan_environment["cwd"],
+            label="Test-runner environment cwd",
+        )
+    execution_environment = _execution_environment(plan_environment)
+    with _configured_process_environment(plan_environment["variables"]):
+        runtime_plan = (
+            plan_runtime_test_manifest(
+                artifact_payload,
+                manifest,
+                project_root=project_root,
+            )
+            if manifest is not None
+            else _empty_runtime_plan(artifact_payload, artifact_source, project_root)
+        )
     runtime_manifest_payload = _runtime_manifest_payload(manifest)
     if runtime_manifest_payload is not None:
         runtime_plan = _runtime_plan_with_manifest_metadata(
@@ -71,11 +85,14 @@ def build_project_test_runner_plan(
         if isinstance(target, str) and target.strip()
     }
     plan_targets = _selected_targets(artifact_payload, runtime_plan, target_filter)
-    adapters = _adapter_availability(runtime_plan.get("adapters", []))
+    adapters = _adapter_availability(
+        runtime_plan.get("adapters", []), environment=execution_environment
+    )
     commands = _plan_commands(
         test_commands or _commands_from_runtime_tests(runtime_plan),
         targets=plan_targets,
         adapter_by_id={adapter["id"]: adapter for adapter in adapters},
+        environment=execution_environment,
     )
     expected = _expected_artifact_records(expected_artifacts or (), artifact_payload)
     runtime_cases = _runtime_cases_with_provenance(runtime_plan.get("testCases", []))
@@ -96,7 +113,7 @@ def build_project_test_runner_plan(
             _handoff_package_record(path) for path in handoff_packages or ()
         ],
         "selectedTargets": plan_targets,
-        "environment": _environment_setup(environment or {}),
+        "environment": plan_environment,
         "adapters": adapters,
         "testCommands": commands,
         "runtimeTests": runtime_cases,
@@ -116,6 +133,7 @@ def inspect_project_test_runner_plan(
         raise RuntimeVerificationError(
             f"Test-runner plan kind must be {PROJECT_TEST_RUNNER_PLAN_KIND}."
         )
+    _environment_setup(plan_payload.get("environment", {}))
     command_statuses = Counter(
         command.get("status")
         for command in _record_sequence(plan_payload, "testCommands")
@@ -173,32 +191,78 @@ def execute_project_test_runner_plan(
         raise RuntimeVerificationError(
             f"Test-runner plan kind must be {PROJECT_TEST_RUNNER_PLAN_KIND}."
         )
-    root = Path(project_root or plan_payload.get("environment", {}).get("cwd") or ".")
+    plan_environment = _environment_setup(plan_payload.get("environment", {}))
+    root = _execution_project_root(plan_payload, project_root)
+    environment_cwd = _resolve_working_directory(
+        root,
+        root,
+        plan_environment["cwd"],
+        label="Test-runner environment cwd",
+    )
+    execution_environment = _execution_environment(plan_environment)
+    configured_values = tuple(plan_environment["variables"].values())
     adapter_by_id = {
         adapter["id"]: adapter for adapter in _record_sequence(plan_payload, "adapters")
     }
-    command_results = [
-        _execute_command(command, root_path=root, adapter_by_id=adapter_by_id)
-        for command in _record_sequence(plan_payload, "testCommands")
+    commands = _record_sequence(plan_payload, "testCommands")
+    command_cwds = [
+        _resolve_working_directory(
+            root,
+            environment_cwd,
+            command.get("cwd", "."),
+            label=f"Test command {command.get('id', index + 1)!r} cwd",
+        )
+        for index, command in enumerate(commands)
     ]
+    environment_setup = _execute_environment_setup(
+        plan_environment,
+        cwd=environment_cwd,
+        environment=execution_environment,
+    )
+    if environment_setup["status"] == PASSED:
+        command_results = [
+            _execute_command(
+                command,
+                project_root=root,
+                cwd_path=command_cwd,
+                environment=execution_environment,
+                configured_values=configured_values,
+                adapter_by_id=adapter_by_id,
+            )
+            for command, command_cwd in zip(commands, command_cwds)
+        ]
+    else:
+        command_results = [
+            _command_after_environment_setup_failure(
+                command,
+                adapter_by_id=adapter_by_id,
+                setup_failure=environment_setup,
+            )
+            for command in commands
+        ]
     runtime_report = None
     runtime_plan = plan_payload.get("runtimeTestPlan")
     if (
-        run_runtime_tests
+        environment_setup["status"] == PASSED
+        and run_runtime_tests
         and isinstance(runtime_plan, Mapping)
         and runtime_plan.get("kind") == RUNTIME_TEST_PLAN_KIND
     ):
-        runtime_report = _execute_runtime_plan(
-            runtime_plan,
-            plan_payload.get("runtimeTestManifest"),
-            root,
-            artifact_source=plan_payload.get("sourceArtifacts"),
-            executors=runtime_executors,
-        )
+        with _configured_process_environment(plan_environment["variables"]):
+            runtime_report = _execute_runtime_plan(
+                runtime_plan,
+                plan_payload.get("runtimeTestManifest"),
+                root,
+                artifact_source=plan_payload.get("sourceArtifacts"),
+                executors=runtime_executors,
+            )
     results = list(command_results)
     if isinstance(runtime_report, Mapping):
         results.extend(_runtime_report_results(runtime_report))
-    summary = _execution_summary(results)
+    summary = _execution_summary(
+        results,
+        environment_setup_failed=environment_setup["status"] != PASSED,
+    )
     report = {
         "schemaVersion": PROJECT_TEST_RUNNER_SCHEMA_VERSION,
         "kind": PROJECT_TEST_RUNNER_REPORT_KIND,
@@ -208,6 +272,7 @@ def execute_project_test_runner_plan(
         "sourceArtifacts": plan_payload.get("sourceArtifacts"),
         "runtimeHandoffPackages": plan_payload.get("runtimeHandoffPackages", []),
         "selectedTargets": plan_payload.get("selectedTargets", []),
+        "environmentSetup": environment_setup,
         "summary": summary,
         "results": results,
     }
@@ -247,7 +312,11 @@ def _empty_runtime_plan(
             "kind": artifact_payload.get("kind"),
         },
         "sourceManifest": None,
-        "projectRoot": str(project_root) if project_root is not None else None,
+        "projectRoot": (
+            str(Path(os.fspath(project_root)).resolve())
+            if project_root is not None
+            else None
+        ),
         "summary": {
             "testCount": 0,
             "plannedCount": 0,
@@ -337,7 +406,10 @@ def _selected_targets(
     return sorted(targets)
 
 
-def _adapter_availability(adapters: Sequence[Any]) -> list[dict[str, Any]]:
+def _adapter_availability(
+    adapters: Sequence[Any], *, environment: Mapping[str, str]
+) -> list[dict[str, Any]]:
+    process_environment = environment
     records = []
     for adapter in adapters:
         if not isinstance(adapter, Mapping):
@@ -350,19 +422,25 @@ def _adapter_availability(adapters: Sequence[Any]) -> list[dict[str, Any]]:
             for tool in requirements.get("requiredTools", [])
             if isinstance(tool, str) and tool.strip()
         ]
-        environment = [
+        required_environment = [
             str(name)
             for name in requirements.get("requiredEnvironment", [])
             if isinstance(name, str) and name.strip()
         ]
-        missing_tools = [tool for tool in tools if shutil.which(tool) is None]
-        missing_environment = [name for name in environment if not os.environ.get(name)]
+        missing_tools = [
+            tool
+            for tool in tools
+            if shutil.which(tool, path=process_environment.get("PATH")) is None
+        ]
+        missing_environment = [
+            name for name in required_environment if not process_environment.get(name)
+        ]
         record = dict(adapter)
         record["availability"] = {
             "available": not missing_tools and not missing_environment,
             "requiredTools": tools,
             "missingTools": missing_tools,
-            "requiredEnvironment": environment,
+            "requiredEnvironment": required_environment,
             "missingEnvironment": missing_environment,
         }
         records.append(record)
@@ -405,6 +483,7 @@ def _plan_commands(
     *,
     targets: Sequence[str],
     adapter_by_id: Mapping[str, Mapping[str, Any]],
+    environment: Mapping[str, str],
 ) -> list[dict[str, Any]]:
     target_set = set(targets)
     planned = []
@@ -430,10 +509,14 @@ def _plan_commands(
         availability = adapter.get("availability", {}) if adapter is not None else {}
         required = _command_requirements(command, adapter)
         missing_tools = [
-            tool for tool in required["requiredTools"] if shutil.which(tool) is None
+            tool
+            for tool in required["requiredTools"]
+            if shutil.which(tool, path=environment.get("PATH")) is None
         ]
         missing_environment = [
-            name for name in required["requiredEnvironment"] if not os.environ.get(name)
+            name
+            for name in required["requiredEnvironment"]
+            if not environment.get(name)
         ]
         missing_tools = sorted(
             set(missing_tools) | set(availability.get("missingTools", []))
@@ -627,19 +710,152 @@ def _handoff_package_record(path_value: str | os.PathLike[str]) -> dict[str, Any
     }
 
 
-def _environment_setup(environment: Mapping[str, Any]) -> dict[str, Any]:
-    cwd = environment.get("cwd", ".")
-    variables = environment.get("variables", {})
-    if not isinstance(variables, Mapping):
-        variables = {}
-    setup_commands = environment.get("setupCommands", [])
+def _environment_setup(environment: Any) -> dict[str, Any]:
+    if not isinstance(environment, Mapping):
+        raise RuntimeVerificationError("Test-runner environment must be an object.")
+
+    cwd_value = environment.get("cwd", ".")
+    if not isinstance(cwd_value, (str, os.PathLike)):
+        raise RuntimeVerificationError(
+            "Test-runner environment cwd must be a non-empty path string."
+        )
+    cwd = os.fspath(cwd_value)
+    if not cwd or "\0" in cwd:
+        raise RuntimeVerificationError(
+            "Test-runner environment cwd must be a non-empty path string."
+        )
+
+    variable_values = environment.get("variables", {})
+    if not isinstance(variable_values, Mapping):
+        raise RuntimeVerificationError(
+            "Test-runner environment variables must be an object."
+        )
+    variables: dict[str, str] = {}
+    for name, value in variable_values.items():
+        if not isinstance(name, str) or not name or "=" in name or "\0" in name:
+            raise RuntimeVerificationError(
+                "Test-runner environment variable names must be non-empty strings "
+                "without '=' or null bytes."
+            )
+        if not isinstance(value, (str, int, float, bool, os.PathLike)):
+            raise RuntimeVerificationError(
+                f"Test-runner environment variable {name!r} must have a scalar value."
+            )
+        normalized_value = (
+            os.fspath(value) if isinstance(value, os.PathLike) else str(value)
+        )
+        if "\0" in normalized_value:
+            raise RuntimeVerificationError(
+                f"Test-runner environment variable {name!r} contains a null byte."
+            )
+        variables[name] = normalized_value
+
+    setup_values = environment.get("setupCommands", [])
+    if not isinstance(setup_values, Sequence) or isinstance(setup_values, (str, bytes)):
+        raise RuntimeVerificationError(
+            "Test-runner environment setupCommands must be a list of commands."
+        )
+    setup_commands = [
+        _environment_command_parts(command, index=index)
+        for index, command in enumerate(setup_values)
+    ]
     return {
-        "cwd": str(cwd),
-        "variables": {str(key): str(value) for key, value in variables.items()},
-        "setupCommands": [
-            _command_parts(command) for command in setup_commands if command
-        ],
+        "cwd": cwd,
+        "variables": variables,
+        "setupCommands": setup_commands,
     }
+
+
+def _environment_command_parts(value: Any, *, index: int) -> list[str]:
+    if isinstance(value, (str, os.PathLike)):
+        candidates = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        candidates = list(value)
+    else:
+        raise RuntimeVerificationError(
+            f"Test-runner setup command {index + 1} must be a string or argv list."
+        )
+    if not candidates:
+        raise RuntimeVerificationError(
+            f"Test-runner setup command {index + 1} must not be empty."
+        )
+    parts = []
+    for part in candidates:
+        if not isinstance(part, (str, os.PathLike)):
+            raise RuntimeVerificationError(
+                f"Test-runner setup command {index + 1} argv values must be strings."
+            )
+        normalized = os.fspath(part)
+        if not normalized or "\0" in normalized:
+            raise RuntimeVerificationError(
+                f"Test-runner setup command {index + 1} argv values must be non-empty strings."
+            )
+        parts.append(normalized)
+    return parts
+
+
+def _execution_project_root(
+    plan: Mapping[str, Any], override: str | os.PathLike[str] | None
+) -> Path:
+    root_value: Any = override
+    if root_value is None:
+        runtime_plan = plan.get("runtimeTestPlan")
+        if isinstance(runtime_plan, Mapping):
+            root_value = runtime_plan.get("projectRoot")
+    if not isinstance(root_value, (str, os.PathLike)) or not os.fspath(root_value):
+        raise RuntimeVerificationError(
+            "Project test-runner execution requires an explicit project root."
+        )
+    root = Path(os.fspath(root_value)).resolve()
+    if not root.is_dir():
+        raise RuntimeVerificationError(
+            f"Project test-runner root is not a directory: {root}."
+        )
+    return root
+
+
+def _resolve_working_directory(
+    project_root: Path,
+    base: Path,
+    value: Any,
+    *,
+    label: str,
+) -> Path:
+    if not isinstance(value, (str, os.PathLike)):
+        raise RuntimeVerificationError(f"{label} must be a non-empty path string.")
+    path_value = os.fspath(value)
+    if not path_value or "\0" in path_value:
+        raise RuntimeVerificationError(f"{label} must be a non-empty path string.")
+    path = Path(path_value)
+    resolved = (path if path.is_absolute() else base / path).resolve()
+    try:
+        resolved.relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise RuntimeVerificationError(
+            f"{label} escapes project root {project_root.resolve()}: {path_value}."
+        ) from exc
+    return resolved
+
+
+def _execution_environment(environment: Mapping[str, Any]) -> dict[str, str]:
+    merged = os.environ.copy()
+    merged.update(environment["variables"])
+    return merged
+
+
+@contextmanager
+def _configured_process_environment(variables: Mapping[str, str]):
+    missing = object()
+    previous = {name: os.environ.get(name, missing) for name in variables}
+    os.environ.update(variables)
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is missing:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def _plan_diagnostics(
@@ -686,13 +902,58 @@ def _plan_summary(
 def _execute_command(
     command: Mapping[str, Any],
     *,
-    root_path: Path,
+    project_root: Path,
+    cwd_path: Path,
+    environment: Mapping[str, str],
+    configured_values: Sequence[str],
     adapter_by_id: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any]:
     adapter_id = command.get("adapter")
     adapter = adapter_by_id.get(adapter_id) if isinstance(adapter_id, str) else None
     availability = adapter.get("availability", {}) if adapter is not None else {}
     diagnostics = list(command.get("diagnostics", []))
+    parts = _command_parts(command.get("command"))
+    skipped = _preexecution_command_skip(
+        command,
+        availability=availability,
+        diagnostics=diagnostics,
+        parts=parts,
+    )
+    if skipped is not None:
+        return skipped
+    cwd = _resolve_working_directory(
+        project_root,
+        project_root,
+        cwd_path,
+        label=f"Test command {command.get('id', command.get('name'))!r} cwd",
+    )
+    log = _run_command(
+        parts,
+        cwd=cwd,
+        environment=environment,
+        configured_values=configured_values,
+    )
+    status = PASSED if log["returncode"] == 0 else RUNTIME_FAILED
+    return {
+        "kind": "project-test-command",
+        "name": command.get("name"),
+        "fixture": command.get("fixture"),
+        "status": status,
+        "failurePhase": None if status == PASSED else "test-command",
+        "provenance": command.get("provenance", {}),
+        "logs": [log],
+        "adapterAvailability": availability,
+        "diagnostics": diagnostics,
+    }
+
+
+def _preexecution_command_skip(
+    command: Mapping[str, Any],
+    *,
+    availability: Mapping[str, Any],
+    diagnostics: Sequence[Mapping[str, Any]],
+    parts: Sequence[str],
+) -> dict[str, Any] | None:
     if command.get("status") == SKIPPED or not availability.get("available", True):
         return {
             "kind": "project-test-command",
@@ -703,57 +964,168 @@ def _execute_command(
             "provenance": command.get("provenance", {}),
             "logs": [],
             "adapterAvailability": availability,
-            "diagnostics": diagnostics,
+            "diagnostics": list(diagnostics),
         }
-    parts = _command_parts(command.get("command"))
-    if not parts:
-        return {
-            "kind": "project-test-command",
-            "name": command.get("name"),
-            "fixture": command.get("fixture"),
-            "status": SKIPPED,
-            "failurePhase": "test-command",
-            "provenance": command.get("provenance", {}),
-            "logs": [],
-            "adapterAvailability": availability,
-            "diagnostics": [
-                *diagnostics,
-                {
-                    "severity": "note",
-                    "code": "project.test-runner.command-empty",
-                    "message": (
-                        "Project test command skipped because no command was provided."
-                    ),
-                },
-            ],
-        }
-    cwd = root_path / str(command.get("cwd", "."))
-    result = subprocess.run(
-        parts,
-        cwd=str(cwd),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    status = PASSED if result.returncode == 0 else RUNTIME_FAILED
+    if parts:
+        return None
     return {
         "kind": "project-test-command",
         "name": command.get("name"),
         "fixture": command.get("fixture"),
-        "status": status,
-        "failurePhase": None if status == PASSED else "test-command",
+        "status": SKIPPED,
+        "failurePhase": "test-command",
         "provenance": command.get("provenance", {}),
-        "logs": [
-            {
-                "command": parts,
-                "returncode": result.returncode,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-            }
-        ],
+        "logs": [],
         "adapterAvailability": availability,
-        "diagnostics": diagnostics,
+        "diagnostics": [
+            *diagnostics,
+            {
+                "severity": "note",
+                "code": "project.test-runner.command-empty",
+                "message": (
+                    "Project test command skipped because no command was provided."
+                ),
+            },
+        ],
     }
+
+
+def _command_after_environment_setup_failure(
+    command: Mapping[str, Any],
+    *,
+    adapter_by_id: Mapping[str, Mapping[str, Any]],
+    setup_failure: Mapping[str, Any],
+) -> dict[str, Any]:
+    adapter_id = command.get("adapter")
+    adapter = adapter_by_id.get(adapter_id) if isinstance(adapter_id, str) else None
+    availability = adapter.get("availability", {}) if adapter is not None else {}
+    diagnostics = list(command.get("diagnostics", []))
+    skipped = _preexecution_command_skip(
+        command,
+        availability=availability,
+        diagnostics=diagnostics,
+        parts=_command_parts(command.get("command")),
+    )
+    if skipped is not None:
+        return skipped
+    return {
+        "kind": "project-test-command",
+        "name": command.get("name"),
+        "fixture": command.get("fixture"),
+        "status": SKIPPED,
+        "failurePhase": "environment-setup",
+        "provenance": command.get("provenance", {}),
+        "logs": [],
+        "adapterAvailability": availability,
+        "diagnostics": [
+            *diagnostics,
+            {
+                "severity": "note",
+                "code": "project.test-runner.environment-setup-failed",
+                "message": (
+                    "Project test command skipped because environment setup failed."
+                ),
+                "setupCommand": setup_failure.get("command"),
+                "returncode": setup_failure.get("returncode"),
+            },
+        ],
+    }
+
+
+def _execute_environment_setup(
+    setup: Mapping[str, Any],
+    *,
+    cwd: Path,
+    environment: Mapping[str, str],
+) -> dict[str, Any]:
+    configured_values = tuple(setup["variables"].values())
+    record = {
+        "kind": "project-test-environment-setup",
+        "status": PASSED,
+        "failurePhase": None,
+        "cwd": str(cwd),
+        "appliedVariables": sorted(setup["variables"]),
+        "logs": [],
+        "diagnostics": [],
+    }
+    for parts in setup["setupCommands"]:
+        log = _run_command(
+            parts,
+            cwd=cwd,
+            environment=environment,
+            configured_values=configured_values,
+        )
+        record["logs"].append(log)
+        if log["returncode"] == 0:
+            continue
+        record.update(
+            {
+                "status": RUNTIME_FAILED,
+                "failurePhase": "environment-setup",
+                "command": log["command"],
+                "returncode": log["returncode"],
+                "stdout": log["stdout"],
+                "stderr": log["stderr"],
+                "diagnostics": [
+                    {
+                        "severity": "error",
+                        "code": "project.test-runner.environment-setup-failed",
+                        "message": "Project test-runner environment setup failed.",
+                        "command": log["command"],
+                        "returncode": log["returncode"],
+                    }
+                ],
+            }
+        )
+        break
+    return record
+
+
+def _run_command(
+    parts: Sequence[str],
+    *,
+    cwd: Path,
+    environment: Mapping[str, str],
+    configured_values: Sequence[str],
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            list(parts),
+            cwd=str(cwd),
+            env=dict(environment),
+            text=True,
+            capture_output=True,
+            check=False,
+            shell=False,
+        )
+    except OSError as exc:
+        return {
+            "command": _redact_command(parts, configured_values),
+            "returncode": None,
+            "stdout": "",
+            "stderr": _redact_environment_values(str(exc), configured_values),
+        }
+    return {
+        "command": _redact_command(parts, configured_values),
+        "returncode": result.returncode,
+        "stdout": _redact_environment_values(result.stdout, configured_values),
+        "stderr": _redact_environment_values(result.stderr, configured_values),
+    }
+
+
+def _redact_command(
+    parts: Sequence[str], configured_values: Sequence[str]
+) -> list[str]:
+    return [_redact_environment_values(str(part), configured_values) for part in parts]
+
+
+def _redact_environment_values(text: str, configured_values: Sequence[str]) -> str:
+    redacted = text
+    for value in sorted(
+        {value for value in configured_values if value}, key=len, reverse=True
+    ):
+        redacted = redacted.replace(value, "<redacted>")
+    return redacted
 
 
 def _execute_runtime_plan(
@@ -850,15 +1222,20 @@ def _runtime_report_results(runtime_report: Mapping[str, Any]) -> list[dict[str,
     return results
 
 
-def _execution_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+def _execution_summary(
+    results: Sequence[Mapping[str, Any]], *, environment_setup_failed: bool = False
+) -> dict[str, int]:
     statuses = Counter(result.get("status") for result in results)
-    failed = statuses[RUNTIME_FAILED] + statuses["comparison-failed"]
+    setup_failed_count = int(environment_setup_failed)
+    runtime_failed = statuses[RUNTIME_FAILED] + setup_failed_count
+    failed = runtime_failed + statuses["comparison-failed"]
     return {
         "resultCount": len(results),
         "passedCount": statuses[PASSED],
         "skippedCount": statuses[SKIPPED],
-        "runtimeFailedCount": statuses[RUNTIME_FAILED],
+        "runtimeFailedCount": runtime_failed,
         "comparisonFailedCount": statuses["comparison-failed"],
+        "environmentSetupFailedCount": setup_failed_count,
         "failedCount": failed,
     }
 

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -37,17 +37,17 @@ implicitly supported.
 .. csv-table:: Summary by backend
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "68", "0", "2", "1", "0", "0"
-   "OpenGL / GLSL", "69", "0", "2", "0", "0", "0"
-   "WebGL / GLSL ES", "38", "0", "23", "10", "0", "0"
-   "WebGPU / WGSL", "42", "0", "21", "8", "0", "0"
-   "Metal", "66", "0", "4", "1", "0", "0"
-   "Vulkan SPIR-V", "68", "0", "2", "1", "0", "0"
-   "CUDA", "62", "0", "8", "1", "0", "0"
-   "HIP", "62", "0", "8", "1", "0", "0"
-   "Mojo", "64", "0", "6", "1", "0", "0"
-   "Rust", "65", "0", "5", "1", "0", "0"
-   "Slang", "66", "0", "4", "1", "0", "0"
+   "DirectX / HLSL", "69", "0", "2", "1", "0", "0"
+   "OpenGL / GLSL", "70", "0", "2", "0", "0", "0"
+   "WebGL / GLSL ES", "39", "0", "23", "10", "0", "0"
+   "WebGPU / WGSL", "43", "0", "21", "8", "0", "0"
+   "Metal", "67", "0", "4", "1", "0", "0"
+   "Vulkan SPIR-V", "69", "0", "2", "1", "0", "0"
+   "CUDA", "63", "0", "8", "1", "0", "0"
+   "HIP", "63", "0", "8", "1", "0", "0"
+   "Mojo", "65", "0", "6", "1", "0", "0"
+   "Rust", "66", "0", "5", "1", "0", "0"
+   "Slang", "67", "0", "4", "1", "0", "0"
 
 Graphics Backend Focus
 ----------------------
@@ -58,9 +58,9 @@ scope for graphics backend completion work.
 .. csv-table:: Graphics backend status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "68", "0", "2", "1", "0", "0"
-   "OpenGL / GLSL", "69", "0", "2", "0", "0", "0"
-   "Metal", "66", "0", "4", "1", "0", "0"
+   "DirectX / HLSL", "69", "0", "2", "1", "0", "0"
+   "OpenGL / GLSL", "70", "0", "2", "0", "0", "0"
+   "Metal", "67", "0", "4", "1", "0", "0"
 
 .. csv-table:: DirectX/OpenGL/Metal actionable backlog
    :header: "Backend", "Category", "Feature", "Status", "Notes"
@@ -75,17 +75,17 @@ inspection, diagnostics, validation, and corpus-coverage rows.
 .. csv-table:: Project-porting status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "25", "0", "1", "1", "0", "0"
-   "OpenGL / GLSL", "26", "0", "1", "0", "0", "0"
-   "WebGL / GLSL ES", "25", "0", "1", "1", "0", "0"
-   "WebGPU / WGSL", "25", "0", "1", "1", "0", "0"
-   "Metal", "25", "0", "1", "1", "0", "0"
-   "Vulkan SPIR-V", "25", "0", "1", "1", "0", "0"
-   "CUDA", "25", "0", "1", "1", "0", "0"
-   "HIP", "25", "0", "1", "1", "0", "0"
-   "Mojo", "25", "0", "1", "1", "0", "0"
-   "Rust", "25", "0", "1", "1", "0", "0"
-   "Slang", "25", "0", "1", "1", "0", "0"
+   "DirectX / HLSL", "26", "0", "1", "1", "0", "0"
+   "OpenGL / GLSL", "27", "0", "1", "0", "0", "0"
+   "WebGL / GLSL ES", "26", "0", "1", "1", "0", "0"
+   "WebGPU / WGSL", "26", "0", "1", "1", "0", "0"
+   "Metal", "26", "0", "1", "1", "0", "0"
+   "Vulkan SPIR-V", "26", "0", "1", "1", "0", "0"
+   "CUDA", "26", "0", "1", "1", "0", "0"
+   "HIP", "26", "0", "1", "1", "0", "0"
+   "Mojo", "26", "0", "1", "1", "0", "0"
+   "Rust", "26", "0", "1", "1", "0", "0"
+   "Slang", "26", "0", "1", "1", "0", "0"
 
 .. csv-table:: Project-porting actionable backlog
    :header: "Backend", "Feature", "Status", "Current gap", "Next scope"
@@ -194,6 +194,7 @@ Each category below uses the status codes from the legend.
    "Runtime adapter plan", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime loader manifest", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime test manifest", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Project test-runner environment execution", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime host loader scaffolds", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime host loader scaffold inspection", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime host loader consumption plan", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"

--- a/support/features.json
+++ b/support/features.json
@@ -10478,6 +10478,146 @@
       }
     },
     {
+      "id": "project.test_runner_environment",
+      "category": "project",
+      "name": "Project test-runner environment execution",
+      "description": "Execute repository-agnostic project test-runner plans with validated, project-root-contained environment setup.",
+      "support": {
+        "directx": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "opengl": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "webgl": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "wgsl": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "metal": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "vulkan": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "cuda": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "hip": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "mojo": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "rust": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        },
+        "slang": {
+          "status": "supported",
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ]
+        }
+      }
+    },
+    {
       "id": "project.runtime_host_loader_scaffolds",
       "category": "project",
       "name": "Runtime host loader scaffolds",

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -3297,6 +3297,50 @@
     },
     {
       "category": "project",
+      "description": "Execute repository-agnostic project test-runner plans with validated, project-root-contained environment setup.",
+      "id": "project.test_runner_environment",
+      "name": "Project test-runner environment execution",
+      "support": {
+        "directx": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Emit deterministic host loader scaffold metadata from runtime loader manifests without rewriting host code or executing device code.",
       "id": "project.runtime_host_loader_scaffolds",
       "name": "Runtime host loader scaffolds",
@@ -4461,12 +4505,12 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 71,
+    "feature_count": 72,
     "status_counts": {
       "directx": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 68,
+        "supported": 69,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -4474,7 +4518,7 @@
       "metal": {
         "diagnostic": 4,
         "partial": 0,
-        "supported": 66,
+        "supported": 67,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -4482,7 +4526,7 @@
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 69,
+        "supported": 70,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -5505,6 +5505,146 @@
     },
     {
       "category": "project",
+      "description": "Execute repository-agnostic project test-runner plans with validated, project-root-contained environment setup.",
+      "id": "project.test_runner_environment",
+      "name": "Project test-runner environment execution",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Emit deterministic host loader scaffold metadata from runtime loader manifests without rewriting host code or executing device code.",
       "id": "project.runtime_host_loader_scaffolds",
       "name": "Runtime host loader scaffolds",
@@ -9466,12 +9606,12 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 27,
+    "feature_count": 28,
     "status_counts": {
       "cuda": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9479,7 +9619,7 @@
       "directx": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9487,7 +9627,7 @@
       "hip": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9495,7 +9635,7 @@
       "metal": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9503,7 +9643,7 @@
       "mojo": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9511,7 +9651,7 @@
       "opengl": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 26,
+        "supported": 27,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -9519,7 +9659,7 @@
       "rust": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9527,7 +9667,7 @@
       "slang": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9535,7 +9675,7 @@
       "vulkan": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9543,7 +9683,7 @@
       "webgl": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -9551,7 +9691,7 @@
       "wgsl": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 25,
+        "supported": 26,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -11910,6 +11910,146 @@
     },
     {
       "category": "project",
+      "description": "Execute repository-agnostic project test-runner plans with validated, project-root-contained environment setup.",
+      "id": "project.test_runner_environment",
+      "name": "Project test-runner environment execution",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_project_test_runner.py::def test_runtime_adapter_requirements_use_plan_environment",
+            "tests/test_project_test_runner.py::def test_project_test_runner_applies_environment_and_ordered_setup",
+            "tests/test_project_test_runner.py::def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands",
+            "tests/test_project_test_runner.py::def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell",
+            "tests/test_project_test_runner.py::def test_project_test_runner_rejects_working_directory_escape",
+            "tests/test_project_test_runner.py::def test_project_cli_round_trips_test_runner_environment"
+          ],
+          "notes": "execute-test-runner validates saved environment contracts, resolves environment and command working directories beneath an explicit project root, merges configured variables for setup and test subprocesses, executes setup argv in declaration order without an implicit shell, skips dependent commands after setup failure, and reports setup logs plus applied variable names without configured values. Required adapter tools and environment variables retain deterministic structured skips. The runner does not install dependencies or hard-code repository or backend setup.",
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Emit deterministic host loader scaffold metadata from runtime loader manifests without rewriting host code or executing device code.",
       "id": "project.runtime_host_loader_scaffolds",
       "name": "Runtime host loader scaffolds",
@@ -15875,12 +16015,12 @@
   "summary": {
     "backend_count": 11,
     "backlog_count": 0,
-    "feature_count": 71,
+    "feature_count": 72,
     "status_counts": {
       "cuda": {
         "diagnostic": 8,
         "partial": 0,
-        "supported": 62,
+        "supported": 63,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15888,7 +16028,7 @@
       "directx": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 68,
+        "supported": 69,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15896,7 +16036,7 @@
       "hip": {
         "diagnostic": 8,
         "partial": 0,
-        "supported": 62,
+        "supported": 63,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15904,7 +16044,7 @@
       "metal": {
         "diagnostic": 4,
         "partial": 0,
-        "supported": 66,
+        "supported": 67,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15912,7 +16052,7 @@
       "mojo": {
         "diagnostic": 6,
         "partial": 0,
-        "supported": 64,
+        "supported": 65,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15920,7 +16060,7 @@
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 69,
+        "supported": 70,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -15928,7 +16068,7 @@
       "rust": {
         "diagnostic": 5,
         "partial": 0,
-        "supported": 65,
+        "supported": 66,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15936,7 +16076,7 @@
       "slang": {
         "diagnostic": 4,
         "partial": 0,
-        "supported": 66,
+        "supported": 67,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15944,7 +16084,7 @@
       "vulkan": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 68,
+        "supported": 69,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -15952,7 +16092,7 @@
       "webgl": {
         "diagnostic": 23,
         "partial": 0,
-        "supported": 38,
+        "supported": 39,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 10
@@ -15960,7 +16100,7 @@
       "wgsl": {
         "diagnostic": 21,
         "partial": 0,
-        "supported": 42,
+        "supported": 43,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 8

--- a/tests/test_project_test_runner.py
+++ b/tests/test_project_test_runner.py
@@ -1,7 +1,10 @@
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 from crosstl.project import (
     PROJECT_TEST_RUNNER_INSPECTION_KIND,
@@ -11,7 +14,10 @@ from crosstl.project import (
     execute_project_test_runner_plan,
     inspect_project_test_runner_plan,
 )
-from crosstl.project.runtime_verification import RuntimeParityAdapter
+from crosstl.project.runtime_verification import (
+    RuntimeParityAdapter,
+    RuntimeVerificationError,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -136,6 +142,33 @@ def test_runtime_derived_command_inherits_unavailable_adapter_requirements(tmp_p
     )
 
 
+def test_runtime_adapter_requirements_use_plan_environment(tmp_path, monkeypatch):
+    variable_name = "CROSSTL_RUNTIME_ADAPTER_ENV_1722"
+    monkeypatch.delenv(variable_name, raising=False)
+    manifest = _manifest()
+    manifest["adapters"][0].pop("target")
+    manifest["adapters"][0]["platformRequirements"] = {
+        "requiredEnvironment": [variable_name]
+    }
+    manifest["tests"][0]["metadata"]["testCommand"] = [
+        sys.executable,
+        "-c",
+        "",
+    ]
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        manifest,
+        environment={"variables": {variable_name: "configured"}},
+        project_root=tmp_path,
+    )
+
+    assert plan["adapters"][0]["availability"]["available"] is True
+    assert plan["adapters"][0]["availability"]["missingEnvironment"] == []
+    assert plan["runtimeTests"][0]["status"] == "planned"
+    assert plan["testCommands"][0]["status"] == "planned"
+
+
 def test_project_test_runner_plans_mapping_adapter_references(tmp_path):
     missing_tool = "crosstl-test-runner-mapping-tool-that-does-not-exist"
 
@@ -194,6 +227,441 @@ def test_project_test_runner_executes_available_project_command(tmp_path):
     assert report["results"][0]["status"] == "passed"
     assert report["results"][0]["logs"][0]["returncode"] == 0
     assert output_file.read_text(encoding="utf-8") == "ok"
+
+
+def test_project_test_runner_applies_environment_and_ordered_setup(
+    tmp_path, monkeypatch
+):
+    variable_name = "CROSSTL_TEST_RUNNER_VALUE_1722"
+    variable_value = "runner-secret-value-1722"
+    monkeypatch.delenv(variable_name, raising=False)
+    work_dir = tmp_path / "upstream"
+    work_dir.mkdir()
+    setup_script = (
+        "import os, sys; "
+        "from pathlib import Path; "
+        "path = Path('setup-order.txt'); "
+        "path.write_text(path.read_text() + sys.argv[1] + ':' + "
+        f"os.environ[{variable_name!r}] + '\\n' if path.exists() else "
+        f"sys.argv[1] + ':' + os.environ[{variable_name!r}] + '\\n')"
+    )
+    test_script = (
+        "import json, os; "
+        "from pathlib import Path; "
+        "Path('result.json').write_text(json.dumps({"
+        f"'value': os.environ[{variable_name!r}], "
+        "'order': Path('setup-order.txt').read_text()}))"
+    )
+    first_arg = "first argument; $SHELL remains data"
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "consume configured environment",
+                "command": [sys.executable, "-c", test_script],
+                "requiredEnvironment": [variable_name],
+            }
+        ],
+        environment={
+            "cwd": "upstream",
+            "variables": {variable_name: variable_value},
+            "setupCommands": [
+                [sys.executable, "-c", setup_script, first_arg],
+                [sys.executable, "-c", setup_script, "second"],
+            ],
+        },
+        project_root=tmp_path,
+    )
+
+    assert plan["testCommands"][0]["status"] == "planned"
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=tmp_path,
+        run_runtime_tests=False,
+    )
+
+    result_payload = json.loads((work_dir / "result.json").read_text(encoding="utf-8"))
+    assert result_payload == {
+        "value": variable_value,
+        "order": f"{first_arg}:{variable_value}\nsecond:{variable_value}\n",
+    }
+    assert report["success"] is True
+    assert report["results"][0]["status"] == "passed"
+    setup = report["environmentSetup"]
+    assert setup["status"] == "passed"
+    assert setup["cwd"] == str(work_dir)
+    assert setup["appliedVariables"] == [variable_name]
+    assert [log["returncode"] for log in setup["logs"]] == [0, 0]
+    assert setup["logs"][0]["command"][-1] == first_arg
+    assert variable_value not in json.dumps(report)
+    assert variable_name not in os.environ
+
+
+def test_project_test_runner_plan_environment_satisfies_required_variables(
+    tmp_path, monkeypatch
+):
+    supplied = "CROSSTL_TEST_RUNNER_SUPPLIED_1722"
+    missing = "CROSSTL_TEST_RUNNER_MISSING_1722"
+    monkeypatch.delenv(supplied, raising=False)
+    monkeypatch.delenv(missing, raising=False)
+    output_file = tmp_path / "supplied.txt"
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "supplied variable",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(output_file)!r}).write_text('ok')",
+                ],
+                "requiredEnvironment": [supplied],
+            },
+            {
+                "name": "missing variable",
+                "command": [sys.executable, "-c", "raise SystemExit(99)"],
+                "requiredEnvironment": [missing],
+            },
+        ],
+        environment={"variables": {supplied: "configured"}},
+        project_root=tmp_path,
+    )
+
+    assert [command["status"] for command in plan["testCommands"]] == [
+        "planned",
+        "skipped",
+    ]
+    assert plan["testCommands"][1]["diagnostics"][0]["missingEnvironment"] == [missing]
+
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=tmp_path,
+        run_runtime_tests=False,
+    )
+
+    assert output_file.read_text(encoding="utf-8") == "ok"
+    assert [result["status"] for result in report["results"]] == [
+        "passed",
+        "skipped",
+    ]
+    assert report["results"][1]["failurePhase"] == "adapter-availability"
+
+
+def test_project_test_runner_reports_setup_failure_and_skips_dependent_commands(
+    tmp_path,
+):
+    secret = "setup-secret-value-1722"
+    order_file = tmp_path / "setup-order.txt"
+    skipped_setup_file = tmp_path / "setup-after-failure.txt"
+    skipped_test_file = tmp_path / "test-after-failure.txt"
+    append_script = (
+        "from pathlib import Path; "
+        f"path = Path({str(order_file)!r}); "
+        "path.write_text(path.read_text() + 'first\\n' if path.exists() else 'first\\n')"
+    )
+    failure_script = (
+        "import os, sys; "
+        "print('setup stdout'); "
+        "print(os.environ['CROSSTL_SETUP_SECRET_1722'], file=sys.stderr); "
+        "raise SystemExit(7)"
+    )
+
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "must not run",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(skipped_test_file)!r}).touch()",
+                ],
+            }
+        ],
+        environment={
+            "variables": {"CROSSTL_SETUP_SECRET_1722": secret},
+            "setupCommands": [
+                [sys.executable, "-c", append_script],
+                [sys.executable, "-c", failure_script],
+                [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(skipped_setup_file)!r}).touch()",
+                ],
+            ],
+        },
+        project_root=tmp_path,
+    )
+
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=tmp_path,
+        run_runtime_tests=False,
+    )
+
+    setup = report["environmentSetup"]
+    assert report["success"] is False
+    assert report["summary"]["environmentSetupFailedCount"] == 1
+    assert setup["status"] == "runtime-failed"
+    assert setup["failurePhase"] == "environment-setup"
+    assert setup["returncode"] == 7
+    assert setup["stdout"] == "setup stdout\n"
+    assert setup["stderr"] == "<redacted>\n"
+    assert len(setup["logs"]) == 2
+    assert report["results"][0]["status"] == "skipped"
+    assert report["results"][0]["failurePhase"] == "environment-setup"
+    assert order_file.read_text(encoding="utf-8") == "first\n"
+    assert not skipped_setup_file.exists()
+    assert not skipped_test_file.exists()
+    assert secret not in json.dumps(report)
+
+
+def test_project_test_runner_does_not_interpret_string_setup_commands_with_shell(
+    tmp_path,
+):
+    shell_output = tmp_path / "implicit-shell-output.txt"
+    command = (
+        f'{sys.executable} -c "from pathlib import Path; '
+        f'Path({str(shell_output)!r}).touch()"'
+    )
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        environment={"setupCommands": [command]},
+        project_root=tmp_path,
+    )
+
+    report = execute_project_test_runner_plan(
+        plan,
+        project_root=tmp_path,
+        run_runtime_tests=False,
+    )
+
+    assert report["success"] is False
+    assert report["environmentSetup"]["command"] == [command]
+    assert report["environmentSetup"]["returncode"] is None
+    assert not shell_output.exists()
+
+
+@pytest.mark.parametrize("escape_kind", ["environment", "command"])
+def test_project_test_runner_rejects_working_directory_escape(tmp_path, escape_kind):
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[{"name": "safe", "command": [sys.executable, "-c", ""]}],
+        project_root=tmp_path,
+    )
+    if escape_kind == "environment":
+        plan["environment"]["cwd"] = ".."
+    else:
+        plan["testCommands"][0]["cwd"] = "../outside"
+
+    with pytest.raises(RuntimeVerificationError, match="escapes project root"):
+        execute_project_test_runner_plan(
+            plan,
+            project_root=tmp_path,
+            run_runtime_tests=False,
+        )
+
+
+def test_project_cli_round_trips_test_runner_environment(tmp_path, monkeypatch):
+    variable_name = "CROSSTL_CLI_TEST_RUNNER_VALUE_1722"
+    variable_value = "cli-runner-secret-value-1722"
+    monkeypatch.delenv(variable_name, raising=False)
+    work_dir = tmp_path / "upstream"
+    work_dir.mkdir()
+    artifact_report_path = tmp_path / "artifact-report.json"
+    config_path = tmp_path / "test-runner-config.json"
+    plan_path = tmp_path / "test-runner-plan.json"
+    report_path = tmp_path / "test-runner-report.json"
+    artifact_report_path.write_text(
+        json.dumps(_artifact_report(tmp_path, [_artifact()])), encoding="utf-8"
+    )
+    setup_script = (
+        "import sys; from pathlib import Path; "
+        "path = Path('setup-order.txt'); "
+        "path.write_text((path.read_text() if path.exists() else '') + "
+        "sys.argv[1] + '\\n')"
+    )
+    test_script = (
+        "import json, os; from pathlib import Path; "
+        "Path('result.json').write_text(json.dumps({"
+        f"'value': os.environ[{variable_name!r}], "
+        "'order': Path('setup-order.txt').read_text()}))"
+    )
+    config_path.write_text(
+        json.dumps(
+            {
+                "environment": {
+                    "cwd": "upstream",
+                    "variables": {variable_name: variable_value},
+                    "setupCommands": [
+                        [sys.executable, "-c", setup_script, "first"],
+                        [sys.executable, "-c", setup_script, "second"],
+                    ],
+                },
+                "testCommands": [
+                    {
+                        "name": "serialized environment",
+                        "command": [sys.executable, "-c", test_script],
+                        "requiredEnvironment": [variable_name],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "test-runner-plan",
+            str(artifact_report_path),
+            "--test-config",
+            str(config_path),
+            "--project-root",
+            str(tmp_path),
+            "--output",
+            str(plan_path),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert plan_result.returncode == 0, plan_result.stdout or plan_result.stderr
+    serialized_plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert serialized_plan["testCommands"][0]["status"] == "planned"
+
+    execute_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "execute-test-runner",
+            str(plan_path),
+            "--project-root",
+            str(tmp_path),
+            "--no-runtime-tests",
+            "--output",
+            str(report_path),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert execute_result.returncode == 0, (
+        execute_result.stdout or execute_result.stderr
+    )
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["success"] is True
+    assert report["environmentSetup"]["appliedVariables"] == [variable_name]
+    assert [log["returncode"] for log in report["environmentSetup"]["logs"]] == [
+        0,
+        0,
+    ]
+    assert json.loads((work_dir / "result.json").read_text(encoding="utf-8")) == {
+        "value": variable_value,
+        "order": "first\nsecond\n",
+    }
+    assert variable_value not in json.dumps(report)
+
+
+def test_project_cli_serialized_plan_reports_environment_setup_failure(tmp_path):
+    skipped_file = tmp_path / "skipped-command.txt"
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "must not run",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(skipped_file)!r}).touch()",
+                ],
+            }
+        ],
+        environment={
+            "setupCommands": [
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('failed setup'); raise SystemExit(9)",
+                ]
+            ]
+        },
+        project_root=tmp_path,
+    )
+    plan_path = tmp_path / "test-runner-plan.json"
+    report_path = tmp_path / "test-runner-report.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "execute-test-runner",
+            str(plan_path),
+            "--project-root",
+            str(tmp_path),
+            "--no-runtime-tests",
+            "--output",
+            str(report_path),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["environmentSetup"]["failurePhase"] == "environment-setup"
+    assert report["environmentSetup"]["returncode"] == 9
+    assert report["environmentSetup"]["stdout"] == "failed setup\n"
+    assert report["results"][0]["status"] == "skipped"
+    assert not skipped_file.exists()
+
+
+def test_project_cli_serialized_plan_rejects_environment_path_escape(tmp_path):
+    plan = build_project_test_runner_plan(
+        _artifact_report(tmp_path, [_artifact()]),
+        test_commands=[
+            {
+                "name": "must not run",
+                "command": [sys.executable, "-c", "raise SystemExit(99)"],
+            }
+        ],
+        project_root=tmp_path,
+    )
+    plan["environment"]["cwd"] = ".."
+    plan_path = tmp_path / "escaped-test-runner-plan.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "crosstl._crosstl",
+            "execute-test-runner",
+            str(plan_path),
+            "--project-root",
+            str(tmp_path),
+            "--no-runtime-tests",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "escapes project root" in result.stdout
 
 
 def test_project_test_runner_executes_runtime_tests_with_supplied_executor(tmp_path):


### PR DESCRIPTION
## Summary

- validate serialized project test-runner environments and contain configured working directories beneath an explicit project root
- merge configured variables over the process environment for adapter requirements, setup commands, project tests, and runtime checks
- execute setup argv sequentially without an implicit shell and skip dependent commands after the first setup failure
- report ordered setup results and applied variable names while redacting configured values from commands and captured output
- preserve deterministic adapter and requirement skips when tools or environment variables are unavailable

## Runtime integration impact

Repository test plans can now establish backend selection, translated package paths, loader search paths, and ordered setup steps before invoking an upstream test command. The implementation is repository- and backend-agnostic; it does not install dependencies or encode MLX-specific paths.

This supplies the execution-environment contract needed by future non-Metal MLX host bridges while keeping actual artifact loading and full upstream test-suite parity as separate runtime work.

## Validation

- project test-runner and project translation environment tests (`21 passed`)
- direct API and serialized CLI coverage for setup ordering, variable propagation, failure handling, argv boundaries, requirement skips, redaction, and path containment
- support matrix check and support issue dry-run (`0` desired issues)
- `pre-commit run --all-files`

Closes #1722
