### PR TITLE
Reflect exact scalar resource layouts for native runtimes

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -28,6 +28,7 @@ on:
       - "tests/fixtures/project_porting/mlx/**"
       - "tests/test_translator/test_native_runtime_drivers.py"
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
+      - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
       - "tests/test_translator/test_runtime_verification.py"
@@ -54,6 +55,7 @@ on:
       - "tests/fixtures/project_porting/mlx/**"
       - "tests/test_translator/test_native_runtime_drivers.py"
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
+      - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
       - "tests/test_translator/test_runtime_verification.py"
@@ -300,6 +302,15 @@ jobs:
           python -m pytest -q -n auto
           tests/test_translator/test_native_loader_dispatch_integration.py::test_native_loader_descriptor_executes_directx_on_device
 
+      - name: Prove pinned MLX arange Direct3D native-loader execution
+        if: runner.os == 'Windows'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_ARANGE_DIRECTX_NATIVE_LOADER: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_arange_native_loader.py::test_pinned_mlx_arange_executes_through_directx_native_loader
+
       - name: Prove Direct3D local-struct byte-view native readback
         if: runner.os == 'Windows'
         env:
@@ -353,6 +364,18 @@ jobs:
         run: >-
           python -m pytest -q -n auto
           tests/test_translator/test_native_loader_dispatch_integration.py::test_native_loader_descriptor_executes_opengl_on_device
+
+      - name: Prove pinned MLX arange OpenGL native-loader execution
+        if: runner.os == 'Linux'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_ARANGE_OPENGL_NATIVE_LOADER: "1"
+          EGL_PLATFORM: surfaceless
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          PYOPENGL_PLATFORM: egl
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_arange_native_loader.py::test_pinned_mlx_arange_executes_through_opengl_native_loader
 
       - name: Validate generated OpenGL subgroup contract through Vulkan
         if: runner.os == 'Linux'

--- a/crosstl/project/host_reflection.py
+++ b/crosstl/project/host_reflection.py
@@ -418,6 +418,20 @@ HLSL_CONSTANT_RE = re.compile(
     r"(?P<name>[A-Za-z_]\w*)\s*=\s*(?P<value>[^;]+);",
     re.IGNORECASE,
 )
