### PR TITLE
Fix PyPI classifier metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14"
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Compilers",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
## Summary
- separate the Python 3.14 and compiler Trove classifiers in package metadata
- fix the PyPI 400 rejection from release run 29684446786

## Validation
- `ruff check setup.py`
- fresh wheel and sdist built with `build==1.3.0`
- strict checks passed with `twine==6.2.0`
- wheel METADATA contains both classifiers separately and not the invalid concatenation
- `git diff --check`

Support issue traceability: no issue closed