### PR TITLE
Fix release version verification tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
               ;;
           esac
 
+          # setup-python does not guarantee that setuptools is preinstalled.
+          python -m pip install setuptools==75.3.2
           package_version="$(python setup.py --version)"
           test "v${package_version}" = "${GITHUB_REF_NAME}"
 


### PR DESCRIPTION
## Summary
- install the pinned build-backend version of setuptools before querying setup.py metadata
- unblock the v3.1.0 release workflow after run 29682180610 failed before publication

## Validation
- `actionlint .github/workflows/release.yml`
- `python3 tools/ci_coverage.py check`
- `git diff --check`

Support issue traceability: no issue closed