+HLSL_SCALAR_BLOCK_MEMBER_RE = re.compile(
+    r"\A\s*(?P<type>float|int|uint)\s+(?P<name>[A-Za-z_]\w*)\s*;\s*\Z",
+    re.IGNORECASE,
+)
+HLSL_STRUCTURED_SCALAR_RE = re.compile(
+    r"\A(?:RW)?StructuredBuffer\s*<\s*(?P<type>float|int|uint)\s*>\Z",
+    re.IGNORECASE,
+)
+
+SCALAR_PHYSICAL_TYPES = {
+    "float": "float32",
+    "int": "int32",
+    "uint": "uint32",
+}
 
 HLSL_ENTRY_STAGE_BY_NAME = {
     "VSMain": "vertex",
@@ -684,29 +698,34 @@ def _reflect_hlsl_source(
     resources = []
     for match in HLSL_CBUFFER_RE.finditer(source):
         set_number, binding = _parse_register(match.group("register"))
-        resources.append(
-            {
-                "name": match.group("name"),
-                "kind": "constant-buffer",
-                "type": match.group("name"),
-                "set": set_number,
-                "binding": binding,
-                "access": "read",
-            }
-        )
+        resource = {
+            "name": match.group("name"),
+            "kind": "constant-buffer",
+            "type": match.group("name"),
+            "set": set_number,
+            "binding": binding,
+            "access": "read",
+        }
+        body = _braced_body(source, match.end() - 1)
+        scalar_layout = _hlsl_scalar_block_layout(match.group("kind"), body)
+        if scalar_layout is not None:
+            resource["scalarLayout"] = scalar_layout
+        resources.append(resource)
     for match in HLSL_RESOURCE_RE.finditer(source):
         type_name = " ".join(match.group("type").split())
         set_number, binding = _parse_register(match.group("register"))
-        resources.append(
-            {
-                "name": match.group("name"),
-                "kind": _hlsl_resource_kind(type_name),
-                "type": type_name,
-                "set": set_number,
-                "binding": binding,
-                "access": _hlsl_resource_access(type_name),
-            }
-        )
+        resource = {
+            "name": match.group("name"),
+            "kind": _hlsl_resource_kind(type_name),
+            "type": type_name,
+            "set": set_number,
+            "binding": binding,
+            "access": _hlsl_resource_access(type_name),
+        }
+        scalar_layout = _hlsl_structured_scalar_layout(type_name)
+        if scalar_layout is not None:
+            resource["scalarLayout"] = scalar_layout
+        resources.append(resource)
 
     constants = [
         {
@@ -760,6 +779,53 @@ def _hlsl_resource_access(type_name: str) -> str | None:
     return None
 
 
+def _braced_body(source: str, opening_brace: int) -> str | None:
+    if opening_brace < 0 or opening_brace >= len(source):
+        return None
+    if source[opening_brace] != "{":
+        return None
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        character = source[index]
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace + 1 : index]
+    return None
+
+
+def _hlsl_scalar_block_layout(
+    block_kind: str, body: str | None
+) -> dict[str, Any] | None:
+    if block_kind.lower() != "cbuffer" or body is None:
+        return None
+    match = HLSL_SCALAR_BLOCK_MEMBER_RE.fullmatch(body)
+    if match is None:
+        return None
+    return _scalar_physical_layout(
+        match.group("type"),
+        member_name=match.group("name"),
+        storage_layout="hlsl-constant-buffer",
+        alignment_bytes=16,
+        runtime_sized=False,
+        block_size_bytes=16,
+    )
+
+
+def _hlsl_structured_scalar_layout(type_name: str) -> dict[str, Any] | None:
+    match = HLSL_STRUCTURED_SCALAR_RE.fullmatch(type_name)
+    if match is None:
+        return None
+    return _scalar_physical_layout(
+        match.group("type"),
+        storage_layout="hlsl-structured-buffer",
+        alignment_bytes=4,
+        runtime_sized=True,
+    )
+
+
 GLSL_LAYOUT_RE = re.compile(r"layout\s*\((?P<layout>[^)]*)\)\s*", re.IGNORECASE)
 GLSL_LOCAL_SIZE_RE = re.compile(
     r"layout\s*\((?P<layout>[^)]*local_size_[^)]*)\)\s*in\s*;",
@@ -770,9 +836,14 @@ GLSL_BLOCK_RESOURCE_RE = re.compile(
     r"(?:layout\s*\((?P<layout>[^)]*)\)\s*)?"
     r"(?P<qualifiers>(?:(?:readonly|writeonly|coherent|restrict|volatile)\s+)*)"
     r"(?P<storage>uniform|buffer)\s+"
-    r"(?P<block>[A-Za-z_]\w*)\s*\{[^}]*\}\s*"
+    r"(?P<block>[A-Za-z_]\w*)\s*\{(?P<body>[^}]*)\}\s*"
     r"(?P<name>[A-Za-z_]\w*)?\s*;",
     re.IGNORECASE | re.DOTALL,
+)
+GLSL_SCALAR_BLOCK_MEMBER_RE = re.compile(
+    r"\A\s*(?P<type>float|int|uint)\s+(?P<name>[A-Za-z_]\w*)"
+    r"(?P<runtime_array>\s*\[\s*\])?\s*;\s*\Z",
+    re.IGNORECASE,
 )
 GLSL_RESOURCE_RE = re.compile(
     r"(?:layout\s*\((?P<layout>[^)]*)\)\s*)?"
@@ -836,16 +907,22 @@ def _reflect_glsl_source(
         storage = match.group("storage").lower()
         qualifiers = match.group("qualifiers") or ""
         name = match.group("name") or match.group("block")
-        resources.append(
-            {
-                "name": name,
-                "kind": "constant-buffer" if storage == "uniform" else "buffer",
-                "type": match.group("block"),
-                "set": _layout_int(layout, ("set", "descriptor_set"), default=0),
-                "binding": _layout_int(layout, ("binding",)),
-                "access": _glsl_access(storage, qualifiers),
-            }
+        resource = {
+            "name": name,
+            "kind": "constant-buffer" if storage == "uniform" else "buffer",
+            "type": match.group("block"),
+            "set": _layout_int(layout, ("set", "descriptor_set"), default=0),
+            "binding": _layout_int(layout, ("binding",)),
+            "access": _glsl_access(storage, qualifiers),
+        }
+        scalar_layout = _glsl_scalar_block_layout(
+            storage=storage,
+            layout_text=match.group("layout"),
+            body=match.group("body"),
         )
+        if scalar_layout is not None:
+            resource["scalarLayout"] = scalar_layout
+        resources.append(resource)
     for match in GLSL_RESOURCE_RE.finditer(source):
         if any(start <= match.start() < end for start, end in occupied_spans):
             continue
@@ -950,6 +1027,67 @@ def _parse_layout(layout: str | None) -> dict[str, Any]:
         key, value = part.split("=", 1)
         values[key.strip()] = _literal_value(value)
     return values
+
+
+def _glsl_scalar_block_layout(
+    *, storage: str, layout_text: str | None, body: str
+) -> dict[str, Any] | None:
+    match = GLSL_SCALAR_BLOCK_MEMBER_RE.fullmatch(body)
+    if match is None:
+        return None
+    runtime_sized = match.group("runtime_array") is not None
+    qualifiers = {
+        part.strip().lower()
+        for part in (layout_text or "").split(",")
+        if "=" not in part
+    }
+    if storage == "uniform":
+        if runtime_sized or "std140" not in qualifiers:
+            return None
+        return _scalar_physical_layout(
+            match.group("type"),
+            member_name=match.group("name"),
+            storage_layout="std140",
+            alignment_bytes=16,
+            runtime_sized=False,
+            block_size_bytes=16,
+        )
+    if not runtime_sized or "std430" not in qualifiers:
+        return None
+    return _scalar_physical_layout(
+        match.group("type"),
+        member_name=match.group("name"),
+        storage_layout="std430",
+        alignment_bytes=4,
+        runtime_sized=True,
+    )
+
+
+def _scalar_physical_layout(
+    physical_type: str,
+    *,
+    storage_layout: str,
+    alignment_bytes: int,
+    runtime_sized: bool,
+    member_name: str | None = None,
+    block_size_bytes: int | None = None,
+) -> dict[str, Any]:
+    normalized_type = physical_type.lower()
+    layout: dict[str, Any] = {
+        "physicalType": normalized_type,
+        "elementType": SCALAR_PHYSICAL_TYPES[normalized_type],
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": alignment_bytes,
+        "memberOffsetBytes": 0,
+        "storageLayout": storage_layout,
+        "runtimeSized": runtime_sized,
+    }
+    if member_name is not None:
+        layout["memberName"] = member_name
+    if block_size_bytes is not None:
+        layout["blockSizeBytes"] = block_size_bytes
+    return layout
 
 
 def _layout_int(

--- a/crosstl/project/native_loader_dispatch.py
+++ b/crosstl/project/native_loader_dispatch.py
@@ -79,6 +79,14 @@ _SPECIALIZATION_DTYPE_ALIASES = {
     "boolean": "bool",
 }
 _DTYPE_SIZES = {"float32": 4, "int32": 4, "uint32": 4}
+_PHYSICAL_TYPES = {"float32": "float", "int32": "int", "uint32": "uint"}
+_TARGET_STORAGE_LAYOUTS = {
+    "directx": {
+        "buffer": "hlsl-structured-buffer",
+        "constant-buffer": "hlsl-constant-buffer",
+    },
+    "opengl": {"buffer": "std430", "constant-buffer": "std140"},
+}
 _VALUE_FIELDS = frozenset(
     ("name", "kind", "dtype", "shape", "values", "value", "tolerance", "metadata")
 )
@@ -899,6 +907,8 @@ def _resource_bindings(
         scalar_layout = _validated_scalar_layout(
             binding.get("scalarLayout"),
             runtime_value=value,
+            target=target,
+            resource_kind=kind,
             path=f"{path}.scalarLayout",
         )
         result.append(
@@ -926,7 +936,12 @@ def _resource_bindings(
 
 
 def _validated_scalar_layout(
-    layout: Any, *, runtime_value: RuntimeValue, path: str
+    layout: Any,
+    *,
+    runtime_value: RuntimeValue,
+    target: str,
+    resource_kind: str,
+    path: str,
 ) -> dict[str, Any]:
     if not isinstance(layout, Mapping):
         raise NativeLoaderDispatchError(
@@ -938,6 +953,8 @@ def _validated_scalar_layout(
     element_type = _buffer_dtype(layout.get("elementType"), path=f"{path}.elementType")
     element_size = layout.get("elementSizeBytes")
     element_stride = layout.get("elementStrideBytes")
+    alignment = layout.get("alignmentBytes")
+    member_offset = layout.get("memberOffsetBytes")
     if (
         not isinstance(element_size, int)
         or isinstance(element_size, bool)
@@ -945,43 +962,98 @@ def _validated_scalar_layout(
         or not isinstance(element_stride, int)
         or isinstance(element_stride, bool)
         or element_stride <= 0
+        or not isinstance(alignment, int)
+        or isinstance(alignment, bool)
+        or alignment <= 0
+        or not isinstance(member_offset, int)
+        or isinstance(member_offset, bool)
+        or member_offset < 0
     ):
         raise NativeLoaderDispatchError(
             "resource-layout-invalid",
-            "Scalar layout element size and stride must be positive integers.",
+            "Scalar layout sizes, alignment, and member offset must be concrete integers.",
             path=path,
             details={
                 "binding": runtime_value.name,
                 "elementSizeBytes": element_size,
                 "elementStrideBytes": element_stride,
+                "alignmentBytes": alignment,
+                "memberOffsetBytes": member_offset,
             },
         )
+    physical_type = layout.get("physicalType")
+    storage_layout = layout.get("storageLayout")
+    runtime_sized = layout.get("runtimeSized")
+    expected_physical_type = _PHYSICAL_TYPES[runtime_value.dtype]
+    expected_storage_layout = _TARGET_STORAGE_LAYOUTS[target][resource_kind]
     if (
         element_type != runtime_value.dtype
         or element_size != _DTYPE_SIZES[runtime_value.dtype]
+        or physical_type != expected_physical_type
+        or storage_layout != expected_storage_layout
     ):
         raise NativeLoaderDispatchError(
             "resource-layout-mismatch",
-            "Runtime value dtype is incompatible with the descriptor scalar layout.",
+            "Runtime value or target storage is incompatible with the descriptor scalar layout.",
             path=path,
             details={
                 "binding": runtime_value.name,
                 "valueDtype": runtime_value.dtype,
                 "layoutElementType": element_type,
                 "layoutElementSizeBytes": element_size,
+                "layoutPhysicalType": physical_type,
+                "expectedPhysicalType": expected_physical_type,
+                "layoutStorage": storage_layout,
+                "expectedStorage": expected_storage_layout,
             },
         )
-    if element_stride != element_size:
+    if element_stride != element_size or member_offset != 0:
         raise NativeLoaderDispatchError(
             "resource-layout-unsupported",
-            "Native loader dispatch requires tightly packed scalar buffer layouts.",
-            path=f"{path}.elementStrideBytes",
+            "Native loader dispatch requires a tightly packed scalar at byte offset zero.",
+            path=path,
             details={
                 "binding": runtime_value.name,
                 "elementSizeBytes": element_size,
                 "elementStrideBytes": element_stride,
+                "memberOffsetBytes": member_offset,
             },
         )
+    if resource_kind == "buffer":
+        if runtime_sized is not True or alignment != element_size:
+            raise NativeLoaderDispatchError(
+                "resource-layout-unsupported",
+                "Native loader storage buffers require an exact scalar runtime-array layout.",
+                path=path,
+                details={
+                    "binding": runtime_value.name,
+                    "runtimeSized": runtime_sized,
+                    "alignmentBytes": alignment,
+                    "elementSizeBytes": element_size,
+                },
+            )
+    else:
+        block_size = layout.get("blockSizeBytes")
+        if (
+            runtime_sized is not False
+            or not isinstance(block_size, int)
+            or isinstance(block_size, bool)
+            or block_size < element_size
+            or block_size % alignment
+            or alignment < element_size
+        ):
+            raise NativeLoaderDispatchError(
+                "resource-layout-unsupported",
+                "Native loader constant buffers require an aligned fixed-size scalar block.",
+                path=path,
+                details={
+                    "binding": runtime_value.name,
+                    "runtimeSized": runtime_sized,
+                    "alignmentBytes": alignment,
+                    "blockSizeBytes": block_size,
+                    "elementSizeBytes": element_size,
+                },
+            )
     return copy.deepcopy(dict(layout))
 
 

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -91,6 +91,7 @@ class _PreparedOpenGLBuffer:
     source: str | None
     output_name: str | None
     payload: bytes
+    allocation_size: int
 
     @property
     def size(self) -> int:
@@ -1227,9 +1228,10 @@ class OpenGLComputeRuntime:
 
     def _create_buffer(self, context: Any, prepared: _PreparedOpenGLBuffer) -> Any:
         if prepared.payload:
-            buffer = context.buffer(prepared.payload)
+            payload = prepared.payload.ljust(prepared.allocation_size, b"\x00")
+            buffer = context.buffer(payload)
         else:
-            buffer = context.buffer(reserve=max(prepared.size, 1))
+            buffer = context.buffer(reserve=max(prepared.allocation_size, 1))
         try:
             if prepared.resource_kind in {"constant-buffer", "uniform"}:
                 buffer.bind_to_uniform_block(prepared.binding_index)
@@ -1973,9 +1975,16 @@ def _prepare_directx_buffers(
                 ) from exc
 
         stride = _directx_buffer_stride(binding, namespace, dtype, len(payload))
-        allocation_size = (
-            _align_to(len(payload), 256) if namespace == "cbv" else len(payload)
-        )
+        if namespace == "cbv":
+            block_size = _scalar_block_size(
+                binding,
+                target="directx",
+                dtype=dtype,
+                payload_size=len(payload),
+            )
+            allocation_size = _align_to(max(len(payload), block_size), 256)
+        else:
+            allocation_size = len(payload)
         prepared.append(
             _PreparedDirectXBuffer(
                 name=name,
@@ -2971,6 +2980,14 @@ def _prepare_opengl_buffers(
                 expected_count=element_count,
                 target="OpenGL",
             )
+        allocation_size = len(payload)
+        if namespace == "uniform":
+            allocation_size = _scalar_block_size(
+                binding,
+                target="opengl",
+                dtype=dtype,
+                payload_size=len(payload),
+            )
         prepared.append(
             _PreparedOpenGLBuffer(
                 name=name,
@@ -2981,6 +2998,7 @@ def _prepare_opengl_buffers(
                 source=binding.source,
                 output_name=_runtime_value_name(binding),
                 payload=payload,
+                allocation_size=allocation_size,
             )
         )
     return tuple(
@@ -2992,6 +3010,170 @@ def _prepare_opengl_buffers(
             ),
         )
     )
+
+
+def _scalar_block_size(
+    binding: NativeRuntimeBufferBinding,
+    *,
+    target: str,
+    dtype: str,
+    payload_size: int,
+) -> int:
+    resource = binding.binding
+    target_name = {"directx": "DirectX", "opengl": "OpenGL"}[target]
+    raw_layout = resource.metadata.get("scalarLayout")
+    if raw_layout is None:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has no physical layout metadata.",
+            "scalar-block-layout-missing",
+            resource=binding.name,
+        )
+    if not isinstance(raw_layout, Mapping):
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has malformed physical layout metadata.",
+            "scalar-block-layout-invalid",
+            resource=binding.name,
+            scalarLayout=raw_layout,
+        )
+
+    required_fields = {
+        "physicalType",
+        "elementType",
+        "elementSizeBytes",
+        "elementStrideBytes",
+        "storageLayout",
+        "alignmentBytes",
+        "blockSizeBytes",
+        "memberOffsetBytes",
+        "runtimeSized",
+    }
+    missing_fields = sorted(required_fields.difference(raw_layout))
+    if missing_fields:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has incomplete physical layout metadata.",
+            "scalar-block-layout-invalid",
+            resource=binding.name,
+            missingFields=missing_fields,
+        )
+
+    storage_layout = raw_layout["storageLayout"]
+    expected_storage_layout = {
+        "directx": "hlsl-constant-buffer",
+        "opengl": "std140",
+    }[target]
+    if storage_layout != expected_storage_layout:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has an incompatible storage layout.",
+            "scalar-block-storage-layout-unsupported",
+            resource=binding.name,
+            storageLayout=storage_layout,
+            expectedStorageLayout=expected_storage_layout,
+        )
+
+    integer_fields = {}
+    for field_name in (
+        "elementSizeBytes",
+        "elementStrideBytes",
+        "alignmentBytes",
+        "blockSizeBytes",
+        "memberOffsetBytes",
+    ):
+        value = raw_layout[field_name]
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise _scalar_block_error(
+                target,
+                f"{target_name} scalar block {binding.name!r} has a non-integer {field_name}.",
+                "scalar-block-layout-invalid",
+                resource=binding.name,
+                field=field_name,
+                value=value,
+            )
+        integer_fields[field_name] = value
+
+    element_type = str(raw_layout["elementType"] or "").strip().lower()
+    physical_type = str(raw_layout["physicalType"] or "").strip().lower()
+    expected_physical_type = {
+        "float32": "float",
+        "int32": "int",
+        "uint32": "uint",
+    }[dtype]
+    element_size = integer_fields["elementSizeBytes"]
+    element_stride = integer_fields["elementStrideBytes"]
+    if (
+        element_type != dtype
+        or physical_type != expected_physical_type
+        or element_size != _dtype_size(dtype)
+        or element_stride != element_size
+        or payload_size != element_size
+    ):
+        raise _scalar_block_error(
+            target,
+            f"{target_name} constant and uniform buffers support one reflected scalar value.",
+            "scalar-block-element-layout-unsupported",
+            resource=binding.name,
+            dtype=dtype,
+            payloadSizeBytes=payload_size,
+            elementType=raw_layout["elementType"],
+            physicalType=raw_layout["physicalType"],
+            expectedPhysicalType=expected_physical_type,
+            elementSizeBytes=element_size,
+            elementStrideBytes=element_stride,
+        )
+
+    member_offset = integer_fields["memberOffsetBytes"]
+    if member_offset != 0:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} requires member offset zero.",
+            "scalar-block-member-offset-unsupported",
+            resource=binding.name,
+            memberOffsetBytes=member_offset,
+        )
+    if raw_layout["runtimeSized"] is not False:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} cannot be runtime-sized.",
+            "scalar-block-runtime-size-invalid",
+            resource=binding.name,
+            runtimeSized=raw_layout["runtimeSized"],
+        )
+
+    alignment = integer_fields["alignmentBytes"]
+    if alignment < 16 or alignment & (alignment - 1):
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has an invalid alignment.",
+            "scalar-block-alignment-invalid",
+            resource=binding.name,
+            alignmentBytes=alignment,
+        )
+    block_size = integer_fields["blockSizeBytes"]
+    if block_size < payload_size or block_size % alignment:
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has an invalid block size.",
+            "scalar-block-size-invalid",
+            resource=binding.name,
+            payloadSizeBytes=payload_size,
+            blockSizeBytes=block_size,
+            alignmentBytes=alignment,
+        )
+    return block_size
+
+
+def _scalar_block_error(
+    target: str,
+    message: str,
+    reason_kind: str,
+    **details: Any,
+) -> RuntimeAdapterSetupError:
+    if target == "directx":
+        return _directx_setup_error(message, reason_kind, **details)
+    return _opengl_setup_error(message, reason_kind, **details)
 
 
 def _runtime_value_name(binding: NativeRuntimeBufferBinding) -> str | None:

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -27929,9 +27929,20 @@ def _runtime_manifest_resource_bindings(
             "status": _runtime_manifest_binding_status(resource),
             "source": "hostInterface.resources",
         }
-        metadata = resource.get("metadata")
-        if isinstance(metadata, Mapping) and metadata:
-            binding["metadata"] = dict(metadata)
+        resource_metadata = resource.get("metadata")
+        metadata = (
+            dict(resource_metadata) if isinstance(resource_metadata, Mapping) else {}
+        )
+        if "scalarLayout" in metadata:
+            metadata["scalarLayout"] = _runtime_host_interface_json_value(
+                metadata["scalarLayout"]
+            )
+        if "scalarLayout" in resource:
+            metadata["scalarLayout"] = _runtime_host_interface_json_value(
+                resource.get("scalarLayout")
+            )
+        if metadata:
+            binding["metadata"] = metadata
         bindings.append(binding)
     return bindings
 

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -3907,6 +3907,16 @@ def _parse_runtime_resource_binding(
             f"{field_name} must identify a resource by id, name, or binding."
         )
     metadata = _parse_runtime_contract_item_metadata(value, field_name=field_name)
+    if "scalarLayout" in metadata:
+        metadata["scalarLayout"] = _parse_runtime_scalar_layout(
+            metadata["scalarLayout"],
+            field_name=f"{field_name}.metadata.scalarLayout",
+        )
+    if "scalarLayout" in value:
+        metadata["scalarLayout"] = _parse_runtime_scalar_layout(
+            value.get("scalarLayout"),
+            field_name=f"{field_name}.scalarLayout",
+        )
     if "required" in value:
         metadata["required"] = _optional_bool(
             value.get("required"), field_name=f"{field_name}.required"
@@ -3926,6 +3936,12 @@ def _parse_runtime_resource_binding(
         value=_optional_string(value.get("value"), field_name=f"{field_name}.value"),
         metadata=metadata,
     )
+
+
+def _parse_runtime_scalar_layout(value: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RuntimeVerificationError(f"{field_name} must be an object.")
+    return dict(value)
 
 
 def _parse_runtime_specialization_constants(
@@ -5372,10 +5388,8 @@ def _merge_runtime_adapter_contract(
             override.entry_points,
             key=lambda item: (item.name, item.stage),
         ),
-        resource_bindings=_merge_runtime_contract_items(
-            base.resource_bindings,
-            override.resource_bindings,
-            key=_runtime_resource_binding_key,
+        resource_bindings=_merge_runtime_resource_bindings(
+            base.resource_bindings, override.resource_bindings
         ),
         specialization_constants=_merge_runtime_contract_items(
             base.specialization_constants,
@@ -5421,6 +5435,63 @@ def _runtime_resource_binding_key(binding: RuntimeResourceBinding) -> Any:
     if binding.name is not None:
         return ("name", binding.name)
     return ("binding", binding.set, binding.binding, binding.index)
+
+
+def _merge_runtime_resource_bindings(
+    base: tuple[RuntimeResourceBinding, ...],
+    override: tuple[RuntimeResourceBinding, ...],
+) -> tuple[RuntimeResourceBinding, ...]:
+    if not base:
+        return override
+    if not override:
+        return base
+    result = list(base)
+    for item in override:
+        position = next(
+            (
+                index
+                for index, existing in enumerate(result)
+                if _runtime_resource_bindings_match(existing, item)
+            ),
+            None,
+        )
+        if position is None:
+            result.append(item)
+        else:
+            result[position] = _merge_runtime_resource_binding(result[position], item)
+    return tuple(result)
+
+
+def _runtime_resource_bindings_match(
+    base: RuntimeResourceBinding, override: RuntimeResourceBinding
+) -> bool:
+    if base.binding_id is not None and override.binding_id is not None:
+        return base.binding_id == override.binding_id
+    if base.name is not None and override.name is not None:
+        return base.name == override.name
+    return _runtime_resource_binding_key(base) == _runtime_resource_binding_key(
+        override
+    )
+
+
+def _merge_runtime_resource_binding(
+    base: RuntimeResourceBinding, override: RuntimeResourceBinding
+) -> RuntimeResourceBinding:
+    def selected(override_value: Any, base_value: Any) -> Any:
+        return base_value if override_value is None else override_value
+
+    return RuntimeResourceBinding(
+        binding_id=selected(override.binding_id, base.binding_id),
+        name=selected(override.name, base.name),
+        kind=selected(override.kind, base.kind),
+        type_name=selected(override.type_name, base.type_name),
+        set=selected(override.set, base.set),
+        binding=selected(override.binding, base.binding),
+        index=selected(override.index, base.index),
+        access=selected(override.access, base.access),
+        value=selected(override.value, base.value),
+        metadata={**dict(base.metadata), **dict(override.metadata)},
+    )
 
 
 def _merge_runtime_dispatch(

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -826,6 +826,47 @@ diagnostics and runtime-reference review actions forward, and it remains a
 metadata contract only: it does not rewrite host application code, execute
 device code, generate runtime framework code, or install target SDKs.
 
+Exact Scalar Physical Resource Layouts
+--------------------------------------
+
+Source reflection records a ``scalarLayout`` only when the target-language
+resource has an exact physical representation covered by the project runtime
+contract. HLSL reflection supports ``StructuredBuffer`` and
+``RWStructuredBuffer`` resources whose element type is exactly ``float``,
+``int``, or ``uint``, together with ``cbuffer`` declarations containing one
+member of one of those types. GLSL reflection supports explicit ``std430``
+buffer blocks containing one scalar runtime-array member and explicit
+``std140`` uniform blocks containing one scalar member of those types.
+
+The reflected layout records ``physicalType``, ``elementType``,
+``elementSizeBytes``, ``elementStrideBytes``, ``alignmentBytes``,
+``memberOffsetBytes``, ``storageLayout``, and ``runtimeSized``. It also records
+``memberName`` when the source block provides one and ``blockSizeBytes`` for a
+fixed scalar block. These fields are preserved through runtime packages and
+native loader ABI descriptors. Descriptor-to-request validation rejects
+missing, incomplete, or mismatched layouts instead of inferring a host ABI.
+
+Native runtime allocation consumes the same physical contract. DirectX
+constant-buffer views require a fixed HLSL scalar block and allocate at least
+the reflected block size, rounded to the 256-byte API alignment. OpenGL
+uniform buffers require a fixed ``std140`` scalar block and zero-pad the upload
+to ``blockSizeBytes``; ``std430`` scalar runtime arrays retain their logical
+payload size for storage-buffer readback.
+
+Vectors, matrices, fixed arrays, aggregates, packed or widened scalar types,
+implicit GLSL block layouts, arbitrary member offsets, and multi-member blocks
+do not receive this layout metadata. Those shapes remain unresolved and fail
+closed when a native loader request requires a physical layout.
+
+At pinned MLX commit ``4367c73b60541ddd5a266ce4644fd93d20223b6e``, the
+``arangeuint32`` entry from ``arange.metal`` is translated to DirectX and
+OpenGL, reflected, packaged, converted through the public native loader bridge,
+and executed in Windows Direct3D and Linux EGL CI. With ``start = 3``,
+``step = 2``, and four invocations, both readbacks are exactly
+``[3, 5, 7, 9]``. This is an end-to-end proof for one scalar kernel contract;
+it is not a claim of vector or aggregate layout support, full MLX runtime
+integration, or MLX test-suite parity.
+
 Build a versioned native loader ABI descriptor and optional C declarations for
 one ready load unit:
 
@@ -950,10 +991,12 @@ layout metadata is a structured error rather than an inferred ABI.
 This API prepares one request. Repository scheduling, application loader and
 host integration, and device execution remain downstream responsibilities. A
 read-write resource may be used as an output, but initializing and reading back
-the same read-write resource in one request is not supported. Generated MLX
-descriptors do not yet carry complete physical scalar layouts, so they remain
-rejected until physical layout reflection is available; request construction
-does not establish MLX runtime execution or numerical parity.
+the same read-write resource in one request is not supported. Generated
+descriptors for the exact HLSL and GLSL scalar forms described above carry the
+complete physical layout into request construction; unsupported resource
+shapes remain rejected rather than inferred. The pinned MLX ``arangeuint32``
+proof establishes native DirectX and OpenGL execution for that one contract,
+not full MLX runtime integration or numerical parity across the MLX test suite.
 
 Build a deterministic runtime variant registry from either a ready runtime
 package or loader manifest:

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -37,17 +37,17 @@ implicitly supported.
 .. csv-table:: Summary by backend
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "76", "0", "2", "0", "0", "0"
-   "OpenGL / GLSL", "75", "0", "2", "1", "0", "0"
-   "WebGL / GLSL ES", "42", "0", "23", "13", "0", "0"
-   "WebGPU / WGSL", "46", "0", "21", "11", "0", "0"
-   "Metal", "70", "0", "4", "4", "0", "0"
-   "Vulkan SPIR-V", "72", "0", "2", "4", "0", "0"
-   "CUDA", "66", "0", "8", "4", "0", "0"
-   "HIP", "66", "0", "8", "4", "0", "0"
-   "Mojo", "68", "0", "6", "4", "0", "0"
-   "Rust", "69", "0", "5", "4", "0", "0"
-   "Slang", "70", "0", "4", "4", "0", "0"
+   "DirectX / HLSL", "77", "0", "2", "0", "0", "0"
+   "OpenGL / GLSL", "76", "0", "2", "1", "0", "0"
+   "WebGL / GLSL ES", "42", "0", "23", "14", "0", "0"
+   "WebGPU / WGSL", "46", "0", "21", "12", "0", "0"
+   "Metal", "70", "0", "4", "5", "0", "0"
+   "Vulkan SPIR-V", "72", "0", "2", "5", "0", "0"
+   "CUDA", "66", "0", "8", "5", "0", "0"
+   "HIP", "66", "0", "8", "5", "0", "0"
+   "Mojo", "68", "0", "6", "5", "0", "0"
+   "Rust", "69", "0", "5", "5", "0", "0"
+   "Slang", "70", "0", "4", "5", "0", "0"
 
 Graphics Backend Focus
 ----------------------
@@ -58,9 +58,9 @@ scope for graphics backend completion work.
 .. csv-table:: Graphics backend status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "76", "0", "2", "0", "0", "0"
-   "OpenGL / GLSL", "75", "0", "2", "1", "0", "0"
-   "Metal", "70", "0", "4", "4", "0", "0"
+   "DirectX / HLSL", "77", "0", "2", "0", "0", "0"
+   "OpenGL / GLSL", "76", "0", "2", "1", "0", "0"
+   "Metal", "70", "0", "4", "5", "0", "0"
 
 .. rubric:: DirectX/OpenGL/Metal actionable backlog
 
@@ -75,17 +75,17 @@ inspection, diagnostics, validation, and corpus-coverage rows.
 .. csv-table:: Project-porting status summary
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
-   "DirectX / HLSL", "33", "0", "1", "0", "0", "0"
-   "OpenGL / GLSL", "32", "0", "1", "1", "0", "0"
-   "WebGL / GLSL ES", "29", "0", "1", "4", "0", "0"
-   "WebGPU / WGSL", "29", "0", "1", "4", "0", "0"
-   "Metal", "29", "0", "1", "4", "0", "0"
-   "Vulkan SPIR-V", "29", "0", "1", "4", "0", "0"
-   "CUDA", "29", "0", "1", "4", "0", "0"
-   "HIP", "29", "0", "1", "4", "0", "0"
-   "Mojo", "29", "0", "1", "4", "0", "0"
-   "Rust", "29", "0", "1", "4", "0", "0"
-   "Slang", "29", "0", "1", "4", "0", "0"
+   "DirectX / HLSL", "34", "0", "1", "0", "0", "0"
+   "OpenGL / GLSL", "33", "0", "1", "1", "0", "0"
+   "WebGL / GLSL ES", "29", "0", "1", "5", "0", "0"
+   "WebGPU / WGSL", "29", "0", "1", "5", "0", "0"
+   "Metal", "29", "0", "1", "5", "0", "0"
+   "Vulkan SPIR-V", "29", "0", "1", "5", "0", "0"
+   "CUDA", "29", "0", "1", "5", "0", "0"
+   "HIP", "29", "0", "1", "5", "0", "0"
+   "Mojo", "29", "0", "1", "5", "0", "0"
+   "Rust", "29", "0", "1", "5", "0", "0"
+   "Slang", "29", "0", "1", "5", "0", "0"
 
 .. rubric:: Project-porting actionable backlog
 
@@ -196,6 +196,7 @@ Each category below uses the status codes from the legend.
    "Runtime host binding plan", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime adapter plan", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime loader manifest", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
+   "Exact scalar physical resource layouts", "Y", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
    "Native loader ABI descriptors", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Native loader dispatch request", "Y", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
    "Runtime test manifest", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"

--- a/support/features.json
+++ b/support/features.json
@@ -10688,6 +10688,103 @@
       }
     },
     {
+      "id": "project.exact_scalar_resource_layout",
+      "category": "project",
+      "name": "Exact scalar physical resource layouts",
+      "description": "Reflect and enforce exact 32-bit scalar resource layouts from target source through native loader descriptors, runtime requests, and target buffer allocation without inferring unsupported physical ABIs.",
+      "support": {
+        "directx": {
+          "status": "supported",
+          "notes": "HLSL host reflection emits scalarLayout for float, int, and uint StructuredBuffer/RWStructuredBuffer resources and one-member scalar cbuffer declarations. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and DirectX CBV preparation validates the fixed block before allocating at least blockSizeBytes with 256-byte API alignment. Windows Direct3D CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Vectors, matrices, fixed arrays, aggregates, packed or widened types, arbitrary offsets, and multi-member blocks are not inferred.",
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_uses_reflected_block_size_as_allocation_minimum",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
+          ]
+        },
+        "opengl": {
+          "status": "supported",
+          "notes": "GLSL host reflection emits scalarLayout for explicit std430 one-member float, int, and uint runtime-array buffer blocks and explicit std140 one-member scalar uniform blocks. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and OpenGL UBO preparation zero-pads scalar uploads to blockSizeBytes while storage-buffer readback retains its logical payload size. Linux EGL CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Implicit layouts and unsupported aggregate shapes are not inferred.",
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_opengl_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_zero_pads_scalar_uniform_block_allocation",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
+          ]
+        },
+        "webgl": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WebGL descriptors with a structured target-unsupported diagnostic; no WebGL physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "wgsl": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WGSL descriptors with a structured target-unsupported diagnostic; no WGSL physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "metal": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Metal descriptors with a structured target-unsupported diagnostic; no Metal physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "vulkan": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Vulkan descriptors with a structured target-unsupported diagnostic; no Vulkan physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "cuda": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects CUDA descriptors with a structured target-unsupported diagnostic; no CUDA physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "hip": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects HIP descriptors with a structured target-unsupported diagnostic; no HIP physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "mojo": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Mojo descriptors with a structured target-unsupported diagnostic; no Mojo physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "rust": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Rust descriptors with a structured target-unsupported diagnostic; no Rust physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        },
+        "slang": {
+          "status": "validated_rejection",
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Slang descriptors with a structured target-unsupported diagnostic; no Slang physical-layout allocation or execution support is claimed.",
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ]
+        }
+      }
+    },
+    {
       "id": "project.native_loader_abi",
       "category": "project",
       "name": "Native loader ABI descriptors",
@@ -10881,32 +10978,40 @@
       "support": {
         "directx": {
           "status": "supported",
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Windows Direct3D CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_directx_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_missing_extra_and_read_only_output_values",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
           ]
         },
         "opengl": {
           "status": "supported",
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Linux EGL CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_opengl_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_specialization_provenance_distinguishes_descriptor_default_and_explicit",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
           ]
         },
         "webgl": {

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -3388,6 +3388,47 @@
     },
     {
       "category": "project",
+      "description": "Reflect and enforce exact 32-bit scalar resource layouts from target source through native loader descriptors, runtime requests, and target buffer allocation without inferring unsupported physical ABIs.",
+      "id": "project.exact_scalar_resource_layout",
+      "name": "Exact scalar physical resource layouts",
+      "support": {
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_uses_reflected_block_size_as_allocation_minimum",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
+          ],
+          "notes": "HLSL host reflection emits scalarLayout for float, int, and uint StructuredBuffer/RWStructuredBuffer resources and one-member scalar cbuffer declarations. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and DirectX CBV preparation validates the fixed block before allocating at least blockSizeBytes with 256-byte API alignment. Windows Direct3D CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Vectors, matrices, fixed arrays, aggregates, packed or widened types, arbitrary offsets, and multi-member blocks are not inferred.",
+          "status": "supported"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Metal descriptors with a structured target-unsupported diagnostic; no Metal physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_opengl_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_zero_pads_scalar_uniform_block_allocation",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
+          ],
+          "notes": "GLSL host reflection emits scalarLayout for explicit std430 one-member float, int, and uint runtime-array buffer blocks and explicit std140 one-member scalar uniform blocks. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and OpenGL UBO preparation zero-pads scalar uploads to blockSizeBytes while storage-buffer readback retains its logical payload size. Linux EGL CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Implicit layouts and unsupported aggregate shapes are not inferred.",
+          "status": "supported"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Build deterministic native loader ABI metadata, C declarations, and multi-unit packages from ready runtime loader units without creating runtime objects or dispatching device work.",
       "id": "project.native_loader_abi",
       "name": "Native loader ABI descriptors",
@@ -3453,16 +3494,20 @@
         "directx": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_directx_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_missing_extra_and_read_only_output_values",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Windows Direct3D CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         },
         "metal": {
@@ -3475,16 +3520,20 @@
         "opengl": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_opengl_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_specialization_provenance_distinguishes_descriptor_default_and_explicit",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Linux EGL CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         }
       }
@@ -4836,12 +4885,12 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 78,
+    "feature_count": 79,
     "status_counts": {
       "directx": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 76,
+        "supported": 77,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -4852,12 +4901,12 @@
         "supported": 70,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 75,
+        "supported": 76,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -5692,6 +5692,103 @@
     },
     {
       "category": "project",
+      "description": "Reflect and enforce exact 32-bit scalar resource layouts from target source through native loader descriptors, runtime requests, and target buffer allocation without inferring unsupported physical ABIs.",
+      "id": "project.exact_scalar_resource_layout",
+      "name": "Exact scalar physical resource layouts",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects CUDA descriptors with a structured target-unsupported diagnostic; no CUDA physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_uses_reflected_block_size_as_allocation_minimum",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
+          ],
+          "notes": "HLSL host reflection emits scalarLayout for float, int, and uint StructuredBuffer/RWStructuredBuffer resources and one-member scalar cbuffer declarations. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and DirectX CBV preparation validates the fixed block before allocating at least blockSizeBytes with 256-byte API alignment. Windows Direct3D CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Vectors, matrices, fixed arrays, aggregates, packed or widened types, arbitrary offsets, and multi-member blocks are not inferred.",
+          "status": "supported"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects HIP descriptors with a structured target-unsupported diagnostic; no HIP physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Metal descriptors with a structured target-unsupported diagnostic; no Metal physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Mojo descriptors with a structured target-unsupported diagnostic; no Mojo physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_opengl_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_zero_pads_scalar_uniform_block_allocation",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
+          ],
+          "notes": "GLSL host reflection emits scalarLayout for explicit std430 one-member float, int, and uint runtime-array buffer blocks and explicit std140 one-member scalar uniform blocks. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and OpenGL UBO preparation zero-pads scalar uploads to blockSizeBytes while storage-buffer readback retains its logical payload size. Linux EGL CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Implicit layouts and unsupported aggregate shapes are not inferred.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Rust descriptors with a structured target-unsupported diagnostic; no Rust physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Slang descriptors with a structured target-unsupported diagnostic; no Slang physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Vulkan descriptors with a structured target-unsupported diagnostic; no Vulkan physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WebGL descriptors with a structured target-unsupported diagnostic; no WebGL physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WGSL descriptors with a structured target-unsupported diagnostic; no WGSL physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Build deterministic native loader ABI metadata, C declarations, and multi-unit packages from ready runtime loader units without creating runtime objects or dispatching device work.",
       "id": "project.native_loader_abi",
       "name": "Native loader ABI descriptors",
@@ -5892,16 +5989,20 @@
         "directx": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_directx_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_missing_extra_and_read_only_output_values",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Windows Direct3D CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         },
         "hip": {
@@ -5928,16 +6029,20 @@
         "opengl": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_opengl_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_specialization_provenance_distinguishes_descriptor_default_and_explicit",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Linux EGL CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         },
         "rust": {
@@ -10491,7 +10596,7 @@
         "validated_rejection": 0
       }
     },
-    "feature_count": 34,
+    "feature_count": 35,
     "status_counts": {
       "cuda": {
         "diagnostic": 1,
@@ -10499,12 +10604,12 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "directx": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 33,
+        "supported": 34,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -10515,7 +10620,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "metal": {
         "diagnostic": 1,
@@ -10523,7 +10628,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "mojo": {
         "diagnostic": 1,
@@ -10531,12 +10636,12 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "opengl": {
         "diagnostic": 1,
         "partial": 0,
-        "supported": 32,
+        "supported": 33,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -10547,7 +10652,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "slang": {
         "diagnostic": 1,
@@ -10555,7 +10660,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "vulkan": {
         "diagnostic": 1,
@@ -10563,7 +10668,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "webgl": {
         "diagnostic": 1,
@@ -10571,7 +10676,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "wgsl": {
         "diagnostic": 1,
@@ -10579,7 +10684,7 @@
         "supported": 29,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       }
     }
   },

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -12116,6 +12116,103 @@
     },
     {
       "category": "project",
+      "description": "Reflect and enforce exact 32-bit scalar resource layouts from target source through native loader descriptors, runtime requests, and target buffer allocation without inferring unsupported physical ABIs.",
+      "id": "project.exact_scalar_resource_layout",
+      "name": "Exact scalar physical resource layouts",
+      "support": {
+        "cuda": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects CUDA descriptors with a structured target-unsupported diagnostic; no CUDA physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "directx": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_directx_buffers_uses_reflected_block_size_as_allocation_minimum",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
+          ],
+          "notes": "HLSL host reflection emits scalarLayout for float, int, and uint StructuredBuffer/RWStructuredBuffer resources and one-member scalar cbuffer declarations. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and DirectX CBV preparation validates the fixed block before allocating at least blockSizeBytes with 256-byte API alignment. Windows Direct3D CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Vectors, matrices, fixed arrays, aggregates, packed or widened types, arbitrary offsets, and multi-member blocks are not inferred.",
+          "status": "supported"
+        },
+        "hip": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects HIP descriptors with a structured target-unsupported diagnostic; no HIP physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "metal": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Metal descriptors with a structured target-unsupported diagnostic; no Metal physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "mojo": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Mojo descriptors with a structured target-unsupported diagnostic; no Mojo physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "opengl": {
+          "evidence": [
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_host_reflection.py::def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_prepare_opengl_buffers_rejects_missing_scalar_block_layout",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_zero_pads_scalar_uniform_block_allocation",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
+          ],
+          "notes": "GLSL host reflection emits scalarLayout for explicit std430 one-member float, int, and uint runtime-array buffer blocks and explicit std140 one-member scalar uniform blocks. The contract records physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed blocks. Native loader ABI packaging preserves these fields, request construction rejects missing or mismatched layouts, and OpenGL UBO preparation zero-pads scalar uploads to blockSizeBytes while storage-buffer readback retains its logical payload size. Linux EGL CI translates, reflects, packages, dispatches, and executes pinned MLX arangeuint32 with exact output [3, 5, 7, 9]. Implicit layouts and unsupported aggregate shapes are not inferred.",
+          "status": "supported"
+        },
+        "rust": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Rust descriptors with a structured target-unsupported diagnostic; no Rust physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "slang": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Slang descriptors with a structured target-unsupported diagnostic; no Slang physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "vulkan": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects Vulkan descriptors with a structured target-unsupported diagnostic; no Vulkan physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "webgl": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WebGL descriptors with a structured target-unsupported diagnostic; no WebGL physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        },
+        "wgsl": {
+          "evidence": [
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_unsupported_target_stage_and_artifact_combinations"
+          ],
+          "notes": "The exact scalar physical layout-to-native-runtime contract is limited to DirectX and OpenGL. Native loader request construction rejects WGSL descriptors with a structured target-unsupported diagnostic; no WGSL physical-layout allocation or execution support is claimed.",
+          "status": "validated_rejection"
+        }
+      }
+    },
+    {
+      "category": "project",
       "description": "Build deterministic native loader ABI metadata, C declarations, and multi-unit packages from ready runtime loader units without creating runtime objects or dispatching device work.",
       "id": "project.native_loader_abi",
       "name": "Native loader ABI descriptors",
@@ -12316,16 +12413,20 @@
         "directx": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_hlsl_reflection_preserves_entry_points_resources_and_constants",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_directx_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_missing_extra_and_read_only_output_values",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_directx_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained HLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates DirectX binding namespaces, coordinates, access modes, materialized specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Windows Direct3D CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         },
         "hip": {
@@ -12352,16 +12453,20 @@
         "opengl": {
           "evidence": [
             "tests/test_native_loader_dispatch_public_api.py::def test_project_exports_native_loader_dispatch_contract",
+            "tests/test_translator/test_host_reflection.py::def test_glsl_reflection_records_exact_mlx_scalar_block_layouts",
+            "tests/test_translator/test_native_loader_abi_integration.py::def test_runtime_packages_preserve_reflected_native_loader_contract",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_complete_package_descriptor_builds_preflighted_request",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_tampered_package_artifact_fails_before_runtime_consultation",
             "tests/test_translator/test_native_loader_dispatch_integration.py::def test_native_loader_descriptor_executes_opengl_on_device",
             "tests/test_translator/test_native_loader_dispatch.py::def test_builds_preflighted_native_runtime_request",
             "tests/test_translator/test_native_loader_dispatch.py::def test_specialization_provenance_distinguishes_descriptor_default_and_explicit",
             "tests/test_translator/test_native_loader_dispatch.py::def test_attests_artifact_size_and_hash_before_building_request",
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_incomplete_or_incompatible_physical_layouts",
             "tests/test_translator/test_native_loader_dispatch.py::def test_missing_scalar_layout_remains_fail_closed",
-            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry"
+            "tests/test_translator/test_native_loader_dispatch.py::def test_rejects_invalid_dispatch_geometry",
+            "tests/test_translator/test_mlx_arange_native_loader.py::def test_pinned_mlx_arange_executes_through_opengl_native_loader"
           ],
-          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names and complete tightly packed 32-bit scalar layouts, and validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. Repository scheduling, host integration, device execution, and combined read-write initialization plus readback remain outside this API. Generated MLX descriptors without physical scalar layout reflection are rejected rather than inferred.",
+          "notes": "build_native_loader_dispatch_request constructs a preflighted RuntimeExecutionRequest from one complete schema-v1 native loader ABI descriptor. It verifies the package-contained GLSL artifact size and SHA-256 digest before binding, requires exact reflected names, and validates physicalType, elementType, elementSizeBytes, elementStrideBytes, alignmentBytes, memberOffsetBytes, storageLayout, runtimeSized, optional memberName, and blockSizeBytes for fixed scalar blocks. It also validates OpenGL binding namespaces, coordinates, access modes, specialization values, and dispatch geometry. The pinned MLX arangeuint32 kernel at commit 4367c73b60541ddd5a266ce4644fd93d20223b6e follows this public descriptor-to-request path and executes in Linux EGL CI with exact output [3, 5, 7, 9]. Missing, incomplete, mismatched, or unsupported physical layouts are rejected rather than inferred. This single-kernel proof does not establish full MLX runtime integration or test-suite parity; repository scheduling and combined read-write initialization plus readback remain outside this API.",
           "status": "supported"
         },
         "rust": {
@@ -16919,7 +17024,7 @@
   "summary": {
     "backend_count": 11,
     "backlog_count": 0,
-    "feature_count": 78,
+    "feature_count": 79,
     "status_counts": {
       "cuda": {
         "diagnostic": 8,
@@ -16927,12 +17032,12 @@
         "supported": 66,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "directx": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 76,
+        "supported": 77,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 0
@@ -16943,7 +17048,7 @@
         "supported": 66,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "metal": {
         "diagnostic": 4,
@@ -16951,7 +17056,7 @@
         "supported": 70,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "mojo": {
         "diagnostic": 6,
@@ -16959,12 +17064,12 @@
         "supported": 68,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "opengl": {
         "diagnostic": 2,
         "partial": 0,
-        "supported": 75,
+        "supported": 76,
         "unknown": 0,
         "unsupported": 0,
         "validated_rejection": 1
@@ -16975,7 +17080,7 @@
         "supported": 69,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "slang": {
         "diagnostic": 4,
@@ -16983,7 +17088,7 @@
         "supported": 70,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "vulkan": {
         "diagnostic": 2,
@@ -16991,7 +17096,7 @@
         "supported": 72,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 4
+        "validated_rejection": 5
       },
       "webgl": {
         "diagnostic": 23,
@@ -16999,7 +17104,7 @@
         "supported": 42,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 13
+        "validated_rejection": 14
       },
       "wgsl": {
         "diagnostic": 21,
@@ -17007,7 +17112,7 @@
         "supported": 46,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 11
+        "validated_rejection": 12
       }
     }
   }

--- a/tests/fixtures/runtime_verification/mlx/arange_directx.fixture-metadata.json
+++ b/tests/fixtures/runtime_verification/mlx/arange_directx.fixture-metadata.json
@@ -136,7 +136,7 @@
           ]
         },
         "metadata": {
-          "artifactContractMode": "replace",
+          "artifactContractMode": "merge",
           "sourceEntryPoint": "arangeuint32",
           "scope": "curated-generated-host-interface"
         }

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2550,6 +2550,44 @@ def test_mlx_project_porting_workflow_runs_native_loader_dispatch_bridge():
     assert "mlx-upstream" not in opengl_step
 
 
+def test_mlx_project_porting_workflow_runs_pinned_arange_native_loader_proof():
+    mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
+    ci_coverage = _load_ci_coverage_module()
+    test_path = "tests/test_translator/test_mlx_arange_native_loader.py"
+
+    assert mlx_porting.count(f'"{test_path}"') == 2
+    step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Prove pinned MLX arange OpenGL native-loader execution",
+    )
+    assert "if: runner.os == 'Linux'" in step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in step
+    assert 'CROSTL_REQUIRE_MLX_ARANGE_OPENGL_NATIVE_LOADER: "1"' in step
+    assert "EGL_PLATFORM: surfaceless" in step
+    assert 'LIBGL_ALWAYS_SOFTWARE: "1"' in step
+    assert "PYOPENGL_PLATFORM: egl" in step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_arange_executes_through_opengl_native_loader" in step
+    )
+    assert "-n auto" in step
+    assert "-k" not in step
+
+    directx_step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Prove pinned MLX arange Direct3D native-loader execution",
+    )
+    assert "if: runner.os == 'Windows'" in directx_step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in directx_step
+    assert 'CROSTL_REQUIRE_MLX_ARANGE_DIRECTX_NATIVE_LOADER: "1"' in directx_step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_arange_executes_through_directx_native_loader" in directx_step
+    )
+    assert "-n auto" in directx_step
+    assert "-k" not in directx_step
+
+
 def test_support_matrix_workflow_runs_daily_checks_and_docs_probe():
     workflows = _workflow_texts()
     support_matrix = workflows.get("support-matrix.yml", "")

--- a/tests/test_translator/test_host_reflection.py
+++ b/tests/test_translator/test_host_reflection.py
@@ -56,6 +56,18 @@ def test_hlsl_reflection_preserves_entry_points_resources_and_constants(tmp_path
             "set": 3,
             "binding": 2,
             "access": "read",
+            "scalarLayout": {
+                "physicalType": "float",
+                "elementType": "float32",
+                "elementSizeBytes": 4,
+                "elementStrideBytes": 4,
+                "alignmentBytes": 16,
+                "memberOffsetBytes": 0,
+                "storageLayout": "hlsl-constant-buffer",
+                "runtimeSized": False,
+                "memberName": "exposure",
+                "blockSizeBytes": 16,
+            },
         },
         {
             "name": "sourceTexture",
@@ -72,6 +84,16 @@ def test_hlsl_reflection_preserves_entry_points_resources_and_constants(tmp_path
             "set": 0,
             "binding": 4,
             "access": "read_write",
+            "scalarLayout": {
+                "physicalType": "float",
+                "elementType": "float32",
+                "elementSizeBytes": 4,
+                "elementStrideBytes": 4,
+                "alignmentBytes": 4,
+                "memberOffsetBytes": 0,
+                "storageLayout": "hlsl-structured-buffer",
+                "runtimeSized": True,
+            },
         },
         {
             "name": "linearSampler",
@@ -124,6 +146,89 @@ def test_glsl_reflection_canonicalizes_c_family_specialization_ids(tmp_path):
         ("hexadecimal", 16),
         ("binary", 16),
     ]
+
+
+def test_glsl_reflection_records_exact_mlx_scalar_block_layouts(tmp_path):
+    artifact = tmp_path / "arangeuint32.glsl"
+    artifact.write_text(
+        textwrap.dedent("""
+            #version 450 core
+            layout(std430, binding = 2) buffer out_Buffer { uint out_[]; };
+            layout(std140, binding = 0) uniform arangeuint32_start_Args {
+                uint start;
+            };
+            layout(std140, binding = 1) uniform arangeuint32_step_Args {
+                uint step;
+            };
+            layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+            void main() {}
+            """).strip(),
+        encoding="utf-8",
+    )
+
+    reflection = reflect_target_host_interface(
+        artifact, target="opengl", stage="compute"
+    )
+
+    by_name = {resource["name"]: resource for resource in reflection["resources"]}
+    assert by_name["out_Buffer"]["scalarLayout"] == {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "std430",
+        "runtimeSized": True,
+        "memberName": "out_",
+    }
+    assert by_name["arangeuint32_start_Args"]["scalarLayout"] == {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "std140",
+        "runtimeSized": False,
+        "memberName": "start",
+        "blockSizeBytes": 16,
+    }
+    assert by_name["arangeuint32_step_Args"]["scalarLayout"]["memberName"] == "step"
+
+
+def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts(tmp_path):
+    hlsl = _reflect_hlsl(
+        tmp_path,
+        """
+        cbuffer Multiple : register(b0) {
+            uint first;
+            uint second;
+        };
+        RWStructuredBuffer<uint2> vectors : register(u0);
+        ByteAddressBuffer bytes : register(t0);
+        [numthreads(1, 1, 1)] void CSMain() {}
+        """,
+    )
+    assert all("scalarLayout" not in resource for resource in hlsl["resources"])
+
+    artifact = tmp_path / "unsupported.comp"
+    artifact.write_text(
+        textwrap.dedent("""
+            #version 450 core
+            layout(std140, binding = 0) uniform Multiple {
+                uint first;
+                uint second;
+            };
+            layout(std430, binding = 1) buffer Vectors { uvec2 values[]; };
+            layout(binding = 2) buffer Implicit { uint values[]; };
+            layout(local_size_x = 1) in;
+            void main() {}
+            """).strip(),
+        encoding="utf-8",
+    )
+    glsl = reflect_target_host_interface(artifact, target="opengl", stage="compute")
+    assert all("scalarLayout" not in resource for resource in glsl["resources"])
 
 
 def test_hlsl_reflection_excludes_malformed_function_declarations(tmp_path):

--- a/tests/test_translator/test_mlx_arange_native_loader.py
+++ b/tests/test_translator/test_mlx_arange_native_loader.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from crosstl.project import (
+    DirectXComputeRuntime,
+    DirectXRuntimeParityAdapter,
+    OpenGLComputeRuntime,
+    OpenGLRuntimeParityAdapter,
+    RuntimeParityExecutor,
+    RuntimeTestAdapterSpec,
+    build_native_loader_abi_descriptor,
+    build_native_loader_dispatch_request,
+    build_runtime_artifact_manifest,
+    build_runtime_loader_manifest,
+    build_runtime_package,
+    load_project_config,
+    translate_project,
+)
+
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_ARANGE_SOURCE = "mlx/backend/metal/kernels/arange.metal"
+REQUIRE_PROOF_ENVS = {
+    "directx": "CROSTL_REQUIRE_MLX_ARANGE_DIRECTX_NATIVE_LOADER",
+    "opengl": "CROSTL_REQUIRE_MLX_ARANGE_OPENGL_NATIVE_LOADER",
+}
+
+
+def _project_config(target: str) -> str:
+    return textwrap.dedent(f"""
+        [project]
+        source_roots = ["mlx/backend/metal/kernels"]
+        include = ["{MLX_ARANGE_SOURCE}"]
+        include_dirs = ["."]
+        targets = ["{target}"]
+        output_dir = ".crosstl-mlx-arange-native-loader/out"
+
+        [project.sources]
+        "**/*.metal" = "metal"
+
+        [project.entry_points]
+        "{MLX_ARANGE_SOURCE}" = "arangeuint32"
+        """).strip()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _skip_or_fail(target: str, message: str) -> None:
+    if os.environ.get(REQUIRE_PROOF_ENVS[target]) == "1":
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+def _pinned_mlx_root() -> Path:
+    root_value = os.environ.get("CROSTL_MLX_ROOT")
+    if not root_value:
+        if any(os.environ.get(name) == "1" for name in REQUIRE_PROOF_ENVS.values()):
+            pytest.fail("CROSTL_MLX_ROOT is not configured")
+        pytest.skip("CROSTL_MLX_ROOT is not configured")
+
+    mlx_root = Path(root_value).resolve()
+    source_path = mlx_root / MLX_ARANGE_SOURCE
+    if not source_path.is_file():
+        pytest.fail(f"Pinned MLX arange source is missing: {source_path}")
+
+    checkout_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=mlx_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert checkout_commit == MLX_COMMIT
+    return mlx_root
+
+
+def _expected_scalar_layouts(target: str) -> dict[str, dict]:
+    scalar_array = {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer" if target == "directx" else "std430",
+        "runtimeSized": True,
+    }
+    if target == "opengl":
+        scalar_array["memberName"] = "out_"
+    scalar_block = {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer" if target == "directx" else "std140",
+        "runtimeSized": False,
+        "blockSizeBytes": 16,
+    }
+    if target == "directx":
+        return {
+            "out_": scalar_array,
+            "arangeuint32_start_Constants": {
+                **scalar_block,
+                "memberName": "arangeuint32_start",
+            },
+            "arangeuint32_step_Constants": {
+                **scalar_block,
+                "memberName": "arangeuint32_step",
+            },
+        }
+    return {
+        "out_Buffer": scalar_array,
+        "arangeuint32_start_Args": {**scalar_block, "memberName": "start"},
+        "arangeuint32_step_Args": {**scalar_block, "memberName": "step"},
+    }
+
+
+def _build_runtime_package(
+    mlx_root: Path, work_dir: Path, target: str
+) -> tuple[dict, Path]:
+    config_path = work_dir / "crosstl.toml"
+    config_path.write_text(_project_config(target) + "\n", encoding="utf-8")
+    output_dir = work_dir / "out"
+    report = translate_project(
+        load_project_config(mlx_root, config_path),
+        targets=(target,),
+        output_dir=output_dir.relative_to(mlx_root).as_posix(),
+        format_output=False,
+        validate=True,
+    )
+    report_payload = report.to_json()
+
+    assert report_payload["summary"]["unitCount"] == 1
+    assert report_payload["summary"]["translatedCount"] == 1
+    assert report_payload["summary"]["failedCount"] == 0
+    artifact = report_payload["artifacts"][0]
+    assert artifact["source"] == MLX_ARANGE_SOURCE
+    assert artifact["entryPoint"] == {
+        "source": "arangeuint32",
+        "target": "CSMain" if target == "directx" else "main",
+        "stage": "compute",
+    }
+    assert artifact["provenance"]["pipeline"] == "entry-scoped-translate"
+    assert artifact["includePathProcessing"] == {
+        "frontend": "lexer",
+        "includePathCount": 1,
+        "status": "forwarded",
+        "supportsIncludePaths": True,
+    }
+    assert artifact["path"].endswith(
+        f"/{target}/mlx/backend/metal/kernels/arange/arangeuint32."
+        f"{'hlsl' if target == 'directx' else 'glsl'}"
+    )
+
+    report_path = work_dir / "portability-report.json"
+    report.write_json(report_path)
+    runtime_artifacts = build_runtime_artifact_manifest(report_path)
+    assert runtime_artifacts["success"] is True, json.dumps(runtime_artifacts, indent=2)
+
+    reflected_artifact = runtime_artifacts["artifacts"][0]
+    assert reflected_artifact["hostInterface"]["status"] == "ready"
+    reflected_layouts = {
+        resource["name"]: resource["scalarLayout"]
+        for resource in reflected_artifact["hostInterface"]["resources"]
+    }
+    assert reflected_layouts == _expected_scalar_layouts(target)
+
+    runtime_artifacts_path = work_dir / "runtime-artifacts.json"
+    _write_json(runtime_artifacts_path, runtime_artifacts)
+    package_dir = work_dir / "runtime-package"
+    package = build_runtime_package(runtime_artifacts_path, package_dir)
+    assert package["success"] is True, json.dumps(package, indent=2)
+
+    loader_manifest = build_runtime_loader_manifest(
+        package_dir / "runtime-package.json"
+    )
+    assert loader_manifest["success"] is True, json.dumps(loader_manifest, indent=2)
+    assert loader_manifest["summary"]["readyLoadUnitCount"] == 1
+    assert loader_manifest["summary"]["blockedLoadUnitCount"] == 0
+    load_unit = loader_manifest["loadUnits"][0]
+    descriptor = build_native_loader_abi_descriptor(
+        loader_manifest,
+        load_unit_id=load_unit["id"],
+    )
+    descriptor_layouts = {
+        binding["name"]: binding["scalarLayout"] for binding in descriptor["bindings"]
+    }
+    assert descriptor_layouts == _expected_scalar_layouts(target)
+    return descriptor, package_dir
+
+
+def _execute_pinned_mlx_arange(target: str) -> None:
+    mlx_root = _pinned_mlx_root()
+    with tempfile.TemporaryDirectory(
+        prefix=f".crosstl-arange-{target}-native-loader-",
+        dir=mlx_root,
+    ) as temporary_directory:
+        descriptor, package_dir = _build_runtime_package(
+            mlx_root,
+            Path(temporary_directory),
+            target,
+        )
+        expected_values = [3, 5, 7, 9]
+        if target == "directx":
+            start_binding = "arangeuint32_start_Constants"
+            step_binding = "arangeuint32_step_Constants"
+            output_binding = "out_"
+        else:
+            start_binding = "arangeuint32_start_Args"
+            step_binding = "arangeuint32_step_Args"
+            output_binding = "out_Buffer"
+        request = build_native_loader_dispatch_request(
+            descriptor,
+            package_dir,
+            {
+                start_binding: {
+                    "dtype": "uint32",
+                    "shape": [1],
+                    "values": [3],
+                },
+                step_binding: {
+                    "dtype": "uint32",
+                    "shape": [1],
+                    "values": [2],
+                },
+            },
+            {
+                output_binding: {
+                    "dtype": "uint32",
+                    "shape": [4],
+                    "values": expected_values,
+                }
+            },
+            (4, 1, 1),
+            expected_target=target,
+        )
+        assert request.execution_plan is not None
+        assert request.execution_plan.diagnostics == ()
+        assert request.execution_plan.dispatch.global_size == (4, 1, 1)
+
+        runtime_adapter = (
+            DirectXRuntimeParityAdapter(runtime=DirectXComputeRuntime())
+            if target == "directx"
+            else OpenGLRuntimeParityAdapter(
+                runtime=OpenGLComputeRuntime(context_backends=("egl",))
+            )
+        )
+        executor = RuntimeParityExecutor(
+            RuntimeTestAdapterSpec(
+                adapter_id=f"mlx-arange-{target}-native-loader",
+                target=target,
+                executor=target,
+                adapter_kind=f"{target}-native-runtime",
+            ),
+            runtime_adapter=runtime_adapter,
+        )
+        availability = executor.is_available(request)
+        if not availability.available:
+            _skip_or_fail(
+                target,
+                availability.reason or f"The native {target} runtime is unavailable",
+            )
+
+        result = executor.run(request)
+
+    assert result.status == "ok"
+    assert result.outputs == {
+        output_binding: {
+            "dtype": "uint32",
+            "shape": [4],
+            "values": expected_values,
+        }
+    }
+
+
+def test_pinned_mlx_arange_executes_through_directx_native_loader():
+    _execute_pinned_mlx_arange("directx")
+
+
+def test_pinned_mlx_arange_executes_through_opengl_native_loader():
+    _execute_pinned_mlx_arange("opengl")

--- a/tests/test_translator/test_native_loader_abi_integration.py
+++ b/tests/test_translator/test_native_loader_abi_integration.py
@@ -171,6 +171,22 @@ def test_runtime_packages_preserve_reflected_native_loader_contract(
             )
             for binding in descriptor["bindings"]
         ] == expected_bindings[target]
+        for binding in descriptor["bindings"]:
+            layout = binding["scalarLayout"]
+            assert layout["physicalType"] == "float"
+            assert layout["elementType"] == "float32"
+            assert layout["elementSizeBytes"] == 4
+            assert layout["elementStrideBytes"] == 4
+            assert layout["alignmentBytes"] == 4
+            assert layout["memberOffsetBytes"] == 0
+            assert layout["runtimeSized"] is True
+            assert (
+                layout["storageLayout"]
+                == {
+                    "directx": "hlsl-structured-buffer",
+                    "opengl": "std430",
+                }[target]
+            )
 
         artifact_path = package_dir / descriptor["artifact"]["packagePath"]
         assert descriptor["artifact"]["hash"] == {

--- a/tests/test_translator/test_native_loader_dispatch.py
+++ b/tests/test_translator/test_native_loader_dispatch.py
@@ -33,9 +33,14 @@ def _write_descriptor(tmp_path, target="directx", *, constants=None):
     artifact_path.parent.mkdir(parents=True)
     artifact_path.write_bytes(artifact_bytes)
     layout = {
+        "physicalType": "float",
         "elementType": "float32",
         "elementSizeBytes": 4,
         "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer" if target == "directx" else "std430",
+        "runtimeSized": True,
     }
     input_namespace = "srv" if target == "directx" else "storage-buffer"
     output_namespace = "uav" if target == "directx" else "storage-buffer"
@@ -446,6 +451,19 @@ def test_normalizes_supported_resource_kind_aliases(
         kind=input_kind,
         namespace=input_namespace,
     )
+    constant_layout = {
+        "physicalType": "float",
+        "elementType": "float32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer" if target == "directx" else "std140",
+        "runtimeSized": False,
+        "blockSizeBytes": 16,
+    }
+    descriptor["bindings"][0]["scalarLayout"] = copy.deepcopy(constant_layout)
+    descriptor["scalarLayout"]["bindings"][0]["layout"] = copy.deepcopy(constant_layout)
     descriptor["bindings"][1]["kind"] = "storage-buffer"
 
     request = _build(tmp_path, target, descriptor=descriptor)
@@ -593,6 +611,29 @@ def test_rejects_runtime_ambiguous_padded_scalar_layout(tmp_path):
         _build(tmp_path, descriptor=descriptor)
 
     assert caught.value.code.endswith(".resource-layout-unsupported")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("alignmentBytes", None, "resource-layout-invalid"),
+        ("memberOffsetBytes", 4, "resource-layout-unsupported"),
+        ("runtimeSized", False, "resource-layout-unsupported"),
+        ("storageLayout", "std140", "resource-layout-mismatch"),
+        ("physicalType", "int", "resource-layout-mismatch"),
+    ],
+)
+def test_rejects_incomplete_or_incompatible_physical_layouts(
+    tmp_path, field, value, code
+):
+    descriptor = _write_descriptor(tmp_path, "opengl")
+    descriptor["bindings"][0]["scalarLayout"][field] = value
+    descriptor["scalarLayout"]["bindings"][0]["layout"][field] = value
+
+    with pytest.raises(NativeLoaderDispatchError) as caught:
+        _build(tmp_path, "opengl", descriptor=descriptor)
+
+    assert caught.value.code.endswith(f".{code}")
 
 
 def test_missing_scalar_layout_remains_fail_closed(tmp_path):

--- a/tests/test_translator/test_native_loader_dispatch_integration.py
+++ b/tests/test_translator/test_native_loader_dispatch_integration.py
@@ -75,9 +75,14 @@ def _write_package(tmp_path: Path, target: str) -> tuple[dict, Path]:
     artifact_path.write_bytes(source)
 
     scalar_layout = {
+        "physicalType": "uint",
         "elementType": "uint32",
         "elementSizeBytes": 4,
         "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer" if target == "directx" else "std430",
+        "runtimeSized": True,
     }
     bindings = [
         {
@@ -207,14 +212,28 @@ def test_complete_package_descriptor_builds_preflighted_request(tmp_path, target
         for binding in request.adapter_contract.resource_bindings
     ] == [
         {
+            "physicalType": "uint",
             "elementType": "uint32",
             "elementSizeBytes": 4,
             "elementStrideBytes": 4,
+            "alignmentBytes": 4,
+            "memberOffsetBytes": 0,
+            "storageLayout": (
+                "hlsl-structured-buffer" if target == "directx" else "std430"
+            ),
+            "runtimeSized": True,
         },
         {
+            "physicalType": "uint",
             "elementType": "uint32",
             "elementSizeBytes": 4,
             "elementStrideBytes": 4,
+            "alignmentBytes": 4,
+            "memberOffsetBytes": 0,
+            "storageLayout": (
+                "hlsl-structured-buffer" if target == "directx" else "std430"
+            ),
+            "runtimeSized": True,
         },
     ]
 

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -489,6 +489,44 @@ def _opengl_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
     )
 
 
+def _scalar_block_layout(storage_layout: str, **overrides):
+    layout = {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "storageLayout": storage_layout,
+        "alignmentBytes": 16,
+        "blockSizeBytes": 16,
+        "memberOffsetBytes": 0,
+        "runtimeSized": False,
+    }
+    layout.update(overrides)
+    return layout
+
+
+def _scalar_constant_buffer_binding(target: str, scalar_layout=None):
+    metadata = {}
+    if scalar_layout is not None:
+        metadata["scalarLayout"] = scalar_layout
+    return NativeRuntimeBufferBinding(
+        name="params",
+        binding=RuntimeResourceBinding(
+            name="params",
+            kind="constant-buffer",
+            type_name="Params" if target == "directx" else None,
+            set=0,
+            binding=0,
+            access="read",
+            metadata=metadata,
+        ),
+        value=[3],
+        source="input",
+        dtype="uint32",
+        shape=(1,),
+    )
+
+
 def _directx_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
     return NativeRuntimeDispatchRequest(
         target="directx",
@@ -506,6 +544,9 @@ def _directx_dispatch_request(tmp_path: Path) -> NativeRuntimeDispatchRequest:
                     set=0,
                     binding=0,
                     access="read",
+                    metadata={
+                        "scalarLayout": _scalar_block_layout("hlsl-constant-buffer")
+                    },
                 ),
                 value=[3],
                 source="input",
@@ -810,6 +851,65 @@ def test_prepare_directx_buffers_maps_and_packs_descriptor_namespaces(tmp_path):
     assert prepared[1].stride == 4
     assert prepared[2].payload == b"\x00" * 8
     assert prepared[2].output_name == "result"
+
+
+def test_prepare_directx_buffers_rejects_missing_scalar_block_layout():
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_buffers({"params": _scalar_constant_buffer_binding("directx")})
+
+    assert excinfo.value.details == {
+        "target": "directx",
+        "runtime": "directx-compute-runtime",
+        "reasonKind": "scalar-block-layout-missing",
+        "resource": "params",
+    }
+
+
+@pytest.mark.parametrize(
+    ("layout_overrides", "reason_kind"),
+    [
+        ({"blockSizeBytes": 2}, "scalar-block-size-invalid"),
+        ({"blockSizeBytes": 20}, "scalar-block-size-invalid"),
+        ({"alignmentBytes": 8}, "scalar-block-alignment-invalid"),
+        ({"memberOffsetBytes": 4}, "scalar-block-member-offset-unsupported"),
+        ({"runtimeSized": True}, "scalar-block-runtime-size-invalid"),
+        (
+            {"storageLayout": "std140"},
+            "scalar-block-storage-layout-unsupported",
+        ),
+        (
+            {"physicalType": "int"},
+            "scalar-block-element-layout-unsupported",
+        ),
+    ],
+)
+def test_prepare_directx_buffers_rejects_invalid_scalar_block_layout(
+    layout_overrides,
+    reason_kind,
+):
+    binding = _scalar_constant_buffer_binding(
+        "directx",
+        _scalar_block_layout("hlsl-constant-buffer", **layout_overrides),
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_directx_buffers({"params": binding})
+
+    assert excinfo.value.details["target"] == "directx"
+    assert excinfo.value.details["reasonKind"] == reason_kind
+    assert excinfo.value.details["resource"] == "params"
+
+
+def test_prepare_directx_buffers_uses_reflected_block_size_as_allocation_minimum():
+    binding = _scalar_constant_buffer_binding(
+        "directx",
+        _scalar_block_layout("hlsl-constant-buffer", blockSizeBytes=272),
+    )
+
+    prepared = _prepare_directx_buffers({"params": binding})
+
+    assert prepared[0].payload == struct.pack("<I", 3)
+    assert prepared[0].allocation_size == 512
 
 
 def test_prepare_directx_buffers_rejects_nonzero_register_space(tmp_path):
@@ -1147,6 +1247,11 @@ def test_directx_runtime_adapter_compiles_dxil_and_dispatches_fixture(tmp_path):
                             "set": 0,
                             "binding": 0,
                             "access": "read",
+                            "metadata": {
+                                "scalarLayout": _scalar_block_layout(
+                                    "hlsl-constant-buffer"
+                                )
+                            },
                         },
                         {
                             "name": "lhs",
@@ -1567,6 +1672,17 @@ def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device
             ("arangeuint32_step_Constants", "constant-buffer", 1),
             ("out_", "buffer", 2),
         }
+        reflected_layouts = {
+            binding["name"]: binding["metadata"]["scalarLayout"]
+            for binding in reflected["resourceBindings"]
+        }
+        assert reflected_layouts["arangeuint32_start_Constants"]["blockSizeBytes"] == 16
+        assert (
+            reflected_layouts["arangeuint32_step_Constants"]["storageLayout"]
+            == "hlsl-constant-buffer"
+        )
+        assert reflected_layouts["out_"]["elementStrideBytes"] == 4
+        assert reflected_layouts["out_"]["runtimeSized"] is True
 
         manifest = build_runtime_test_manifest(
             runtime_artifacts,
@@ -1594,6 +1710,10 @@ def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device
             ("arangeuint32_step_Constants", "constant-buffer", 1),
             ("out_", "buffer", 2),
         ]
+        assert {
+            item["binding"]["name"]: item["binding"]["metadata"]["scalarLayout"]
+            for item in case["runtimeExecution"]["resourceBindings"]
+        } == reflected_layouts
         assert case["runtimeAdapter"]["metadata"]["sourceEntryPoint"] == (
             "arangeuint32"
         )
@@ -2253,18 +2373,8 @@ def test_prepare_opengl_buffers_packs_storage_and_uniform_buffers():
                 dtype="float32",
                 shape=(2,),
             ),
-            "params": NativeRuntimeBufferBinding(
-                name="params",
-                binding=RuntimeResourceBinding(
-                    name="params",
-                    kind="constant-buffer",
-                    set=0,
-                    binding=0,
-                ),
-                value=[3],
-                source="input",
-                dtype="uint32",
-                shape=(1,),
+            "params": _scalar_constant_buffer_binding(
+                "opengl", _scalar_block_layout("std140")
             ),
             "out": NativeRuntimeBufferBinding(
                 name="out",
@@ -2291,6 +2401,88 @@ def test_prepare_opengl_buffers_packs_storage_and_uniform_buffers():
     assert buffers[1].payload == b"\x00" * 8
     assert buffers[1].output_name == "result"
     assert buffers[2].payload == b"\x03\x00\x00\x00"
+    assert buffers[2].allocation_size == 16
+
+
+def test_prepare_opengl_buffers_rejects_missing_scalar_block_layout():
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_opengl_buffers({"params": _scalar_constant_buffer_binding("opengl")})
+
+    assert excinfo.value.details == {
+        "target": "opengl",
+        "runtime": "opengl-compute-runtime",
+        "reasonKind": "scalar-block-layout-missing",
+        "resource": "params",
+    }
+
+
+@pytest.mark.parametrize(
+    ("layout_overrides", "reason_kind"),
+    [
+        ({"blockSizeBytes": 2}, "scalar-block-size-invalid"),
+        ({"blockSizeBytes": 20}, "scalar-block-size-invalid"),
+        ({"alignmentBytes": 8}, "scalar-block-alignment-invalid"),
+        ({"memberOffsetBytes": 4}, "scalar-block-member-offset-unsupported"),
+        ({"runtimeSized": True}, "scalar-block-runtime-size-invalid"),
+        (
+            {"storageLayout": "hlsl-constant-buffer"},
+            "scalar-block-storage-layout-unsupported",
+        ),
+        (
+            {"physicalType": "int"},
+            "scalar-block-element-layout-unsupported",
+        ),
+    ],
+)
+def test_prepare_opengl_buffers_rejects_invalid_scalar_block_layout(
+    layout_overrides,
+    reason_kind,
+):
+    binding = _scalar_constant_buffer_binding(
+        "opengl",
+        _scalar_block_layout("std140", **layout_overrides),
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        _prepare_opengl_buffers({"params": binding})
+
+    assert excinfo.value.details["target"] == "opengl"
+    assert excinfo.value.details["reasonKind"] == reason_kind
+    assert excinfo.value.details["resource"] == "params"
+
+
+def test_opengl_compute_runtime_zero_pads_scalar_uniform_block_allocation():
+    class FakeBuffer:
+        def __init__(self, payload):
+            self.payload = payload
+            self.uniform_binding = None
+
+        def bind_to_uniform_block(self, binding):
+            self.uniform_binding = binding
+
+    class FakeContext:
+        def __init__(self):
+            self.received_payload = None
+
+        def buffer(self, payload):
+            self.received_payload = payload
+            return FakeBuffer(payload)
+
+    prepared = _prepare_opengl_buffers(
+        {
+            "params": _scalar_constant_buffer_binding(
+                "opengl", _scalar_block_layout("std140")
+            )
+        }
+    )[0]
+    context = FakeContext()
+
+    buffer = OpenGLComputeRuntime()._create_buffer(context, prepared)
+
+    assert prepared.size == 4
+    assert prepared.allocation_size == 16
+    assert context.received_payload == struct.pack("<I", 3) + b"\x00" * 12
+    assert buffer.uniform_binding == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_translator/test_physical_layout_transport.py
+++ b/tests/test_translator/test_physical_layout_transport.py
@@ -1,0 +1,135 @@
+import copy
+
+import pytest
+
+import crosstl.project.pipeline as project_pipeline
+import crosstl.project.runtime_verification as runtime_verification
+from crosstl.project.host_reflection import reflect_target_host_interface
+from crosstl.project.runtime_verification import RuntimeVerificationError
+
+SCALAR_LAYOUT = {
+    "physicalType": "uint",
+    "elementType": "uint32",
+    "elementSizeBytes": 4,
+    "elementStrideBytes": 4,
+    "storageLayout": "std430",
+    "alignmentBytes": 4,
+    "memberOffsetBytes": 0,
+    "runtimeSized": True,
+    "memberName": "values",
+}
+
+
+def test_runtime_manifest_binding_preserves_reflected_scalar_layout(tmp_path):
+    artifact = tmp_path / "kernel.glsl"
+    artifact.write_text(
+        """#version 450
+layout(std430, binding = 2) buffer Values { uint values[]; } outputValues;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() { values[gl_GlobalInvocationID.x] = 1u; }
+""",
+        encoding="utf-8",
+    )
+    host_interface = reflect_target_host_interface(
+        artifact, target="opengl", stage="compute"
+    )
+    original = copy.deepcopy(host_interface)
+
+    bindings = project_pipeline._runtime_manifest_resource_bindings(host_interface)
+
+    assert host_interface == original
+    assert len(bindings) == 1
+    assert bindings[0]["metadata"]["scalarLayout"] == SCALAR_LAYOUT
+    parsed = runtime_verification._parse_runtime_resource_binding(
+        bindings[0], field_name="artifact.resourceBindings[0]"
+    )
+    assert parsed.metadata["scalarLayout"] == SCALAR_LAYOUT
+
+    bindings[0]["metadata"]["scalarLayout"]["elementSizeBytes"] = 8
+    assert host_interface["resources"][0]["scalarLayout"]["elementSizeBytes"] == 4
+
+
+def test_runtime_manifest_binding_does_not_infer_missing_scalar_layout():
+    bindings = project_pipeline._runtime_manifest_resource_bindings(
+        {
+            "resources": [
+                {
+                    "name": "values",
+                    "kind": "buffer",
+                    "type": "Values",
+                    "set": 0,
+                    "binding": 2,
+                    "access": "write",
+                }
+            ]
+        }
+    )
+
+    assert "metadata" not in bindings[0]
+
+
+def test_artifact_scalar_layout_survives_matching_adapter_override():
+    artifact = {
+        "resourceBindings": [
+            {
+                "id": "buffer|0|2|outputValues|0",
+                "name": "outputValues",
+                "kind": "buffer",
+                "type": "Values",
+                "set": 0,
+                "binding": 2,
+                "access": "write",
+                "scalarLayout": SCALAR_LAYOUT,
+                "metadata": {
+                    "provenance": {"source": "hostInterface.resources"},
+                    "status": "bound",
+                },
+            }
+        ],
+        "runtimeAdapter": {
+            "resourceBindings": [
+                {
+                    "name": "outputValues",
+                    "access": "read_write",
+                    "value": "out",
+                    "metadata": {"required": True},
+                }
+            ]
+        },
+    }
+
+    contract = runtime_verification._runtime_adapter_contract_from_artifact(artifact)
+
+    assert len(contract.resource_bindings) == 1
+    binding = contract.resource_bindings[0]
+    assert binding.binding_id == "buffer|0|2|outputValues|0"
+    assert binding.name == "outputValues"
+    assert binding.kind == "buffer"
+    assert binding.type_name == "Values"
+    assert binding.set == 0
+    assert binding.binding == 2
+    assert binding.access == "read_write"
+    assert binding.value == "out"
+    assert binding.metadata == {
+        "scalarLayout": SCALAR_LAYOUT,
+        "provenance": {"source": "hostInterface.resources"},
+        "status": "bound",
+        "required": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        {"name": "values", "scalarLayout": []},
+        {"name": "values", "metadata": {"scalarLayout": "std430"}},
+    ],
+    ids=("top-level", "metadata"),
+)
+def test_runtime_binding_rejects_malformed_scalar_layout_before_dispatch(binding):
+    with pytest.raises(
+        RuntimeVerificationError, match="scalarLayout must be an object"
+    ):
+        runtime_verification._parse_runtime_resource_binding(
+            binding, field_name="artifact.resourceBindings[0]"
+        )

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -39173,6 +39173,16 @@ def test_inspect_runtime_package_reflects_hlsl_artifact_metadata(tmp_path):
             "set": 1,
             "binding": 0,
             "access": "read_write",
+            "scalarLayout": {
+                "physicalType": "float",
+                "elementType": "float32",
+                "elementSizeBytes": 4,
+                "elementStrideBytes": 4,
+                "alignmentBytes": 4,
+                "memberOffsetBytes": 0,
+                "storageLayout": "hlsl-structured-buffer",
+                "runtimeSized": True,
+            },
         }
     ]
     assert host_interface["constants"] == [

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -1282,9 +1282,17 @@ def test_mlx_arange_directx_generated_manifest_plans_curated_interface(tmp_path)
         ],
     }
 
+    fixture_metadata = json.loads(
+        (fixture_dir / "arange_directx.fixture-metadata.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    fixture_metadata["fixtures"][0]["runtimeAdapter"]["metadata"][
+        "artifactContractMode"
+    ] = "replace"
     manifest = build_runtime_test_manifest(
         artifact_report,
-        fixture_dir / "arange_directx.fixture-metadata.json",
+        fixture_metadata,
         project_root=tmp_path,
     )
     plan = plan_runtime_test_manifest(
@@ -1893,6 +1901,7 @@ def test_mlx_file_scope_immutable_lookup_fixture_is_value_sensitive():
         "set": 0,
         "binding": 0,
         "access": "write",
+        "value": "output",
     }
 
 


### PR DESCRIPTION
## Summary

- reflect exact 32-bit scalar layouts for HLSL structured buffers and constant buffers
- reflect explicit std430 scalar runtime arrays and std140 scalar uniform blocks in GLSL
- preserve physical layout metadata through runtime manifests, packages, loader descriptors, and dispatch requests
- validate fixed block allocation in the DirectX and OpenGL runtime drivers
- prove pinned MLX arange translation and execution through the public native-loader path on Windows Direct3D and Linux EGL

## Validation

- `.venv/bin/python -m pytest -n auto -q` (16,623 passed, 211 skipped)
- `.venv/bin/pre-commit run --all-files`
- strict Sphinx HTML build with warnings treated as errors
- support matrix update, audit, evidence validation, and issue-sync dry run
- pinned OpenGL proof executed under Mesa/EGL in a clean Debian environment

## Scope

This change covers exact single-scalar 32-bit resource layouts. Vectors, matrices, fixed arrays, aggregates, packed or widened types, arbitrary offsets, implicit GLSL layouts, and multi-member blocks remain fail-closed.

Advances #1543.

Support issue traceability: no issue closed
