### PR TITLE
Support multiple entry-scoped project artifacts

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -3346,6 +3346,35 @@ def _as_non_empty_str_mapping(value: Any, *, field_name: str) -> dict[str, str]:
     return result
 
 
+def _as_entry_point_selection_mapping(
+    value: Any,
+    *,
+    field_name: str,
+) -> dict[str, str | tuple[str, ...]]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a table")
+
+    result: dict[str, str | tuple[str, ...]] = {}
+    for pattern, selection in value.items():
+        if not isinstance(pattern, str) or not pattern.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        selection_path = _mapping_key_path(field_name, pattern)
+        entries = [
+            entry.strip()
+            for entry in _as_str_list(selection, field_name=selection_path)
+        ]
+        if not entries:
+            raise ValueError(f"{selection_path} must select at least one entry point")
+        if len(entries) != len(set(entries)):
+            raise ValueError(
+                f"{selection_path} must not contain duplicate entry points"
+            )
+        result[pattern] = entries[0] if isinstance(selection, str) else tuple(entries)
+    return result
+
+
 def _as_source_pattern_options(
     value: Any,
     *,
@@ -3891,6 +3920,15 @@ def _normalize_project_relative_path_mapping(
     return {
         _normalize_project_relative_path(path): backend
         for path, backend in paths.items()
+    }
+
+
+def _normalize_entry_point_selection_mapping(
+    selections: Mapping[str, str | tuple[str, ...]],
+) -> dict[str, str | tuple[str, ...]]:
+    return {
+        _normalize_project_relative_path(path): selection
+        for path, selection in selections.items()
     }
 
 
@@ -7428,7 +7466,7 @@ class ProjectConfig:
     targets: Sequence[str] | str = ()
     output_dir: str | os.PathLike[str] = DEFAULT_OUTPUT_DIR
     source_overrides: Mapping[str, str] = field(default_factory=dict)
-    entry_points: Mapping[str, str] = field(default_factory=dict)
+    entry_points: Mapping[str, str | Sequence[str]] = field(default_factory=dict)
     include_dirs: Sequence[str] | str = ()
     defines: Mapping[str, str] = field(default_factory=dict)
     source_options: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
@@ -7523,8 +7561,8 @@ class ProjectConfig:
         object.__setattr__(
             self,
             "entry_points",
-            _normalize_project_relative_path_mapping(
-                _as_non_empty_str_mapping(
+            _normalize_entry_point_selection_mapping(
+                _as_entry_point_selection_mapping(
                     self.entry_points,
                     field_name="ProjectConfig.entry_points",
                 )
@@ -8545,7 +8583,9 @@ class ProjectPortabilityReport:
                 "outputDir": str(self.config.output_path),
                 "sourceOverrides": dict(sorted(self.config.source_overrides.items())),
                 "sourceOverrideCount": len(self.config.source_overrides),
-                "entryPointSelections": dict(sorted(self.config.entry_points.items())),
+                "entryPointSelections": _entry_point_selections_payload(
+                    self.config.entry_points
+                ),
                 "entryPointSelectionCount": len(self.config.entry_points),
                 "sourceOptions": {
                     name: dict(sorted(options.items()))
@@ -8772,7 +8812,7 @@ def load_project_config(
         project.get("index_range_assertions"),
         field_name="crosstl.toml [project.index_range_assertions]",
     )
-    entry_points = _as_non_empty_str_mapping(
+    entry_points = _as_entry_point_selection_mapping(
         project.get("entry_points"),
         field_name="crosstl.toml [project.entry_points]",
     )
@@ -8843,7 +8883,7 @@ def load_project_config(
         targets=_as_str_list(project.get("targets"), field_name="project.targets"),
         output_dir=_normalize_project_relative_path(output_dir or DEFAULT_OUTPUT_DIR),
         source_overrides=_normalize_project_relative_path_mapping(sources),
-        entry_points=_normalize_project_relative_path_mapping(entry_points),
+        entry_points=_normalize_entry_point_selection_mapping(entry_points),
         include_dirs=_normalize_project_relative_paths(
             _as_str_list(project.get("include_dirs"), field_name="project.include_dirs")
         ),
@@ -8885,30 +8925,46 @@ def _entry_point_selector_priority(pattern: str, relative_path: str) -> tuple:
     )
 
 
-def _entry_point_from_mapping(
+def _entry_points_from_mapping(
     relative_path: str,
-    entry_points: Mapping[str, str],
-) -> str | None:
+    entry_points: Mapping[str, str | Sequence[str]],
+) -> tuple[str, ...]:
     normalized_path = _normalize_project_relative_path(relative_path)
     matches = [
-        (pattern, entry_point)
-        for pattern, entry_point in entry_points.items()
+        (pattern, selection)
+        for pattern, selection in entry_points.items()
         if fnmatch.fnmatch(
             normalized_path,
             _normalize_project_relative_path(pattern),
         )
     ]
     if not matches:
-        return None
-    _pattern, entry_point = max(
+        return ()
+    _pattern, selection = max(
         matches,
         key=lambda item: _entry_point_selector_priority(item[0], normalized_path),
     )
-    return entry_point
+    return (
+        (selection.strip(),)
+        if isinstance(selection, str)
+        else tuple(entry.strip() for entry in selection)
+    )
 
 
-def _entry_point_for_path(relative_path: str, config: ProjectConfig) -> str | None:
-    return _entry_point_from_mapping(relative_path, config.entry_points)
+def _entry_points_for_path(
+    relative_path: str,
+    config: ProjectConfig,
+) -> tuple[str, ...]:
+    return _entry_points_from_mapping(relative_path, config.entry_points)
+
+
+def _entry_point_selections_payload(
+    entry_points: Mapping[str, str | Sequence[str]],
+) -> dict[str, str | list[str]]:
+    return {
+        pattern: selection if isinstance(selection, str) else list(selection)
+        for pattern, selection in sorted(entry_points.items())
+    }
 
 
 def _iter_scan_candidates(config: ProjectConfig) -> list[Path]:
@@ -9472,7 +9528,9 @@ def _regular_project_translation_jobs(
     config: ProjectConfig,
     relative_path: str,
 ) -> list[_ProjectArtifactTranslationJob]:
-    entry_point = _entry_point_for_path(relative_path, config)
+    entry_points: tuple[str | None, ...] = _entry_points_for_path(
+        relative_path, config
+    ) or (None,)
     return [
         _ProjectArtifactTranslationJob(
             variant=variant,
@@ -9485,6 +9543,7 @@ def _regular_project_translation_jobs(
             ),
         )
         for variant, defines in _variant_jobs(config)
+        for entry_point in entry_points
     ]
 
 
@@ -9529,7 +9588,7 @@ def _dispatch_project_translation_jobs(
                 ],
             },
         )
-    configured_entry_point = _entry_point_for_path(relative_path, config)
+    configured_entry_points = _entry_points_for_path(relative_path, config)
     configured_workgroup_rule = _configured_workgroup_size_rule(config, relative_path)
     configured_subgroup_rule = _configured_subgroup_width_rule(config, relative_path)
     if config.workgroup_size is not None or configured_workgroup_rule is not None:
@@ -9545,22 +9604,20 @@ def _dispatch_project_translation_jobs(
             details={"source": relative_path},
         )
 
+    planned_entry_points = {artifact.entry_point for _index, artifact in artifacts}
+    if configured_entry_points and set(configured_entry_points) != planned_entry_points:
+        raise DispatchArtifactPlanError(
+            "dispatch-entry-point-config-conflict",
+            "Host dispatch artifact entry points conflict with project config.",
+            details={
+                "source": relative_path,
+                "configuredEntryPoints": list(configured_entry_points),
+                "dispatchEntryPoints": sorted(planned_entry_points),
+            },
+        )
+
     jobs = []
     for index, artifact in artifacts:
-        if (
-            configured_entry_point is not None
-            and configured_entry_point != artifact.entry_point
-        ):
-            raise DispatchArtifactPlanError(
-                "dispatch-entry-point-config-conflict",
-                "Host dispatch artifact entry point conflicts with project config.",
-                details={
-                    "source": relative_path,
-                    "configuredEntryPoint": configured_entry_point,
-                    "dispatchEntryPoint": artifact.entry_point,
-                    "artifactId": artifact.artifact_id,
-                },
-            )
         provenance = _dispatch_artifact_provenance(index, artifact)
         specialization_values = _variant_specialization_values(
             config,
@@ -9624,12 +9681,14 @@ def _project_translation_variants_by_source_target(
     for unit in units:
         for target in _normalized_targets(targets):
             variants[(unit.relative_path, target)] = tuple(
-                job.variant
-                for job in _project_translation_jobs_for_target(
-                    config,
-                    unit,
-                    target,
-                    dispatch_artifacts,
+                dict.fromkeys(
+                    job.variant
+                    for job in _project_translation_jobs_for_target(
+                        config,
+                        unit,
+                        target,
+                        dispatch_artifacts,
+                    )
                 )
             )
     return variants
@@ -11526,6 +11585,7 @@ def _artifact_matrix_report(
         variant_names,
         preserve_source_suffix,
         artifacts=artifacts,
+        entry_point_selections=config.entry_points,
         variants_by_source_target=variants_by_source_target,
     )
     payload["expectedArtifactCount"] = len(expected_identities)
@@ -40789,6 +40849,7 @@ def _inspection_artifact_matrix_identity_sets(
         variant_names,
         preserve_source_suffix,
         artifacts=artifact_records,
+        entry_point_selections=project.get("entryPointSelections"),
         variants_by_source_target=_report_translation_variants_by_source_target(
             project,
             units,
@@ -42954,7 +43015,7 @@ def _project_config_for_scan_validation(
         source_overrides
     ) or not _valid_string_mapping(defines):
         return None
-    if not _valid_non_empty_string_mapping(entry_point_selections):
+    if not _valid_entry_point_selection_mapping(entry_point_selections):
         return None
     if not _valid_source_options_mapping(source_options):
         return None
@@ -43043,7 +43104,12 @@ def _project_config_for_scan_validation(
         targets=tuple(targets),
         output_dir=_normalize_project_relative_path(output_dir),
         source_overrides=_normalize_project_relative_path_mapping(source_overrides),
-        entry_points=_normalize_project_relative_path_mapping(entry_point_selections),
+        entry_points=_normalize_entry_point_selection_mapping(
+            _as_entry_point_selection_mapping(
+                entry_point_selections,
+                field_name="project.entryPointSelections",
+            )
+        ),
         include_dirs=tuple(_normalize_project_relative_paths(include_dirs)),
         defines=dict(defines),
         source_options={
@@ -43240,22 +43306,33 @@ def _artifact_entry_point_source(record: Mapping[str, Any]) -> str | None:
     return str(source) if _is_non_empty_string(source) else None
 
 
-def _configured_entry_point_for_artifact(
+def _configured_entry_points_for_source(
+    source_path: str,
+    selections: Any,
+) -> tuple[str, ...]:
+    if not _is_non_empty_string(source_path) or not isinstance(selections, Mapping):
+        return ()
+    if not _valid_entry_point_selection_mapping(selections):
+        return ()
+    normalized = _as_entry_point_selection_mapping(
+        selections,
+        field_name="project.entryPointSelections",
+    )
+    return _entry_points_from_mapping(source_path, normalized)
+
+
+def _configured_entry_points_for_artifact(
     record: Mapping[str, Any],
     project: Mapping[str, Any] | None,
-) -> str | None:
+) -> tuple[str, ...]:
     source_path = record.get("source")
     selections = (
         project.get("entryPointSelections") if isinstance(project, Mapping) else None
     )
-    if not _is_non_empty_string(source_path) or not isinstance(selections, Mapping):
-        return None
-    valid_selections = {
-        str(pattern): str(value)
-        for pattern, value in selections.items()
-        if _is_non_empty_string(pattern) and _is_non_empty_string(value)
-    }
-    return _entry_point_from_mapping(str(source_path), valid_selections)
+    return _configured_entry_points_for_source(
+        str(source_path) if isinstance(source_path, str) else "",
+        selections,
+    )
 
 
 def _artifact_rule_execution_contract_reasons(
@@ -44126,9 +44203,9 @@ def _artifact_entry_point_contract_reasons(
     project: Mapping[str, Any] | None,
 ) -> list[str]:
     entry_point = record.get("entryPoint")
-    configured = _configured_entry_point_for_artifact(record, project)
+    configured = _configured_entry_points_for_artifact(record, project)
     if entry_point is None:
-        if configured is not None:
+        if configured:
             return [
                 f"{prefix}.entryPoint must be recorded when the source matches "
                 "project.entryPointSelections"
@@ -44145,7 +44222,7 @@ def _artifact_entry_point_contract_reasons(
     if "stage" in entry_point and not _is_non_empty_string(entry_point.get("stage")):
         reasons.append(f"{prefix}.entryPoint.stage must be a string")
 
-    if configured is not None and entry_point.get("source") != configured:
+    if configured and entry_point.get("source") not in configured:
         reasons.append(
             f"{prefix}.entryPoint.source must match project.entryPointSelections"
         )
@@ -44629,7 +44706,15 @@ def _expected_entry_points_from_artifacts(
     source: str,
     target: str,
     variant: str | None,
+    entry_point_selections: Any = None,
 ) -> tuple[str | None, ...]:
+    configured = _configured_entry_points_for_source(
+        source,
+        entry_point_selections,
+    )
+    if configured:
+        return configured
+
     entry_points = {
         entry_point
         for artifact in artifacts
@@ -44673,6 +44758,7 @@ def _expected_artifact_identities(
     preserve_source_suffix: set[tuple[str, str]],
     *,
     artifacts: Sequence[Mapping[str, Any]] = (),
+    entry_point_selections: Any = None,
     variants_by_source_target: (
         Mapping[tuple[str, str], Sequence[str | None]] | None
     ) = None,
@@ -44694,7 +44780,11 @@ def _expected_artifact_identities(
             )
             for variant in source_variants:
                 for entry_point in _expected_entry_points_from_artifacts(
-                    artifacts, source, target, variant
+                    artifacts,
+                    source,
+                    target,
+                    variant,
+                    entry_point_selections,
                 ):
                     for stage in _webgl_expected_stages_from_artifacts(
                         artifacts, source, target, variant
@@ -44989,6 +45079,7 @@ def _artifact_matrix_contract_reasons(
         variant_names,
         preserve_source_suffix,
         artifacts=[artifact for artifact in artifacts if isinstance(artifact, Mapping)],
+        entry_point_selections=project.get("entryPointSelections"),
         variants_by_source_target=variants_by_source_target,
     )
     reasons = []
@@ -45088,6 +45179,7 @@ def _expected_artifact_matrix_metadata(
                     for artifact in _record_sequence(artifacts)
                     if isinstance(artifact, Mapping)
                 ],
+                entry_point_selections=project.get("entryPointSelections"),
                 variants_by_source_target=variants_by_source_target,
             )
         )
@@ -46864,6 +46956,40 @@ def _non_empty_string_mapping_contract_reasons(prefix: str, value: Any) -> list[
     return []
 
 
+def _entry_point_selection_mapping_contract_reasons(
+    prefix: str,
+    value: Any,
+) -> list[str]:
+    if not isinstance(value, Mapping):
+        return [f"{prefix} must be an object"]
+
+    reasons = []
+    for pattern, selection in value.items():
+        if not _is_non_empty_string(pattern):
+            reasons.append(f"{prefix} keys must be non-empty strings")
+            selection_prefix = prefix
+        else:
+            selection_prefix = _mapping_key_path(prefix, pattern)
+        if isinstance(selection, str):
+            if not selection.strip():
+                reasons.append(f"{prefix} values must be non-empty strings")
+            continue
+        if not isinstance(selection, list) or not selection:
+            reasons.append(
+                f"{selection_prefix} must be a non-empty string or list of strings"
+            )
+            continue
+        if any(not _is_non_empty_string(entry) for entry in selection):
+            reasons.append(f"{selection_prefix} entries must be non-empty strings")
+            continue
+        normalized_selection = [entry.strip() for entry in selection]
+        if len(normalized_selection) != len(set(normalized_selection)):
+            reasons.append(
+                f"{selection_prefix} must not contain duplicate entry points"
+            )
+    return reasons
+
+
 def _variant_mapping_contract_reasons(prefix: str, value: Any) -> list[str]:
     if not isinstance(value, Mapping):
         return [f"{prefix} must be an object"]
@@ -47202,6 +47328,13 @@ def _valid_string_mapping(value: Any) -> bool:
 
 def _valid_non_empty_string_mapping(value: Any) -> bool:
     return _valid_string_mapping(value) and all(item.strip() for item in value.values())
+
+
+def _valid_entry_point_selection_mapping(value: Any) -> bool:
+    return not _entry_point_selection_mapping_contract_reasons(
+        "entryPointSelections",
+        value,
+    )
 
 
 def _valid_source_options_mapping(value: Any) -> bool:
@@ -48173,7 +48306,7 @@ def _project_metadata_contract_reasons(
         project, "entryPointSelections", required=require_full_metadata
     ):
         reasons.extend(
-            _non_empty_string_mapping_contract_reasons(
+            _entry_point_selection_mapping_contract_reasons(
                 "project.entryPointSelections", entry_point_selections
             )
         )

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -106,9 +106,9 @@ Use these report fields to decide the next action:
      - Confirm the expected unit, target, and named-variant artifact plan before
        translation, then identify missing or extra artifacts after translation.
    * - ``project.entryPointSelections`` and ``artifacts[].entryPoint``
-     - Confirm that a requested materialized source entry was packaged under its
-       deterministic entry path and identify the reflected target entry and
-       stage.
+     - Confirm that requested materialized source entries were each packaged
+       under deterministic entry paths and identify their reflected target
+       entries and stages.
    * - ``validation``
      - Check current source hashes and byte sizes, generated artifact hashes
        and byte sizes, source maps, source remaps, optional toolchain
@@ -255,8 +255,9 @@ host runtime integration or numerical parity.
 Entry-Scoped Compute Artifacts
 ------------------------------
 
-Repositories can request a standalone artifact for one materialized source
-entry by adding a repository-relative selector table to ``crosstl.toml``:
+Repositories can request standalone artifacts for one or more materialized
+source entries by adding a repository-relative selector table to
+``crosstl.toml``:
 
 .. code-block:: toml
 
@@ -267,27 +268,35 @@ entry by adding a repository-relative selector table to ``crosstl.toml``:
    output_dir = "crosstl-out"
 
    [project.entry_points]
-   "kernels/arange.metal" = "arangeuint32"
+   "kernels/arange.metal" = ["arangeuint32", "arangec64"]
 
-For DirectX compute output, the selected source entry is emitted as target entry
-``CSMain``. A source such as ``kernels/arange.metal`` produces
-``crosstl-out/directx/kernels/arange/arangeuint32.hlsl``. The standalone HLSL
-retains only the selected entry's reachable helpers, resources, constants, and
-execution contract. Explicit registers and spaces remain unchanged, while
+Each value may be one entry name or an ordered array of entry names. An array
+creates one independently checkpointed artifact per entry in the declared
+order. Empty arrays and duplicate names are rejected.
+
+For DirectX compute output, each selected source entry is emitted as target
+entry ``CSMain``. A source such as ``kernels/arange.metal`` produces
+``crosstl-out/directx/kernels/arange/arangeuint32.hlsl`` and
+``crosstl-out/directx/kernels/arange/arangec64.hlsl``. Each standalone HLSL
+artifact retains only that entry's reachable helpers, resources, constants,
+and execution contract. Explicit registers and spaces remain unchanged, while
 runtime-loader metadata records the selected ``cs_6_0`` entry profile.
 
-For OpenGL compute output, the same selection produces
-``crosstl-out/opengl/kernels/arange/arangeuint32.glsl`` with target entry
-``main``. For both targets, the portability report records the source entry,
-target entry, and reflected stage on the artifact; embedded validation records
-carry the same identity. Runtime artifact manifests then reflect only the
-selected stage interface from that standalone output.
+For OpenGL compute output, the same selection produces one ``.glsl`` artifact
+per entry with target entry ``main``. For both targets, the portability report
+records every source entry, target entry, and reflected stage; embedded
+validation records carry the same identities. Runtime artifact manifests then
+reflect only the selected stage interface from each standalone output.
 
 Selection is exact after source materialization. Missing or ambiguous entries
 fail with structured diagnostics and no target file. Targets that do not yet
 implement standalone entry generation also fail explicitly instead of pruning
 an aggregate artifact. When ``project.entry_points`` is absent, project
 translation keeps the existing aggregate output path and behavior.
+
+Entry selection scopes shader or kernel translation; it does not infer host
+dispatch dimensions, runtime bindings, or backend integration. Record those
+requirements through the corresponding dispatch and runtime contracts.
 
 Project Index-Range Assertions
 ------------------------------

--- a/support/features.json
+++ b/support/features.json
@@ -7540,17 +7540,18 @@
       "id": "project.entry_scoped_artifacts",
       "category": "project",
       "name": "Entry-scoped project artifacts",
-      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "description": "Select one or more materialized source entries and emit independently loadable artifacts with deterministic identities, paths, provenance, and reflected interface metadata.",
       "support": {
     "directx": {
       "status": "supported",
-      "notes": "Project configuration selects one materialized compute entry and emits an independently loadable HLSL artifact at a deterministic entry path. The artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
+      "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed HLSL artifact per entry at a deterministic path. Each artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
       "evidence": [
         "tests/test_translator/test_codegen/test_directx_codegen.py::def test_hlsl_entry_scoped_generation_keeps_selected_execution_contract",
         "tests/test_translator/test_codegen/test_directx_codegen.py::def test_hlsl_entry_scoped_generation_reports_available_entries",
         "tests/test_translator/test_directx_entry_packaging.py::def test_selected_directx_compute_is_standalone_and_replayable",
         "tests/test_translator/test_directx_entry_packaging.py::def test_directx_project_preserves_aggregate_output_without_selection",
         "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_cli_packages_materialized_directx_entry",
+        "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_emits_each_materialized_directx_entry",
         "tests/test_translator/test_directx_entry_packaging.py::def test_directx_entry_selection_failures_are_structured_and_write_no_file",
         "tests/test_translator/test_project_translation.py::def test_translate_project_allows_entry_scoped_workgroup_size_specialization",
         "tests/test_translator/test_native_runtime_drivers.py::def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device"
@@ -7558,14 +7559,17 @@
         },
         "opengl": {
           "status": "supported",
-          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed GLSL main artifact per entry at a deterministic path. Each artifact retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
           "evidence": [
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_each_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_multiplies_variants_by_selected_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
             "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
             "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_translator/test_project_translation_checkpoint.py::def test_translate_project_checkpoint_resumes_pending_entry_artifact",
             "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
           ]
         },

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -2466,7 +2466,7 @@
     },
     {
       "category": "project",
-      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "description": "Select one or more materialized source entries and emit independently loadable artifacts with deterministic identities, paths, provenance, and reflected interface metadata.",
       "id": "project.entry_scoped_artifacts",
       "name": "Entry-scoped project artifacts",
       "support": {
@@ -2477,11 +2477,12 @@
             "tests/test_translator/test_directx_entry_packaging.py::def test_selected_directx_compute_is_standalone_and_replayable",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_project_preserves_aggregate_output_without_selection",
             "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_cli_packages_materialized_directx_entry",
+            "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_emits_each_materialized_directx_entry",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_entry_selection_failures_are_structured_and_write_no_file",
             "tests/test_translator/test_project_translation.py::def test_translate_project_allows_entry_scoped_workgroup_size_specialization",
             "tests/test_translator/test_native_runtime_drivers.py::def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device"
           ],
-          "notes": "Project configuration selects one materialized compute entry and emits an independently loadable HLSL artifact at a deterministic entry path. The artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed HLSL artifact per entry at a deterministic path. Each artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
           "status": "supported"
         },
         "metal": {
@@ -2496,12 +2497,15 @@
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_each_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_multiplies_variants_by_selected_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
             "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
             "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_translator/test_project_translation_checkpoint.py::def test_translate_project_checkpoint_resumes_pending_entry_artifact",
             "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
           ],
-          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed GLSL main artifact per entry at a deterministic path. Each artifact retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
           "status": "supported"
         }
       }

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -2785,7 +2785,7 @@
     },
     {
       "category": "project",
-      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "description": "Select one or more materialized source entries and emit independently loadable artifacts with deterministic identities, paths, provenance, and reflected interface metadata.",
       "id": "project.entry_scoped_artifacts",
       "name": "Entry-scoped project artifacts",
       "support": {
@@ -2803,11 +2803,12 @@
             "tests/test_translator/test_directx_entry_packaging.py::def test_selected_directx_compute_is_standalone_and_replayable",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_project_preserves_aggregate_output_without_selection",
             "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_cli_packages_materialized_directx_entry",
+            "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_emits_each_materialized_directx_entry",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_entry_selection_failures_are_structured_and_write_no_file",
             "tests/test_translator/test_project_translation.py::def test_translate_project_allows_entry_scoped_workgroup_size_specialization",
             "tests/test_translator/test_native_runtime_drivers.py::def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device"
           ],
-          "notes": "Project configuration selects one materialized compute entry and emits an independently loadable HLSL artifact at a deterministic entry path. The artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed HLSL artifact per entry at a deterministic path. Each artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
           "status": "supported"
         },
         "hip": {
@@ -2836,12 +2837,15 @@
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_each_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_multiplies_variants_by_selected_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
             "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
             "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_translator/test_project_translation_checkpoint.py::def test_translate_project_checkpoint_resumes_pending_entry_artifact",
             "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
           ],
-          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed GLSL main artifact per entry at a deterministic path. Each artifact retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
           "status": "supported"
         },
         "rust": {

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -9209,7 +9209,7 @@
     },
     {
       "category": "project",
-      "description": "Select one materialized source entry and emit an independently loadable artifact with deterministic identity, path, provenance, and reflected interface metadata.",
+      "description": "Select one or more materialized source entries and emit independently loadable artifacts with deterministic identities, paths, provenance, and reflected interface metadata.",
       "id": "project.entry_scoped_artifacts",
       "name": "Entry-scoped project artifacts",
       "support": {
@@ -9227,11 +9227,12 @@
             "tests/test_translator/test_directx_entry_packaging.py::def test_selected_directx_compute_is_standalone_and_replayable",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_project_preserves_aggregate_output_without_selection",
             "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_cli_packages_materialized_directx_entry",
+            "tests/test_translator/test_directx_entry_packaging.py::def test_translate_project_emits_each_materialized_directx_entry",
             "tests/test_translator/test_directx_entry_packaging.py::def test_directx_entry_selection_failures_are_structured_and_write_no_file",
             "tests/test_translator/test_project_translation.py::def test_translate_project_allows_entry_scoped_workgroup_size_specialization",
             "tests/test_translator/test_native_runtime_drivers.py::def test_directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device"
           ],
-          "notes": "Project configuration selects one materialized compute entry and emits an independently loadable HLSL artifact at a deterministic entry path. The artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed HLSL artifact per entry at a deterministic path. Each artifact retains only reachable helpers, resources, constants, and execution state; preserves explicit registers and spaces; and records source-to-target entry identity, the selected execution contract, reflected interface, source maps, validation, profile, and entry-scoped provenance. The pinned MLX arangeuint32 proof compiles the standalone CSMain artifact with DXC and verifies exact Direct3D 12 readback on Windows CI.",
           "status": "supported"
         },
         "hip": {
@@ -9260,12 +9261,15 @@
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_keeps_only_selected_interface_and_helpers",
             "tests/test_translator/test_codegen/test_GLSL_codegen.py::def test_opengl_entry_scoped_generation_reports_available_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_emits_each_selected_opengl_entry",
+            "tests/test_translator/test_project_translation.py::def test_translate_project_multiplies_variants_by_selected_entries",
             "tests/test_translator/test_project_translation.py::def test_translate_project_keeps_aggregate_opengl_output_without_entry_selection",
             "tests/test_translator/test_project_translation.py::def test_translate_project_reports_missing_selected_opengl_entry",
             "tests/test_translator/test_project_translation.py::def test_validate_project_report_requires_configured_entry_point_metadata",
+            "tests/test_translator/test_project_translation_checkpoint.py::def test_translate_project_checkpoint_resumes_pending_entry_artifact",
             "tests/test_mlx_porting_harness.py::def test_arange_opengl_check_confirms_native_validation"
           ],
-          "notes": "Project configuration selects one materialized compute entry, emits a standalone GLSL main artifact at a deterministic entry path, retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
+          "notes": "Project configuration accepts a string or ordered list of materialized compute entries and emits one independently checkpointed GLSL main artifact per entry at a deterministic path. Each artifact retains only the selected stage interface and reachable helpers, records source-to-target entry identity in report and validation records, preserves provenance and source maps, and exposes an entry-scoped reflected runtime interface. Aggregate output remains unchanged when no entry is selected. The pinned MLX arangeuint32 proof compiles and executes through Mesa OpenGL with exact uint32 readback on Linux CI.",
           "status": "supported"
         },
         "rust": {

--- a/tests/test_translator/test_directx_entry_packaging.py
+++ b/tests/test_translator/test_directx_entry_packaging.py
@@ -121,6 +121,9 @@ def _write_materialized_metal_source(root):
 
             template [[host_name("copy_float")]] [[kernel]]
             decltype(copy_values<float>) copy_values<float>;
+
+            template [[host_name("copy_uint")]] [[kernel]]
+            decltype(copy_values<uint>) copy_values<uint>;
             """).strip() + "\n",
         encoding="utf-8",
     )
@@ -387,6 +390,69 @@ def test_translate_project_cli_packages_materialized_directx_entry(tmp_path):
     assert "StructuredBuffer<float> values" in generated
     assert "RWStructuredBuffer<float> results" in generated
     _assert_hlsl_compute_compiles_if_available(shader_path, tmp_path)
+
+
+def test_translate_project_emits_each_materialized_directx_entry(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _write_materialized_metal_source(root)
+    config = ProjectConfig(
+        root=root,
+        include_patterns=("kernels/materialized.metal",),
+        targets=("directx",),
+        output_dir="translated",
+        entry_points={
+            "kernels/*.metal": ("copy_float", "copy_uint"),
+        },
+    )
+
+    report = translate_project(config, format_output=False, validate=True)
+    payload = report.to_json()
+
+    assert payload["summary"]["translatedCount"] == 2
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["artifactMatrix"]["expectedArtifactCount"] == 2
+    assert payload["artifactMatrix"]["complete"] is True
+    assert payload["project"]["entryPointSelections"] == {
+        "kernels/*.metal": ["copy_float", "copy_uint"]
+    }
+    assert [artifact["path"] for artifact in payload["artifacts"]] == [
+        "translated/directx/kernels/materialized/copy_float.hlsl",
+        "translated/directx/kernels/materialized/copy_uint.hlsl",
+    ]
+
+    expected_types = {
+        "copy_float": "float",
+        "copy_uint": "uint",
+    }
+    for artifact in payload["artifacts"]:
+        entry_point = artifact["entryPoint"]["source"]
+        assert artifact["entryPoint"] == {
+            "source": entry_point,
+            "target": "CSMain",
+            "stage": "compute",
+        }
+        assert {
+            record["hostName"]
+            for record in artifact["templateMaterialization"]["specializations"]
+        } == {entry_point}
+        shader_path = root / artifact["path"]
+        generated = shader_path.read_text(encoding="utf-8")
+        expected_type = expected_types[entry_point]
+        assert generated.count("void CSMain(") == 1
+        assert f"StructuredBuffer<{expected_type}> values" in generated
+        assert f"RWStructuredBuffer<{expected_type}> results" in generated
+        other_entry = "copy_uint" if entry_point == "copy_float" else "copy_float"
+        assert other_entry not in json.dumps(artifact, sort_keys=True)
+        _assert_hlsl_compute_compiles_if_available(shader_path, tmp_path)
+
+    report_path = root / "portability-report.json"
+    report.write_json(report_path)
+    validation = validate_project_report(report_path)
+    assert validation["success"] is True, validation["diagnostics"][0]["message"]
+    manifest = build_runtime_artifact_manifest(report_path)
+    assert manifest["success"] is True
+    assert manifest["summary"]["artifactCount"] == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -1057,6 +1057,124 @@ def test_translate_project_emits_entry_scoped_opengl_artifact_and_reflection(
     } == {0, 1, 2}
 
 
+def test_translate_project_emits_each_selected_opengl_entry(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    (repo / "crosstl.toml").write_text(
+        textwrap.dedent("""
+            [project]
+            include = ["multi.cgl"]
+            targets = ["opengl"]
+            output_dir = "out"
+
+            [project.entry_points]
+            "multi.cgl" = ["second", "first"]
+            """).strip() + "\n",
+        encoding="utf-8",
+    )
+
+    config = load_project_config(repo)
+    report = translate_project(config, format_output=False, validate=True)
+    payload = report.to_json()
+
+    assert config.entry_points == {"multi.cgl": ("second", "first")}
+    assert payload["project"]["entryPointSelections"] == {
+        "multi.cgl": ["second", "first"]
+    }
+    assert payload["project"]["entryPointSelectionCount"] == 1
+    assert payload["summary"]["translatedCount"] == 2
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["artifactMatrix"]["expectedArtifactCount"] == 2
+    assert payload["artifactMatrix"]["complete"] is True
+
+    artifacts = payload["artifacts"]
+    assert [artifact["entryPoint"]["source"] for artifact in artifacts] == [
+        "second",
+        "first",
+    ]
+    assert [artifact["path"] for artifact in artifacts] == [
+        "out/opengl/multi/second.glsl",
+        "out/opengl/multi/first.glsl",
+    ]
+    generated_by_entry = {
+        artifact["entryPoint"]["source"]: (
+            (repo / artifact["path"]).read_text(encoding="utf-8")
+        )
+        for artifact in artifacts
+    }
+    assert "selected_helper" in generated_by_entry["second"]
+    assert "unrelated_helper" not in generated_by_entry["second"]
+    assert "unrelated_helper" in generated_by_entry["first"]
+    assert "selected_helper" not in generated_by_entry["first"]
+    for generated in generated_by_entry.values():
+        assert generated.count("void main()") == 1
+        assert_compute_glsl_validates_if_available(generated, tmp_path)
+
+    report_path = repo / "report.json"
+    report.write_json(report_path)
+    assert validate_project_report(report_path)["success"] is True
+    manifest = build_runtime_artifact_manifest(report_path)
+    assert manifest["success"] is True
+    assert manifest["summary"]["artifactCount"] == 2
+
+    incomplete = json.loads(report_path.read_text(encoding="utf-8"))
+    incomplete["artifacts"] = incomplete["artifacts"][:1]
+    incomplete_path = repo / "incomplete-report.json"
+    incomplete_path.write_text(json.dumps(incomplete), encoding="utf-8")
+    validation = validate_project_report(incomplete_path)
+    assert validation["success"] is False
+    assert "artifacts must include units[0].path multi.cgl target opengl" in (
+        validation["diagnostics"][0]["message"]
+    )
+
+
+def test_translate_project_multiplies_variants_by_selected_entries(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        ENTRY_SCOPED_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    config = project_api.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=("opengl",),
+        output_dir="out",
+        entry_points={"multi.cgl": ("first", "second")},
+        variants={
+            "debug": {"MODE": "1"},
+            "release": {"MODE": "0"},
+        },
+    )
+
+    report = translate_project(config, format_output=False)
+    payload = report.to_json()
+
+    assert payload["artifactMatrix"]["variantCount"] == 2
+    assert payload["artifactMatrix"]["variantMode"] == "named"
+    assert payload["artifactMatrix"]["expectedArtifactCount"] == 4
+    assert payload["artifactMatrix"]["complete"] is True
+    assert [
+        (artifact["variant"], artifact["entryPoint"]["source"])
+        for artifact in payload["artifacts"]
+    ] == [
+        ("debug", "first"),
+        ("debug", "second"),
+        ("release", "first"),
+        ("release", "second"),
+    ]
+    assert len({artifact["path"] for artifact in payload["artifacts"]}) == 4
+
+    report_path = repo / "portability-report.json"
+    report.write_json(report_path)
+    validation = validate_project_report(report_path)
+    assert validation["success"] is True, validation["diagnostics"]
+
+
 @pytest.mark.parametrize(
     "entry_points",
     (
@@ -1156,6 +1274,38 @@ def test_translate_project_reports_missing_selected_opengl_entry(tmp_path):
     )
     assert diagnostic["severity"] == "error"
     assert diagnostic["missingCapabilities"] == ["artifact.entry-point-selection"]
+
+
+@pytest.mark.parametrize(
+    ("selection", "message"),
+    (
+        pytest.param(
+            [],
+            r"ProjectConfig\.entry_points\[\"multi\.cgl\"\] must select at least one",
+            id="empty",
+        ),
+        pytest.param(
+            ["first", "first"],
+            r"ProjectConfig\.entry_points\[\"multi\.cgl\"\] must not contain duplicate",
+            id="duplicate",
+        ),
+        pytest.param(
+            ["first", " first "],
+            r"ProjectConfig\.entry_points\[\"multi\.cgl\"\] must not contain duplicate",
+            id="normalized-duplicate",
+        ),
+    ),
+)
+def test_project_config_rejects_invalid_entry_point_lists(
+    tmp_path,
+    selection,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        project_api.ProjectConfig(
+            root=tmp_path,
+            entry_points={"multi.cgl": selection},
+        )
 
 
 @pytest.mark.parametrize(
@@ -38466,6 +38616,42 @@ def test_runtime_artifact_manifest_accepts_entry_point_selection_metadata(tmp_pa
             {"multi.cgl": ""},
             "project.entryPointSelections values must be non-empty strings",
             id="selection-value",
+        ),
+        pytest.param(
+            "entryPointSelections",
+            {"multi.cgl": []},
+            (
+                'project.entryPointSelections["multi.cgl"] must be a non-empty '
+                "string or list of strings"
+            ),
+            id="empty-selection-list",
+        ),
+        pytest.param(
+            "entryPointSelections",
+            {"multi.cgl": ["second", "second"]},
+            (
+                'project.entryPointSelections["multi.cgl"] must not contain '
+                "duplicate entry points"
+            ),
+            id="duplicate-selection-list",
+        ),
+        pytest.param(
+            "entryPointSelections",
+            {"multi.cgl": ["second", " second "]},
+            (
+                'project.entryPointSelections["multi.cgl"] must not contain '
+                "duplicate entry points"
+            ),
+            id="normalized-duplicate-selection-list",
+        ),
+        pytest.param(
+            "entryPointSelections",
+            {"multi.cgl": ["second", 1]},
+            (
+                'project.entryPointSelections["multi.cgl"] entries must be '
+                "non-empty strings"
+            ),
+            id="invalid-selection-list-entry",
         ),
         pytest.param(
             "entryPointSelectionCount",

--- a/tests/test_translator/test_project_translation_checkpoint.py
+++ b/tests/test_translator/test_project_translation_checkpoint.py
@@ -39,6 +39,26 @@ SIMPLE_CROSSL = textwrap.dedent("""
     }
     """).strip()
 
+MULTI_ENTRY_COMPUTE_CROSSL = textwrap.dedent("""
+    shader CheckpointCompute {
+        RWStructuredBuffer<uint> output @set(0) @binding(0);
+
+        compute first {
+            @numthreads(1, 1, 1)
+            void main(uint index @gl_GlobalInvocationID) {
+                output[index] = 1u;
+            }
+        }
+
+        compute second {
+            @numthreads(1, 1, 1)
+            void main(uint index @gl_GlobalInvocationID) {
+                output[index] = 2u;
+            }
+        }
+    }
+    """).strip()
+
 
 def _identity():
     return {
@@ -373,6 +393,84 @@ def test_translate_project_checkpoint_resumes_only_verified_pending_jobs(
     assert completed["state"] == "complete"
     assert completed["plan"]["completedCount"] == 2
     assert completed["plan"]["pending"] == []
+    assert completed["finalReport"] == resumed
+
+
+def test_translate_project_checkpoint_resumes_pending_entry_artifact(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "multi.cgl").write_text(
+        MULTI_ENTRY_COMPUTE_CROSSL,
+        encoding="utf-8",
+    )
+    checkpoint_path = repo / "progress.json"
+    config = project_pipeline.ProjectConfig(
+        root=repo,
+        include_patterns=("multi.cgl",),
+        targets=("opengl",),
+        output_dir="out",
+        entry_points={"multi.cgl": ("first", "second")},
+    )
+    original_generate = project_pipeline._generate_project_target_from_crossgl_ast
+    interrupted_entries = []
+
+    def interrupt_second(*args, **kwargs):
+        entry_point = kwargs.get("entry_point")
+        interrupted_entries.append(entry_point)
+        if entry_point == "second":
+            raise KeyboardInterrupt("interrupted")
+        return original_generate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        project_pipeline,
+        "_generate_project_target_from_crossgl_ast",
+        interrupt_second,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        project_api.translate_project(
+            config,
+            format_output=False,
+            checkpoint_path=checkpoint_path,
+        )
+
+    interrupted = load_project_translation_checkpoint(checkpoint_path)
+    assert interrupted["state"] == "interrupted"
+    assert interrupted["plan"]["completedCount"] == 1
+    assert interrupted["plan"]["completed"][0]["coordinate"]["entryPoint"] == "first"
+    assert interrupted["plan"]["active"]["entryPoint"] == "second"
+    assert interrupted["plan"]["pending"] == []
+    assert interrupted_entries == ["first", "second"]
+
+    resumed_entries = []
+
+    def record_resumed_translation(*args, **kwargs):
+        resumed_entries.append(kwargs.get("entry_point"))
+        return original_generate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        project_pipeline,
+        "_generate_project_target_from_crossgl_ast",
+        record_resumed_translation,
+    )
+    resumed = project_api.translate_project(
+        config,
+        format_output=False,
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    ).to_json()
+
+    assert resumed_entries == ["second"]
+    assert resumed["summary"]["translatedCount"] == 2
+    assert [artifact["entryPoint"]["source"] for artifact in resumed["artifacts"]] == [
+        "first",
+        "second",
+    ]
+    completed = load_project_translation_checkpoint(checkpoint_path)
+    assert completed["state"] == "complete"
+    assert completed["plan"]["completedCount"] == 2
     assert completed["finalReport"] == resumed
 
 


### PR DESCRIPTION
### Summary

Allow one project source selector to name multiple materialized compute entries. Each selected entry is translated, checkpointed, reported, validated, and packaged as an independent artifact for targets that support entry-scoped generation.

### Related Issue

Refs #1523

Support issue traceability: no issue closed

### Changes

- Accept either a single entry name or an ordered list in `project.entry_points`.
- Expand variants and selected entries into deterministic project translation jobs.
- Preserve entry identities in artifact paths, checkpoints, portability reports, validation, and runtime manifests.
- Validate report completeness against the configured entry list and reject empty, duplicate, or malformed selections.
- Cover independently materialized DirectX HLSL and OpenGL GLSL artifacts, including reachability pruning and optional native toolchain validation.
- Document the configuration contract and refresh support metadata.

Entry selection remains explicit. This change does not infer source entries, host dispatch geometry, runtime bindings, or numerical parity. Targets without entry-scoped generation continue to emit structured unsupported-target diagnostics.

### Testing

- `.venv/bin/python -m pytest -q -n auto tests/test_translator/test_project_translation.py tests/test_translator/test_directx_entry_packaging.py tests/test_translator/test_project_translation_checkpoint.py` (`1239 passed`)
- `.venv/bin/python -m pytest -q -n auto` (`17135 passed, 223 skipped`)
- `.venv/bin/python tools/support_matrix.py check`
- `.venv/bin/python tools/support_signals.py check`
- `.venv/bin/python tools/sync_support_issues.py --dry-run --repo CrossGL/crosstl`
- `.venv/bin/pre-commit run --all-files`
- Pinned MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`: selected `arangeuint32` and `arangefloat32` together for DirectX and OpenGL; produced four complete entry-scoped artifacts, validated both GLSL modules with `glslangValidator`, and compiled both HLSL modules through `glslangValidator` with `spirv-val` validation.
- Pinned MLX `binary.metal`: selected `ss_Addfloat32` and `vv_Addfloat32` for both targets; produced four complete artifacts in 30.66 seconds, retained one reachable specialization per artifact, and pruned 222,641 unrelated candidates per artifact. The same available validator checks passed.
- Built the runtime artifact manifest, runtime package, and loader manifest from the four-artifact `binary.metal` report; all stages succeeded and preserved four distinct source-entry load units.

### Checklist

- [x] Tests cover new or changed code
- [ ] Linked the issue with a closing keyword (the broader issue remains open)
- [x] Added `Support issue traceability: no issue closed`
- [x] Only touched files related to the issue
- [x] Everything builds and runs locally
