### PR TITLE
Expand the pinned MLX DirectX compiler frontier

### DIFF
--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -57,24 +57,27 @@ The current harness verifies:
   clean artifact generation for DirectX, OpenGL, and Vulkan. OpenGL compilation
   and both OpenGL-derived and native SPIR-V validation run in the required Linux
   toolchain gate;
-- DirectX HLSL smoke checks with official DXC v1.9.2602.24 on Windows CI for
-  the nine-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`,
-  `logsumexp.metal`, `rms_norm.metal`, `rope.metal`,
-  `scaled_dot_product_attention.metal`, `softmax.metal`, and `ternary.metal`
-  frontier. At the pinned revision the gate compiles every generated compute
-  entry: 11, 24, 12, 6, 12, 18, 42, 10, and 212 entries respectively, for 347
-  generated compute entries in total. The pinned rope translation
-  supplies required function constant IDs through the quoted `"1"`, `"2"`, and
-  `"3"` selectors in `[project.specialization_constants]` and materializes the
-  concrete DirectX variant before compilation. Aggregate conditional lowering
+- DirectX HLSL compiler checks with official DXC v1.9.2602.24 on Windows CI for
+  the full 11-source clean frontier: `arange.metal`, `arg_reduce.metal`,
+  `binary_two.metal`, `layer_norm.metal`, `logsumexp.metal`, `random.metal`,
+  `rms_norm.metal`, `rope.metal`, `scaled_dot_product_attention.metal`,
+  `softmax.metal`, and `ternary.metal`. At the pinned revision the gate compiles
+  every generated compute entry: 11, 24, 225, 12, 6, 2, 12, 18, 42, 10, and
+  212 entries respectively, for 574 generated compute entries in total. The
+  pinned rope translation supplies required function constant IDs through the
+  quoted `"1"`, `"2"`, and `"3"` selectors in
+  `[project.specialization_constants]` and materializes the concrete DirectX
+  variant before compilation. Aggregate conditional lowering
   completed under [#1695](https://github.com/CrossGL/crosstl/issues/1695) admits
-  every pinned `ternary.metal` entry to this compiler gate. `binary_two.metal`
-  remains outside the gate under
-  [#1694](https://github.com/CrossGL/crosstl/issues/1694) and
-  [#1701](https://github.com/CrossGL/crosstl/issues/1701), while `random.metal`
-  remains outside the gate under
-  [#1696](https://github.com/CrossGL/crosstl/issues/1696), with runtime dispatch
-  metadata still tracked by
+  every pinned `ternary.metal` entry to this compiler gate. Target-ABI overload
+  identity [#1694](https://github.com/CrossGL/crosstl/issues/1694) and
+  minimum-precision arithmetic widening
+  [#1701](https://github.com/CrossGL/crosstl/issues/1701) admit all 225
+  `binary_two.metal` entries. Exact-layout DirectX union lowering
+  [#1728](https://github.com/CrossGL/crosstl/issues/1728) admits both
+  `random.metal` entries; broader union layouts remain tracked by
+  [#1696](https://github.com/CrossGL/crosstl/issues/1696), and runtime dispatch
+  metadata remains tracked by
   [#1542](https://github.com/CrossGL/crosstl/issues/1542). `fence.metal` is
   excluded because its DirectX translation intentionally fails under
   [#1537](https://github.com/CrossGL/crosstl/issues/1537) before DXC. This gate

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -436,7 +436,7 @@
   },
   "directx_toolchain_status": {
     "status": "passing",
-    "note": "Windows CI compiles all 347 generated compute entries in the nine-source DirectX HLSL frontier below. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity. binary_two.metal and random.metal remain outside the clean-frontier DXC gate for the listed defects; fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
+    "note": "Windows CI compiles all 574 generated compute entries in the full 11-source clean DirectX HLSL frontier below. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity. fence.metal is a separate blocked source and emits no DirectX artifact under its atomic-fence contract diagnostic.",
     "compiler": {
       "name": "dxc",
       "version": "v1.9.2602.24"
@@ -456,8 +456,10 @@
     "expected_entry_point_counts": {
       "mlx/backend/metal/kernels/arange.metal": 11,
       "mlx/backend/metal/kernels/arg_reduce.metal": 24,
+      "mlx/backend/metal/kernels/binary_two.metal": 225,
       "mlx/backend/metal/kernels/layer_norm.metal": 12,
       "mlx/backend/metal/kernels/logsumexp.metal": 6,
+      "mlx/backend/metal/kernels/random.metal": 2,
       "mlx/backend/metal/kernels/rms_norm.metal": 12,
       "mlx/backend/metal/kernels/rope.metal": 18,
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": 42,
@@ -467,8 +469,10 @@
     "dxc_validated_sources": [
       "mlx/backend/metal/kernels/arange.metal",
       "mlx/backend/metal/kernels/arg_reduce.metal",
+      "mlx/backend/metal/kernels/binary_two.metal",
       "mlx/backend/metal/kernels/layer_norm.metal",
       "mlx/backend/metal/kernels/logsumexp.metal",
+      "mlx/backend/metal/kernels/random.metal",
       "mlx/backend/metal/kernels/rms_norm.metal",
       "mlx/backend/metal/kernels/rope.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
@@ -476,8 +480,6 @@
       "mlx/backend/metal/kernels/ternary.metal"
     ],
     "directx_toolchain_gaps": {
-      "mlx/backend/metal/kernels/binary_two.metal": "generated HLSL still has target-ABI signature collisions when distinct Metal scalar overloads collapse (https://github.com/CrossGL/crosstl/issues/1694) and minimum-precision signed integer division and remainder operations that require widening before DXC compilation (https://github.com/CrossGL/crosstl/issues/1701)",
-      "mlx/backend/metal/kernels/random.metal": "union-backed aliases still require storage-preserving HLSL lowering (https://github.com/CrossGL/crosstl/issues/1696); reflected dispatch-grid cbuffer binding and dispatch-plan metadata also remain required before native execution (https://github.com/CrossGL/crosstl/issues/1542)",
       "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)"
     },
     "native_runtime_executed": false,
@@ -652,9 +654,7 @@
     "https://github.com/CrossGL/crosstl/issues/1670",
     "https://github.com/CrossGL/crosstl/issues/1671",
     "https://github.com/CrossGL/crosstl/issues/1672",
-    "https://github.com/CrossGL/crosstl/issues/1694",
     "https://github.com/CrossGL/crosstl/issues/1696",
-    "https://github.com/CrossGL/crosstl/issues/1701",
     "https://github.com/CrossGL/crosstl/issues/1750",
     "https://github.com/CrossGL/crosstl/issues/1312",
     "https://github.com/CrossGL/crosstl/issues/1376",
@@ -694,6 +694,9 @@
     "https://github.com/CrossGL/crosstl/issues/1660"
   ],
   "resolved_issues": [
+    "https://github.com/CrossGL/crosstl/issues/1728",
+    "https://github.com/CrossGL/crosstl/issues/1701",
+    "https://github.com/CrossGL/crosstl/issues/1694",
     "https://github.com/CrossGL/crosstl/issues/1695",
     "https://github.com/CrossGL/crosstl/issues/1667",
     "https://github.com/CrossGL/crosstl/issues/1668",

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -40,6 +40,7 @@ MLX_GEMV_SOURCE = "mlx/backend/metal/kernels/gemv.metal"
 MLX_LAYER_NORM_SOURCE = "mlx/backend/metal/kernels/layer_norm.metal"
 MLX_LOGSUMEXP_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
 MLX_METAL_ROUNDTRIP_SOURCE = MLX_FENCE_SOURCE
+MLX_RANDOM_SOURCE = "mlx/backend/metal/kernels/random.metal"
 MLX_RMS_NORM_SOURCE = "mlx/backend/metal/kernels/rms_norm.metal"
 MLX_ROPE_SOURCE = "mlx/backend/metal/kernels/rope.metal"
 MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE = (
@@ -70,7 +71,7 @@ MLX_DIRECTX_VULKAN_FRONTIER_SOURCES = (
     MLX_BINARY_TWO_SOURCE,
     MLX_LAYER_NORM_SOURCE,
     MLX_LOGSUMEXP_SOURCE,
-    "mlx/backend/metal/kernels/random.metal",
+    MLX_RANDOM_SOURCE,
     MLX_RMS_NORM_SOURCE,
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
@@ -96,14 +97,15 @@ MLX_REDUCED_FRONTIER_SOURCES = tuple(
         )
     )
 )
-# Subset of the clean frontier gated by DXC on Windows. The DirectX/Vulkan frontier
-# is still translated in full (and all Vulkan artifacts are spirv-val'd), while
-# the remaining kernels stay outside the DirectX compile gate under tracked gaps.
+# Full clean DirectX frontier gated by DXC on Windows. The separate blocked fence
+# source must fail before target emission under its atomic-fence diagnostic.
 MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = (
     MLX_ARANGE_SOURCE,
     MLX_ARG_REDUCE_SOURCE,
+    MLX_BINARY_TWO_SOURCE,
     MLX_LAYER_NORM_SOURCE,
     MLX_LOGSUMEXP_SOURCE,
+    MLX_RANDOM_SOURCE,
     MLX_RMS_NORM_SOURCE,
     MLX_ROPE_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
@@ -114,8 +116,10 @@ MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = (
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
     MLX_ARANGE_SOURCE: 11,
     MLX_ARG_REDUCE_SOURCE: 24,
+    MLX_BINARY_TWO_SOURCE: 225,
     MLX_LAYER_NORM_SOURCE: 12,
     MLX_LOGSUMEXP_SOURCE: 6,
+    MLX_RANDOM_SOURCE: 2,
     MLX_RMS_NORM_SOURCE: 12,
     MLX_ROPE_SOURCE: 18,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
@@ -284,6 +288,9 @@ FULL_CORPUS_TRACKED_ISSUES = (
     *METAL_ROUNDTRIP_SEMANTIC_TRACKED_ISSUES,
 )
 RESOLVED_FRONTIER_ISSUES = (
+    "https://github.com/CrossGL/crosstl/issues/1728",
+    "https://github.com/CrossGL/crosstl/issues/1701",
+    "https://github.com/CrossGL/crosstl/issues/1694",
     "https://github.com/CrossGL/crosstl/issues/1695",
     "https://github.com/CrossGL/crosstl/issues/1667",
     "https://github.com/CrossGL/crosstl/issues/1668",

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -1369,10 +1369,8 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
         module.MLX_REDUCED_FRONTIER_SOURCES
     ) - set(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
     directx_gaps = directx["directx_toolchain_gaps"]
-    assert "issues/1694" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
-    assert "issues/1701" in directx_gaps[module.MLX_BINARY_TWO_SOURCE]
-    assert "issues/1696" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
-    assert "issues/1542" in directx_gaps["mlx/backend/metal/kernels/random.metal"]
+    assert module.MLX_BINARY_TWO_SOURCE not in directx_gaps
+    assert module.MLX_RANDOM_SOURCE not in directx_gaps
     assert module.MLX_TERNARY_SOURCE not in directx_gaps
     assert "issues/1537" in directx_gaps[module.MLX_FENCE_SOURCE]
     assert "issues/1695" not in json.dumps(directx_gaps)
@@ -3614,12 +3612,12 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
         directory.mkdir(parents=True)
 
     frontier_count = len(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
-    directx_subset_count = len(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
+    directx_toolchain_count = len(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
     directx_paths = {
         source: f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
         for source in module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
     }
-    directx_subset_paths = {
+    directx_toolchain_paths = {
         source: f".crosstl/out/directx/{Path(source).with_suffix('.hlsl')}"
         for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
     }
@@ -3634,9 +3632,9 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     def fake_run_command(name, command, *, log_dir, check=True, timeout_seconds=None):
         commands.append((name, list(command)))
         is_toolchain = name != "translate-directx-vulkan-frontier"
-        # The DXC compile gate runs only on its configured source frontier; the
-        # translation frontier still emits every clean frontier artifact.
-        report_directx_paths = directx_subset_paths if is_toolchain else directx_paths
+        report_directx_paths = (
+            directx_toolchain_paths if is_toolchain else directx_paths
+        )
         report = {
             "summary": {
                 "unitCount": frontier_count,
@@ -3684,7 +3682,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
                             ],
                             "status": "ok",
                         }
-                        for source, path in directx_subset_paths.items()
+                        for source, path in directx_toolchain_paths.items()
                         for index in range(
                             module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS[source]
                         )
@@ -3723,7 +3721,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert result["directxToolchainSources"] == list(
         module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
     )
-    assert result["directxToolchainArtifactCount"] == directx_subset_count
+    assert result["directxToolchainArtifactCount"] == directx_toolchain_count
     assert result["directxToolchainExpectedEntryPointCounts"] == (
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
     )
@@ -3733,7 +3731,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert result["directxToolchainValidatedSources"] == list(
         module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
     )
-    assert result["directxToolchainValidatedArtifactCount"] == directx_subset_count
+    assert result["directxToolchainValidatedArtifactCount"] == directx_toolchain_count
     assert result["directxToolchainValidatedEntryPointCounts"] == (
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
     )
@@ -3752,8 +3750,6 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert "[project.specialization_constants]" in toolchain_config
     for selector, value in module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS.items():
         assert f"{json.dumps(selector)} = {json.dumps(value)}" in toolchain_config
-    # The DXC compile gate is scoped to its configured frontier, not the whole
-    # clean translation frontier, so only those sources appear in this config.
     for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES:
         assert source in toolchain_config
 
@@ -3769,8 +3765,10 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     expected_sources = (
         module.MLX_ARANGE_SOURCE,
         module.MLX_ARG_REDUCE_SOURCE,
+        module.MLX_BINARY_TWO_SOURCE,
         module.MLX_LAYER_NORM_SOURCE,
         module.MLX_LOGSUMEXP_SOURCE,
+        module.MLX_RANDOM_SOURCE,
         module.MLX_RMS_NORM_SOURCE,
         module.MLX_ROPE_SOURCE,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
@@ -3778,31 +3776,35 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_TERNARY_SOURCE,
     )
     assert module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES == expected_sources
-    assert set(expected_sources) < set(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
+    assert set(expected_sources) == set(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
     assert tuple(module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS) == expected_sources
     assert {
         source: module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS[source]
         for source in (
+            module.MLX_BINARY_TWO_SOURCE,
             module.MLX_LAYER_NORM_SOURCE,
             module.MLX_LOGSUMEXP_SOURCE,
+            module.MLX_RANDOM_SOURCE,
             module.MLX_RMS_NORM_SOURCE,
             module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
             module.MLX_SOFTMAX_SOURCE,
             module.MLX_TERNARY_SOURCE,
         )
     } == {
+        module.MLX_BINARY_TWO_SOURCE: 225,
         module.MLX_LAYER_NORM_SOURCE: 12,
         module.MLX_LOGSUMEXP_SOURCE: 6,
+        module.MLX_RANDOM_SOURCE: 2,
         module.MLX_RMS_NORM_SOURCE: 12,
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
         module.MLX_SOFTMAX_SOURCE: 10,
         module.MLX_TERNARY_SOURCE: 212,
     }
-    assert len(expected_sources) == 9
+    assert len(expected_sources) == 11
     assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == sum(
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
     )
-    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 347
+    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 574
     directx_status = gaps["directx_toolchain_status"]
     assert directx_status["specialization_constants"] == (
         module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS
@@ -3811,19 +3813,14 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     assert directx_status["expected_entry_point_counts"] == (
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
     )
-    assert set(directx_status["directx_toolchain_gaps"]) == {
-        module.MLX_BINARY_TWO_SOURCE,
-        "mlx/backend/metal/kernels/random.metal",
-        module.MLX_FENCE_SOURCE,
-    }
+    assert set(directx_status["directx_toolchain_gaps"]) == {module.MLX_FENCE_SOURCE}
     assert {
         f"https://github.com/CrossGL/crosstl/issues/{issue}"
-        for issue in (1694, 1696, 1701)
-    } <= set(gaps["tracked_issues"])
-    aggregate_issue = "https://github.com/CrossGL/crosstl/issues/1695"
-    assert aggregate_issue in module.RESOLVED_FRONTIER_ISSUES
-    assert aggregate_issue in gaps["resolved_issues"]
-    assert aggregate_issue not in gaps["tracked_issues"]
+        for issue in (1694, 1695, 1701, 1728)
+    } <= set(module.RESOLVED_FRONTIER_ISSUES)
+    assert set(module.RESOLVED_FRONTIER_ISSUES) <= set(gaps["resolved_issues"])
+    assert not set(module.RESOLVED_FRONTIER_ISSUES) & set(gaps["tracked_issues"])
+    assert "https://github.com/CrossGL/crosstl/issues/1696" in gaps["tracked_issues"]
 
 
 def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
@@ -3832,14 +3829,15 @@ def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
 
     assert "official DXC v1.9.2602.24 on Windows CI" in readme
     assert (
-        "the nine-source `arange.metal`, `arg_reduce.metal`, `layer_norm.metal`"
+        "the full 11-source clean frontier: `arange.metal`, `arg_reduce.metal`"
         in normalized_readme
     )
-    assert "11, 24, 12, 6, 12, 18, 42, 10, and 212 entries respectively" in (
-        normalized_readme
+    assert (
+        "11, 24, 225, 12, 6, 2, 12, 18, 42, 10, and 212 entries respectively"
+        in normalized_readme
     )
-    assert "347 generated compute entries" in normalized_readme
-    for issue in (1694, 1695, 1696, 1701, 1542, 1537):
+    assert "574 generated compute entries" in normalized_readme
+    for issue in (1694, 1695, 1696, 1701, 1728, 1542, 1537):
         assert f"https://github.com/CrossGL/crosstl/issues/{issue}" in readme
     assert "does not dispatch these kernels or establish numerical parity" in (
         normalized_readme


### PR DESCRIPTION
## Summary

- require official DXC validation for `binary_two.metal` and `random.metal` in the pinned MLX project-porting workflow
- expand the required DirectX compiler frontier to 11 source artifacts and all 574 generated compute entries
- update the machine-readable gap inventory and documentation after the fixes tracked by #1694, #1701, and #1728
- retain explicit exclusions for runtime dispatch, numerical parity, atomic-fence semantics, and broader union layouts

This is a compiler-acceptance proof. It does not claim Direct3D execution or MLX numerical parity for the promoted kernels. Runtime dispatch metadata remains tracked by #1542, atomic-fence semantics by #1537, and broader union layouts by #1696.

## Verification

- pinned MLX reduced-frontier harness with official DXC v1.9.2602.24: passed, 574/574 entry points
- `python -m pytest -q -n auto tests/test_mlx_porting_harness.py`: 79 passed
- `python -m pytest -q -n auto`: 15,228 passed, 194 skipped
- `python tools/support_matrix.py check`: current
- support issue sync dry run: zero desired issues
- `pre-commit run --all-files`: passed

Support issue traceability: no issue closed
