### PR TITLE
Add bounded project translation workers

### DIFF
--- a/crosstl/_crosstl.py
+++ b/crosstl/_crosstl.py
@@ -595,6 +595,7 @@ def _run_translate_project(args):
     checkpoint_path = getattr(args, "checkpoint", None)
     resume = bool(getattr(args, "resume", False))
     checkpoint_interval_jobs = getattr(args, "checkpoint_interval_jobs", 1)
+    max_workers = getattr(args, "workers", 1)
     if resume and checkpoint_path is None:
         print("Error: --resume requires --checkpoint", file=sys.stderr)
         return 2
@@ -618,6 +619,8 @@ def _run_translate_project(args):
         translate_kwargs["checkpoint_path"] = checkpoint_path
         translate_kwargs["resume"] = resume
         translate_kwargs["checkpoint_interval_jobs"] = checkpoint_interval_jobs
+    if max_workers != 1:
+        translate_kwargs["max_workers"] = max_workers
     report = translate_project(config, **translate_kwargs)
     payload = report.to_json()
     if args.report:
@@ -6994,6 +6997,12 @@ def _build_parser():
         type=_positive_int,
         default=1,
         help="Persist checkpoint progress after this many completed jobs",
+    )
+    translate_project_parser.add_argument(
+        "--workers",
+        type=_positive_int,
+        default=1,
+        help="Run up to this many artifact translations in isolated processes",
     )
     translate_project_parser.add_argument(
         "--runtime-binding-manifest",

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -18,8 +18,10 @@ import subprocess
 import tempfile
 import time
 from collections import Counter
+from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass, field, replace
 from importlib import metadata as importlib_metadata
+from multiprocessing import get_context
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
@@ -9576,6 +9578,83 @@ class _ProjectArtifactTranslationJob:
     configured_subgroup: tuple[int, Mapping[str, Any]] | None = None
 
 
+@dataclass(frozen=True)
+class _ProjectArtifactTranslationRequest:
+    unit: ProjectTranslationUnit
+    target: str
+    job: _ProjectArtifactTranslationJob
+    coordinate: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class _ProjectArtifactTranslationPlanItem:
+    request: _ProjectArtifactTranslationRequest
+    setup_diagnostics: tuple[ProjectDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ProjectArtifactTranslationResult:
+    artifacts: tuple[dict[str, Any], ...]
+    diagnostics: tuple[ProjectDiagnostic, ...]
+
+
+@dataclass(frozen=True)
+class _ProjectTranslationWorkerContext:
+    config: ProjectConfig
+    dispatch_artifact_plan: DispatchArtifactPlan | None
+    preserve_source_suffix: frozenset[tuple[str, str]]
+    format_output: bool
+    output_dir_blocked: bool
+
+
+_PROJECT_TRANSLATION_WORKER_CONTEXT: _ProjectTranslationWorkerContext | None = None
+
+
+def _initialize_project_translation_worker(
+    context: _ProjectTranslationWorkerContext,
+) -> None:
+    global _PROJECT_TRANSLATION_WORKER_CONTEXT
+    _PROJECT_TRANSLATION_WORKER_CONTEXT = context
+
+
+def _run_project_translation_worker(
+    request: _ProjectArtifactTranslationRequest,
+) -> _ProjectArtifactTranslationResult:
+    context = _PROJECT_TRANSLATION_WORKER_CONTEXT
+    if context is None:
+        raise RuntimeError("Project translation worker was not initialized")
+    worker_scan = ProjectScan(
+        config=context.config,
+        units=(request.unit,),
+        dispatch_artifact_plan=context.dispatch_artifact_plan,
+    )
+    report = _translate_project_impl(
+        context.config,
+        targets=(request.target,),
+        output_dir=None,
+        variants=None,
+        format_output=context.format_output,
+        validate=False,
+        run_toolchains=False,
+        max_workers=1,
+        checkpoint_run=_ProjectTranslationCheckpointRun(
+            path=None,
+            resume=False,
+            write_interval_jobs=1,
+        ),
+        scan_override=worker_scan,
+        translation_job_override=request,
+        preserve_source_suffix_override=context.preserve_source_suffix,
+        suppress_forwarding_diagnostics=True,
+        suppress_target_diagnostics=True,
+        output_dir_blocked_override=context.output_dir_blocked,
+    )
+    return _ProjectArtifactTranslationResult(
+        artifacts=tuple(report.artifacts),
+        diagnostics=tuple(report.diagnostics),
+    )
+
+
 @dataclass
 class _ProjectTranslationCheckpointRun:
     path: str | os.PathLike[str] | None
@@ -9905,6 +9984,205 @@ def _project_translation_checkpoint_jobs(
             dispatch_artifacts,
         )
     ]
+
+
+def _project_artifact_translation_plan(
+    config: ProjectConfig,
+    units: Sequence[ProjectTranslationUnit],
+    targets: Sequence[str],
+    dispatch_artifacts: Mapping[str, Sequence[tuple[int, DispatchArtifactJob]]],
+    *,
+    include_paths: Sequence[str],
+    preserve_source_suffix: set[tuple[str, str]],
+) -> list[_ProjectArtifactTranslationPlanItem]:
+    variant_jobs = _variant_jobs(config)
+    max_define_count = max(
+        (len(defines) for _variant, defines in variant_jobs),
+        default=0,
+    )
+    define_forwarding_diagnostics: set[str] = set()
+    include_path_forwarding_diagnostics: set[str] = set()
+    plan: list[_ProjectArtifactTranslationPlanItem] = []
+
+    for unit in units:
+        setup_diagnostics: list[ProjectDiagnostic] = []
+        source_supports_defines = _source_frontend_supports_lexer_keyword(
+            unit.source_backend,
+            "defines",
+        )
+        source_supports_include_paths = _source_frontend_supports_lexer_keyword(
+            unit.source_backend,
+            "include_paths",
+        )
+        if (
+            max_define_count > 0
+            and not source_supports_defines
+            and unit.source_backend not in define_forwarding_diagnostics
+        ):
+            setup_diagnostics.append(
+                _frontend_define_forwarding_diagnostic(unit, max_define_count)
+            )
+            define_forwarding_diagnostics.add(unit.source_backend)
+        if (
+            include_paths
+            and not source_supports_include_paths
+            and unit.source_backend not in include_path_forwarding_diagnostics
+        ):
+            setup_diagnostics.append(
+                _frontend_include_path_forwarding_diagnostic(
+                    unit,
+                    len(include_paths),
+                )
+            )
+            include_path_forwarding_diagnostics.add(unit.source_backend)
+
+        first_job = True
+        for target in targets:
+            for job in _project_translation_jobs_for_target(
+                config,
+                unit,
+                target,
+                dispatch_artifacts,
+            ):
+                coordinate = _project_translation_checkpoint_coordinate(
+                    config,
+                    unit,
+                    target,
+                    job,
+                    preserve_source_suffix=preserve_source_suffix,
+                )
+                plan.append(
+                    _ProjectArtifactTranslationPlanItem(
+                        request=_ProjectArtifactTranslationRequest(
+                            unit=unit,
+                            target=target,
+                            job=job,
+                            coordinate=coordinate,
+                        ),
+                        setup_diagnostics=(
+                            tuple(setup_diagnostics) if first_job else ()
+                        ),
+                    )
+                )
+                first_job = False
+    return plan
+
+
+def _validate_project_artifact_translation_plan(
+    plan: Sequence[_ProjectArtifactTranslationPlanItem],
+) -> None:
+    paths: dict[str, Mapping[str, Any]] = {}
+    for item in plan:
+        coordinate = item.request.coordinate
+        path = str(coordinate["path"])
+        previous = paths.get(path)
+        if previous is not None:
+            raise ValueError(
+                "Project translation jobs resolve to the same artifact path "
+                f"'{path}': {dict(previous)} and {dict(coordinate)}"
+            )
+        paths[path] = coordinate
+
+
+def _translate_project_jobs_concurrently(
+    *,
+    config: ProjectConfig,
+    scan: ProjectScan,
+    targets: Sequence[str],
+    dispatch_artifacts: Mapping[str, Sequence[tuple[int, DispatchArtifactJob]]],
+    include_paths: Sequence[str],
+    preserve_source_suffix: set[tuple[str, str]],
+    format_output: bool,
+    output_dir_blocked: bool,
+    max_workers: int,
+    checkpoint_run: _ProjectTranslationCheckpointRun,
+    artifacts: list[dict[str, Any]],
+    diagnostics: list[ProjectDiagnostic],
+) -> None:
+    plan = _project_artifact_translation_plan(
+        config,
+        scan.units,
+        targets,
+        dispatch_artifacts,
+        include_paths=include_paths,
+        preserve_source_suffix=preserve_source_suffix,
+    )
+    _validate_project_artifact_translation_plan(plan)
+    if not plan:
+        return
+
+    restored_results: dict[int, _ProjectArtifactTranslationResult] = {}
+    pending_indices: list[int] = []
+    for index, item in enumerate(plan):
+        restored_completion = checkpoint_run.restore(
+            item.request.coordinate,
+            config=config,
+            unit=item.request.unit,
+        )
+        if restored_completion is None:
+            pending_indices.append(index)
+            continue
+        restored_artifacts, restored_diagnostics = restored_completion
+        restored_results[index] = _ProjectArtifactTranslationResult(
+            artifacts=tuple(restored_artifacts),
+            diagnostics=tuple(restored_diagnostics),
+        )
+
+    context = _ProjectTranslationWorkerContext(
+        config=config,
+        dispatch_artifact_plan=scan.dispatch_artifact_plan,
+        preserve_source_suffix=frozenset(preserve_source_suffix),
+        format_output=format_output,
+        output_dir_blocked=output_dir_blocked,
+    )
+    executor: ProcessPoolExecutor | None = None
+    futures: dict[int, Future[_ProjectArtifactTranslationResult]] = {}
+    next_pending = 0
+
+    def submit_available() -> None:
+        nonlocal next_pending
+        if executor is None:
+            return
+        while len(futures) < max_workers and next_pending < len(pending_indices):
+            index = pending_indices[next_pending]
+            futures[index] = executor.submit(
+                _run_project_translation_worker,
+                plan[index].request,
+            )
+            next_pending += 1
+
+    if pending_indices:
+        executor = ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=get_context("spawn"),
+            initializer=_initialize_project_translation_worker,
+            initargs=(context,),
+        )
+        submit_available()
+
+    try:
+        for index, item in enumerate(plan):
+            diagnostics.extend(item.setup_diagnostics)
+            result = restored_results.get(index)
+            if result is None:
+                checkpoint_run.activate(item.request.coordinate)
+                future = futures.pop(index)
+                result = future.result()
+                checkpoint_run.complete(
+                    item.request.coordinate,
+                    result.artifacts,
+                    result.diagnostics,
+                )
+                submit_available()
+            artifacts.extend(result.artifacts)
+            diagnostics.extend(result.diagnostics)
+    except BaseException:
+        for future in futures.values():
+            future.cancel()
+        raise
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=True)
 
 
 def _validate_project_translation_checkpoint_path(
@@ -24776,6 +25054,54 @@ def _finalize_project_generated_artifact(
     return records, diagnostics
 
 
+def _finalize_project_translation(
+    *,
+    config: ProjectConfig,
+    scan: ProjectScan,
+    selected_targets: Sequence[str],
+    artifacts: Sequence[dict[str, Any]],
+    diagnostics: list[ProjectDiagnostic],
+    validate: bool,
+    run_toolchains: bool,
+    translation_variants: Mapping[tuple[str, str], Sequence[str | None]],
+) -> ProjectPortabilityReport:
+    validation = (
+        _validate_artifacts(artifacts, selected_targets, config)
+        if validate or run_toolchains
+        else {"toolchains": [], "artifacts": []}
+    )
+    if run_toolchains:
+        toolchain_runs = _run_toolchain_smoke(artifacts, config.root)
+        validation["toolchainRuns"] = toolchain_runs
+        validation["_diagnostics"].extend(_toolchain_run_diagnostics(toolchain_runs))
+    diagnostics.extend(validation.pop("_diagnostics", []))
+    return ProjectPortabilityReport(
+        config=config,
+        targets=selected_targets,
+        units=scan.units,
+        skipped=scan.skipped,
+        native_directives=scan.native_directives,
+        artifacts=artifacts,
+        diagnostics=diagnostics,
+        validation=validation,
+        migration_actions=_project_migration_actions(
+            config,
+            scan.units,
+            selected_targets,
+            artifacts,
+        ),
+        artifact_matrix=_artifact_matrix_report(
+            config,
+            scan.units,
+            selected_targets,
+            config.variants,
+            artifacts,
+            variants_by_source_target=translation_variants,
+        ),
+        dispatch_artifact_plan=scan.dispatch_artifact_plan,
+    )
+
+
 def translate_project(
     config_or_root: ProjectConfig | str | os.PathLike[str],
     *,
@@ -24788,6 +25114,7 @@ def translate_project(
     checkpoint_path: str | os.PathLike[str] | None = None,
     resume: bool = False,
     checkpoint_interval_jobs: int = 1,
+    max_workers: int = 1,
 ) -> ProjectPortabilityReport:
     """Translate all discovered project units to one or more target backends."""
     resume = _bool_arg(resume, field_name="resume")
@@ -24804,6 +25131,8 @@ def translate_project(
         raise ValueError("checkpoint_interval_jobs must be a positive integer")
     if checkpoint_path is None and checkpoint_interval_jobs != 1:
         raise ValueError("checkpoint_interval_jobs requires checkpoint_path")
+    if type(max_workers) is not int or max_workers <= 0:
+        raise ValueError("max_workers must be a positive integer")
     checkpoint_run = _ProjectTranslationCheckpointRun(
         path=checkpoint_path,
         resume=resume,
@@ -24818,6 +25147,7 @@ def translate_project(
             format_output=format_output,
             validate=validate,
             run_toolchains=run_toolchains,
+            max_workers=max_workers,
             checkpoint_run=checkpoint_run,
         )
         checkpoint_run.finish(report)
@@ -24836,7 +25166,14 @@ def _translate_project_impl(
     format_output: bool,
     validate: bool,
     run_toolchains: bool,
+    max_workers: int,
     checkpoint_run: _ProjectTranslationCheckpointRun,
+    scan_override: ProjectScan | None = None,
+    translation_job_override: _ProjectArtifactTranslationRequest | None = None,
+    preserve_source_suffix_override: frozenset[tuple[str, str]] | None = None,
+    suppress_forwarding_diagnostics: bool = False,
+    suppress_target_diagnostics: bool = False,
+    output_dir_blocked_override: bool | None = None,
 ) -> ProjectPortabilityReport:
     format_output = _bool_arg(format_output, field_name="format_output")
     validate = _bool_arg(validate, field_name="validate")
@@ -24884,30 +25221,46 @@ def _translate_project_impl(
     if not selected_targets:
         selected_targets = ["cgl"]
 
-    scan = scan_project(config)
+    scan = scan_override if scan_override is not None else scan_project(config)
     config = scan.config
     diagnostics: list[ProjectDiagnostic] = list(scan.diagnostics)
-    diagnostics.extend(_target_diagnostics(config, selected_targets))
+    if not suppress_target_diagnostics:
+        diagnostics.extend(_target_diagnostics(config, selected_targets))
     artifacts: list[dict[str, Any]] = []
     include_paths = _frontend_include_dirs(config)
-    output_dir_blocked = _has_error_diagnostic(
-        diagnostics, OUTPUT_DIR_OUTSIDE_PROJECT_CODE
+    output_dir_blocked = (
+        output_dir_blocked_override
+        if output_dir_blocked_override is not None
+        else _has_error_diagnostic(diagnostics, OUTPUT_DIR_OUTSIDE_PROJECT_CODE)
     )
 
     variant_jobs = _variant_jobs(config)
     dispatch_artifacts = _dispatch_artifacts_by_source(scan.dispatch_artifact_plan)
-    translation_variants = _project_translation_variants_by_source_target(
-        config,
-        scan.units,
-        selected_targets,
-        dispatch_artifacts,
+    translation_variants = (
+        {
+            (
+                translation_job_override.unit.relative_path,
+                translation_job_override.target,
+            ): (translation_job_override.job.variant,)
+        }
+        if translation_job_override is not None
+        else _project_translation_variants_by_source_target(
+            config,
+            scan.units,
+            selected_targets,
+            dispatch_artifacts,
+        )
     )
     max_define_count = max(
         (len(defines) for _variant, defines in variant_jobs), default=0
     )
     define_forwarding_diagnostics: set[str] = set()
     include_path_forwarding_diagnostics: set[str] = set()
-    preserve_source_suffix = _artifact_source_suffix_pairs(scan.units, selected_targets)
+    preserve_source_suffix = (
+        set(preserve_source_suffix_override)
+        if preserve_source_suffix_override is not None
+        else _artifact_source_suffix_pairs(scan.units, selected_targets)
+    )
     if checkpoint_run.path is not None:
         checkpoint_jobs = _project_translation_checkpoint_jobs(
             config,
@@ -24930,7 +25283,38 @@ def _translate_project_impl(
             diagnostics,
         )
 
-    for unit in scan.units:
+    if max_workers > 1 and translation_job_override is None:
+        _translate_project_jobs_concurrently(
+            config=config,
+            scan=scan,
+            targets=selected_targets,
+            dispatch_artifacts=dispatch_artifacts,
+            include_paths=include_paths,
+            preserve_source_suffix=preserve_source_suffix,
+            format_output=format_output,
+            output_dir_blocked=output_dir_blocked,
+            max_workers=max_workers,
+            checkpoint_run=checkpoint_run,
+            artifacts=artifacts,
+            diagnostics=diagnostics,
+        )
+        return _finalize_project_translation(
+            config=config,
+            scan=scan,
+            selected_targets=selected_targets,
+            artifacts=artifacts,
+            diagnostics=diagnostics,
+            validate=validate,
+            run_toolchains=run_toolchains,
+            translation_variants=translation_variants,
+        )
+
+    translation_units = (
+        (translation_job_override.unit,)
+        if translation_job_override is not None
+        else scan.units
+    )
+    for unit in translation_units:
         required_capabilities = _required_capabilities_for_unit(unit)
         source_supports_defines = _source_frontend_supports_lexer_keyword(
             unit.source_backend, "defines"
@@ -24939,7 +25323,8 @@ def _translate_project_impl(
             unit.source_backend, "include_paths"
         )
         if (
-            max_define_count > 0
+            not suppress_forwarding_diagnostics
+            and max_define_count > 0
             and not source_supports_defines
             and unit.source_backend not in define_forwarding_diagnostics
         ):
@@ -24948,7 +25333,8 @@ def _translate_project_impl(
             )
             define_forwarding_diagnostics.add(unit.source_backend)
         if (
-            include_paths
+            not suppress_forwarding_diagnostics
+            and include_paths
             and not source_supports_include_paths
             and unit.source_backend not in include_path_forwarding_diagnostics
         ):
@@ -24959,12 +25345,21 @@ def _translate_project_impl(
                 )
             )
             include_path_forwarding_diagnostics.add(unit.source_backend)
-        for target in selected_targets:
-            translation_jobs = _project_translation_jobs_for_target(
-                config,
-                unit,
-                target,
-                dispatch_artifacts,
+        translation_targets = (
+            (translation_job_override.target,)
+            if translation_job_override is not None
+            else selected_targets
+        )
+        for target in translation_targets:
+            translation_jobs = (
+                (translation_job_override.job,)
+                if translation_job_override is not None
+                else _project_translation_jobs_for_target(
+                    config,
+                    unit,
+                    target,
+                    dispatch_artifacts,
+                )
             )
             for translation_job in translation_jobs:
                 variant = translation_job.variant
@@ -25656,37 +26051,15 @@ def _translate_project_impl(
                     diagnostics[checkpoint_diagnostic_start:],
                 )
 
-    validation = (
-        _validate_artifacts(artifacts, selected_targets, config)
-        if validate or run_toolchains
-        else {"toolchains": [], "artifacts": []}
-    )
-    if run_toolchains:
-        toolchain_runs = _run_toolchain_smoke(artifacts, config.root)
-        validation["toolchainRuns"] = toolchain_runs
-        validation["_diagnostics"].extend(_toolchain_run_diagnostics(toolchain_runs))
-    diagnostics.extend(validation.pop("_diagnostics", []))
-    return ProjectPortabilityReport(
+    return _finalize_project_translation(
         config=config,
-        targets=selected_targets,
-        units=scan.units,
-        skipped=scan.skipped,
-        native_directives=scan.native_directives,
+        scan=scan,
+        selected_targets=selected_targets,
         artifacts=artifacts,
         diagnostics=diagnostics,
-        validation=validation,
-        migration_actions=_project_migration_actions(
-            config, scan.units, selected_targets, artifacts
-        ),
-        artifact_matrix=_artifact_matrix_report(
-            config,
-            scan.units,
-            selected_targets,
-            config.variants,
-            artifacts,
-            variants_by_source_target=translation_variants,
-        ),
-        dispatch_artifact_plan=scan.dispatch_artifact_plan,
+        validate=validate,
+        run_toolchains=run_toolchains,
+        translation_variants=translation_variants,
     )
 
 

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -4514,9 +4514,19 @@ def _derived_line_source_map_mappings(
 
 
 def _artifact_report_path(path: Path, config: ProjectConfig) -> str:
-    return (
-        _relpath(path, config.root) if _is_relative_to(path, config.root) else str(path)
-    )
+    absolute_path = Path(os.path.abspath(path))
+    absolute_root = Path(os.path.abspath(config.root))
+    try:
+        return absolute_path.relative_to(absolute_root).as_posix()
+    except ValueError:
+        pass
+
+    resolved_path = Path(os.path.realpath(path))
+    resolved_root = Path(os.path.realpath(config.root))
+    try:
+        return resolved_path.relative_to(resolved_root).as_posix()
+    except ValueError:
+        return str(path)
 
 
 def _diagnostic_counts(diagnostics: Sequence[ProjectDiagnostic]) -> dict[str, int]:

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -201,6 +201,44 @@ Vulkan smoke checks validate binary ``.spv`` artifacts with ``spirv-val`` and
 assemble textual ``.spvasm`` artifacts with ``spirv-as -o`` pointed at the
 platform null device.
 
+Bounded Translation Concurrency
+-------------------------------
+
+Project translation is sequential by default. Use ``--workers`` to run
+independent artifact jobs in isolated processes:
+
+.. code-block:: bash
+
+   python -m crosstl translate-project /path/to/repo \
+     --target directx \
+     --target opengl \
+     --output-dir crosstl-out \
+     --report crosstl-out/portability-report.json \
+     --workers 2
+
+Python callers use the corresponding ``max_workers`` argument to
+``translate_project``. The value must be a positive integer; ``1`` retains the
+sequential path.
+
+At most ``N`` jobs are submitted at once. Each worker translates one planned
+unit, target, variant, and selected entry combination in a separate process so
+mutable frontend and generator state is not shared between concurrent jobs.
+The parent process consumes results in the deterministic project plan order,
+writes checkpoint completions in that order, and assembles diagnostics,
+artifacts, and the artifact matrix with the same ordering as a sequential run.
+Artifact validation and optional toolchain smoke checks run only after all
+translation jobs have returned, avoiding nested toolchain concurrency.
+
+An interruption stops further submission, cancels work that has not started,
+waits for already running workers to finish, and leaves completed checkpoint
+records available for a verified resume. Outputs from an unrecorded interrupted
+job are not trusted by resume and may be replaced when that job runs again.
+
+Spawned workers independently load installed backends and plugins. A backend
+registered only in the current Python process is not inherited on every
+platform; use ``max_workers=1`` or install that backend through the supported
+plugin discovery mechanism.
+
 Checkpointing Long Runs
 -----------------------
 

--- a/support/features.json
+++ b/support/features.json
@@ -7195,7 +7195,7 @@
       "support": {
         "directx": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7208,12 +7208,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "opengl": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7229,12 +7231,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_explicit_template_instantiation_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_translate_project_target_template_variant_manifest_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "metal": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7247,12 +7251,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "vulkan": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7265,12 +7271,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "cuda": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7283,12 +7291,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "hip": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7301,12 +7311,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "mojo": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7319,12 +7331,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "rust": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7337,12 +7351,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "slang": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7355,12 +7371,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "webgl": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7373,12 +7391,14 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         },
         "wgsl": {
           "status": "supported",
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "evidence": [
             "tests/test_translator/test_project_translation.py::def test_translate_project_preserves_relative_paths_and_reports_artifacts",
             "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_writes_report",
@@ -7391,7 +7411,9 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ]
         }
       }

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -2401,9 +2401,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "metal": {
@@ -2419,9 +2421,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "opengl": {
@@ -2440,9 +2444,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_explicit_template_instantiation_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_translate_project_target_template_variant_manifest_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         }
       }

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -2552,9 +2552,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "directx": {
@@ -2570,9 +2572,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "hip": {
@@ -2588,9 +2592,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "metal": {
@@ -2606,9 +2612,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "mojo": {
@@ -2624,9 +2632,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "opengl": {
@@ -2645,9 +2655,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_explicit_template_instantiation_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_translate_project_target_template_variant_manifest_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "rust": {
@@ -2663,9 +2675,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "slang": {
@@ -2681,9 +2695,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "vulkan": {
@@ -2699,9 +2715,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "webgl": {
@@ -2717,9 +2735,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "wgsl": {
@@ -2735,9 +2755,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         }
       }

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -8976,9 +8976,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "directx": {
@@ -8994,9 +8996,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "hip": {
@@ -9012,9 +9016,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "metal": {
@@ -9030,9 +9036,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "mojo": {
@@ -9048,9 +9056,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "opengl": {
@@ -9069,9 +9079,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_explicit_template_instantiation_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_translate_project_target_template_variant_manifest_materializes_for_opengl",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "rust": {
@@ -9087,9 +9099,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "slang": {
@@ -9105,9 +9119,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "vulkan": {
@@ -9123,9 +9139,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "webgl": {
@@ -9141,9 +9159,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         },
         "wgsl": {
@@ -9159,9 +9179,11 @@
             "tests/test_translator/test_project_translation.py::def test_translate_project_rejects_output_dir_outside_project_without_writing",
             "tests/test_translator/test_project_translation.py::def test_translate_project_honors_source_backend_overrides",
             "tests/test_translator/test_project_translation.py::def test_project_cli_inspect_report_text_reports_artifact_matrix_gaps",
-            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides"
+            "tests/test_translator/test_project_translation.py::def test_project_cli_translate_project_applies_source_root_overrides",
+            "tests/test_translator/test_project_translation_concurrency.py::def test_parallel_translation_matches_sequential_artifacts_and_order",
+            "docs/source/project-porting.rst"
           ],
-          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support.",
+          "notes": "The project pipeline batches discovered units through the existing single-file translator, normalizes duplicate explicit targets, rejects empty CLI target overrides, applies source backend overrides and command-scoped source-root overrides, preserves repository-relative target and variant output paths, refuses to write artifacts outside the repository, records unsupported target diagnostics and per-artifact failures, records artifact matrix emitted, translated, failed, missing, extra, and completion counts with target and variant rollups, and has real translator coverage for multiple units, all supported target backends, and variants. External corpus coverage is tracked separately from core batch translation support. Opt-in bounded process workers isolate artifact jobs, cap in-flight work, preserve canonical artifact, diagnostic, and checkpoint ordering, and defer validation and toolchain checks to the parent process; sequential execution remains the default.",
           "status": "supported"
         }
       }

--- a/tests/test_translator/test_project_dispatch_artifact_generation.py
+++ b/tests/test_translator/test_project_dispatch_artifact_generation.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import shutil
 import textwrap
 
 import pytest
@@ -228,6 +229,32 @@ def test_directx_and_opengl_generate_only_source_scoped_dispatch_artifacts(tmp_p
     report_path = root / "generated" / "report.json"
     report.write_json(report_path)
     assert validate_project_report(report_path)["success"] is True
+
+
+def test_parallel_dispatch_artifacts_match_sequential_translation(tmp_path):
+    root, config = _write_project(tmp_path)
+
+    sequential = translate_project(config, format_output=False).to_json()
+    sequential_sources = {
+        artifact["path"]: (root / artifact["path"]).read_text(encoding="utf-8")
+        for artifact in sequential["artifacts"]
+    }
+    shutil.rmtree(root / "generated")
+
+    parallel = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+    ).to_json()
+    parallel_sources = {
+        artifact["path"]: (root / artifact["path"]).read_text(encoding="utf-8")
+        for artifact in parallel["artifacts"]
+    }
+
+    assert parallel["artifacts"] == sequential["artifacts"]
+    assert parallel["diagnostics"] == sequential["diagnostics"]
+    assert parallel["artifactMatrix"] == sequential["artifactMatrix"]
+    assert parallel_sources == sequential_sources
 
 
 def test_directx_dispatch_artifact_uses_entry_scoped_target_name(tmp_path):

--- a/tests/test_translator/test_project_translation.py
+++ b/tests/test_translator/test_project_translation.py
@@ -19599,7 +19599,7 @@ def test_translate_project_batches_real_units_targets_and_variants(tmp_path):
         encoding="utf-8",
     )
 
-    report = translate_project(load_project_config(repo))
+    report = translate_project(load_project_config(repo), max_workers=2)
     payload = report.to_json()
     report_path = repo / "translated" / "portability-report.json"
     report.write_json(report_path)

--- a/tests/test_translator/test_project_translation_concurrency.py
+++ b/tests/test_translator/test_project_translation_concurrency.py
@@ -1,0 +1,406 @@
+import shutil
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+import crosstl._crosstl as crosstl_cli
+import crosstl.project as project_api
+import crosstl.project.pipeline as project_pipeline
+from crosstl.project import ProjectConfig, translate_project
+from crosstl.project.translation_checkpoint import (
+    ProjectTranslationCheckpointRecorder,
+    load_project_translation_checkpoint,
+)
+
+SIMPLE_CROSSL = textwrap.dedent("""
+    shader ConcurrentShader {
+        struct VertexInput {
+            vec3 position;
+        }
+
+        struct VertexOutput {
+            vec4 position;
+        }
+
+        vertex {
+            VertexOutput main(VertexInput input) {
+                VertexOutput output;
+                output.position = vec4(input.position, 1.0);
+                return output;
+            }
+        }
+    }
+    """).strip()
+
+MULTI_ENTRY_METAL = textwrap.dedent("""
+    #include <metal_stdlib>
+    using namespace metal;
+
+    kernel void first(
+        device float* output [[buffer(0)]],
+        uint index [[thread_position_in_grid]]
+    ) {
+        output[index] = float(index);
+    }
+
+    kernel void second(
+        device float* output [[buffer(0)]],
+        uint index [[thread_position_in_grid]]
+    ) {
+        output[index] = float(index) + 1.0f;
+    }
+    """).strip()
+
+
+def _write_project(root, *, unit_count=2):
+    root.mkdir()
+    for index in range(unit_count):
+        (root / f"shader-{index}.cgl").write_text(
+            SIMPLE_CROSSL,
+            encoding="utf-8",
+        )
+
+
+def _artifact_sources(root, payload):
+    return {
+        artifact["path"]: (root / artifact["path"]).read_text(encoding="utf-8")
+        for artifact in payload["artifacts"]
+        if artifact["status"] == "translated"
+    }
+
+
+def test_parallel_translation_matches_sequential_artifacts_and_order(tmp_path):
+    repo = tmp_path / "repo"
+    _write_project(repo)
+    config = ProjectConfig(
+        root=repo,
+        targets=("directx", "opengl"),
+        output_dir="translated",
+        variants={
+            "debug": {"MODE": "1"},
+            "release": {"MODE": "0"},
+        },
+    )
+
+    sequential = translate_project(config, format_output=False)
+    sequential_payload = sequential.to_json()
+    sequential_sources = _artifact_sources(repo, sequential_payload)
+    shutil.rmtree(repo / "translated")
+
+    parallel = translate_project(config, format_output=False, max_workers=2)
+    parallel_payload = parallel.to_json()
+    parallel_sources = _artifact_sources(repo, parallel_payload)
+
+    assert parallel_payload["artifacts"] == sequential_payload["artifacts"]
+    assert parallel_payload["diagnostics"] == sequential_payload["diagnostics"]
+    assert parallel_payload["artifactMatrix"] == sequential_payload["artifactMatrix"]
+    assert parallel_sources == sequential_sources
+    assert [
+        (artifact["source"], artifact["target"], artifact["variant"])
+        for artifact in parallel_payload["artifacts"]
+    ] == [
+        ("shader-0.cgl", "directx", "debug"),
+        ("shader-0.cgl", "directx", "release"),
+        ("shader-0.cgl", "opengl", "debug"),
+        ("shader-0.cgl", "opengl", "release"),
+        ("shader-1.cgl", "directx", "debug"),
+        ("shader-1.cgl", "directx", "release"),
+        ("shader-1.cgl", "opengl", "debug"),
+        ("shader-1.cgl", "opengl", "release"),
+    ]
+
+
+def test_parallel_translation_preserves_failure_order(tmp_path):
+    repo = tmp_path / "repo"
+    _write_project(repo)
+    (repo / "shader-0.cgl").write_text(
+        "shader Broken { vertex { void main( { } }",
+        encoding="utf-8",
+    )
+    config = ProjectConfig(
+        root=repo,
+        targets=("directx", "opengl"),
+        output_dir="translated",
+    )
+
+    sequential = translate_project(config, format_output=False).to_json()
+    shutil.rmtree(repo / "translated")
+    parallel = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+    ).to_json()
+
+    assert parallel["artifacts"] == sequential["artifacts"]
+    assert parallel["diagnostics"] == sequential["diagnostics"]
+    assert parallel["summary"]["failedCount"] == 2
+    assert parallel["summary"]["translatedCount"] == 2
+
+
+def test_parallel_translation_does_not_duplicate_target_diagnostics(tmp_path):
+    repo = tmp_path / "repo"
+    _write_project(repo)
+    config = ProjectConfig(
+        root=repo,
+        targets=("unsupported-target",),
+        output_dir="translated",
+    )
+
+    sequential = translate_project(config, format_output=False).to_json()
+    parallel = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+    ).to_json()
+
+    assert parallel["artifacts"] == sequential["artifacts"]
+    assert parallel["diagnostics"] == sequential["diagnostics"]
+    assert (
+        parallel["summary"]["diagnosticsByCode"]["project.config.unsupported-target"]
+        == 1
+    )
+
+
+def test_parallel_translation_preserves_entry_scoped_metal_artifacts(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "kernels.metal").write_text(MULTI_ENTRY_METAL, encoding="utf-8")
+    config = ProjectConfig(
+        root=repo,
+        targets=("directx", "opengl"),
+        output_dir="translated",
+        entry_points={"kernels.metal": ("first", "second")},
+        include_dirs=(".",),
+    )
+
+    sequential = translate_project(config, format_output=False).to_json()
+    sequential_sources = _artifact_sources(repo, sequential)
+    shutil.rmtree(repo / "translated")
+    parallel = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+    ).to_json()
+
+    assert parallel["artifacts"] == sequential["artifacts"]
+    assert parallel["diagnostics"] == sequential["diagnostics"]
+    assert _artifact_sources(repo, parallel) == sequential_sources
+    assert [
+        (
+            artifact["target"],
+            artifact["entryPoint"]["source"],
+            artifact["entryPoint"]["target"],
+        )
+        for artifact in parallel["artifacts"]
+    ] == [
+        ("directx", "first", "CSMain"),
+        ("directx", "second", "CSMain"),
+        ("opengl", "first", "main"),
+        ("opengl", "second", "main"),
+    ]
+
+
+def test_parallel_translation_checkpoint_is_coordinated_in_plan_order(tmp_path):
+    repo = tmp_path / "repo"
+    _write_project(repo)
+    checkpoint_path = tmp_path / "translation-checkpoint.json"
+
+    translate_project(
+        ProjectConfig(
+            root=repo,
+            targets=("directx", "opengl"),
+            output_dir="translated",
+        ),
+        format_output=False,
+        max_workers=2,
+        checkpoint_path=checkpoint_path,
+    )
+
+    checkpoint = load_project_translation_checkpoint(checkpoint_path)
+
+    assert checkpoint["state"] == "complete"
+    assert checkpoint["plan"]["active"] is None
+    assert checkpoint["plan"]["completedCount"] == 4
+    assert [
+        completion["coordinate"] for completion in checkpoint["plan"]["completed"]
+    ] == checkpoint["plan"]["jobs"]
+
+
+def test_parallel_translation_resumes_verified_checkpoint_completions(tmp_path):
+    repo = tmp_path / "repo"
+    _write_project(repo)
+    checkpoint_path = tmp_path / "translation-checkpoint.json"
+    config = ProjectConfig(
+        root=repo,
+        targets=("directx", "opengl"),
+        output_dir="translated",
+    )
+
+    baseline = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+        checkpoint_path=checkpoint_path,
+    ).to_json()
+    complete_checkpoint = load_project_translation_checkpoint(checkpoint_path)
+    initial_count = complete_checkpoint["initialDiagnosticCount"]
+    recorder = ProjectTranslationCheckpointRecorder(
+        checkpoint_path,
+        complete_checkpoint["projectIdentity"],
+        complete_checkpoint["plan"]["jobs"],
+        started_at=complete_checkpoint["startedAt"],
+        completed=complete_checkpoint["plan"]["completed"][:2],
+        initial_diagnostics=complete_checkpoint["diagnostics"][:initial_count],
+    )
+    recorder.write_interrupted(None, RuntimeError("translation interrupted"))
+
+    resumed = translate_project(
+        config,
+        format_output=False,
+        max_workers=2,
+        checkpoint_path=checkpoint_path,
+        resume=True,
+    ).to_json()
+    resumed_checkpoint = load_project_translation_checkpoint(checkpoint_path)
+
+    assert resumed["artifacts"] == baseline["artifacts"]
+    assert resumed["diagnostics"] == baseline["diagnostics"]
+    assert resumed_checkpoint["state"] == "complete"
+    assert resumed_checkpoint["plan"]["completedCount"] == 4
+
+
+def test_parallel_translation_bounds_submitted_work(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _write_project(repo, unit_count=5)
+    executor_state = {"outstanding": 0, "maximum": 0, "submitted": 0}
+
+    class TrackingFuture:
+        def __init__(self, result):
+            self._result = result
+            self._resolved = False
+
+        def result(self):
+            if not self._resolved:
+                executor_state["outstanding"] -= 1
+                self._resolved = True
+            return self._result
+
+        def cancel(self):
+            return False
+
+    class TrackingExecutor:
+        def __init__(self, *, initializer, initargs, **_kwargs):
+            initializer(*initargs)
+
+        def submit(self, function, *args):
+            executor_state["outstanding"] += 1
+            executor_state["submitted"] += 1
+            executor_state["maximum"] = max(
+                executor_state["maximum"],
+                executor_state["outstanding"],
+            )
+            return TrackingFuture(function(*args))
+
+        def shutdown(self, *, wait):
+            assert wait is True
+
+    monkeypatch.setattr(
+        project_pipeline,
+        "ProcessPoolExecutor",
+        TrackingExecutor,
+    )
+
+    report = translate_project(
+        ProjectConfig(
+            root=repo,
+            targets=("directx",),
+            output_dir="translated",
+        ),
+        format_output=False,
+        max_workers=2,
+    ).to_json()
+
+    assert report["summary"]["translatedCount"] == 5
+    assert executor_state == {
+        "outstanding": 0,
+        "maximum": 2,
+        "submitted": 5,
+    }
+
+
+def test_parallel_translation_rejects_output_path_collisions(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    _write_project(repo, unit_count=1)
+    job = project_pipeline._ProjectArtifactTranslationJob(
+        variant=None,
+        defines={},
+        entry_point=None,
+    )
+    monkeypatch.setattr(
+        project_pipeline,
+        "_project_translation_jobs_for_target",
+        lambda *_args, **_kwargs: [job, job],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Project translation jobs resolve to the same artifact path",
+    ):
+        translate_project(
+            ProjectConfig(
+                root=repo,
+                targets=("directx",),
+                output_dir="translated",
+            ),
+            format_output=False,
+            max_workers=2,
+        )
+
+    assert not (repo / "translated").exists()
+
+
+@pytest.mark.parametrize("value", (0, -1, True, 1.5, "2"))
+def test_translate_project_rejects_invalid_max_workers(tmp_path, value):
+    repo = tmp_path / "repo"
+    _write_project(repo, unit_count=1)
+
+    with pytest.raises(
+        ValueError,
+        match="max_workers must be a positive integer",
+    ):
+        translate_project(repo, max_workers=value)
+
+
+def test_translate_project_cli_forwards_workers(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    observed = {}
+    payload = {
+        "kind": project_pipeline.REPORT_KIND,
+        "summary": {"failedCount": 0, "diagnosticCounts": {"error": 0}},
+    }
+
+    def fake_translate_project(config, **kwargs):
+        observed["root"] = config.root
+        observed.update(kwargs)
+        return SimpleNamespace(to_json=lambda: payload)
+
+    monkeypatch.setattr(project_api, "translate_project", fake_translate_project)
+
+    exit_code = crosstl_cli.main(
+        [
+            "translate-project",
+            str(repo),
+            "--workers",
+            "3",
+        ]
+    )
+    capsys.readouterr()
+
+    assert exit_code == 0
+    assert observed["root"] == repo.resolve()
+    assert observed["max_workers"] == 3

--- a/tests/test_translator/test_project_translation_concurrency.py
+++ b/tests/test_translator/test_project_translation_concurrency.py
@@ -1,5 +1,6 @@
 import shutil
 import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -109,6 +110,25 @@ def test_parallel_translation_matches_sequential_artifacts_and_order(tmp_path):
         ("shader-1.cgl", "opengl", "debug"),
         ("shader-1.cgl", "opengl", "release"),
     ]
+
+
+def test_artifact_report_path_does_not_resolve_unpublished_output(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = ProjectConfig(root=repo, output_dir="translated")
+    output_path = config.output_path / "directx" / "kernel.hlsl"
+
+    def fail_resolve(*_args, **_kwargs):
+        raise AssertionError("artifact report paths must not resolve the filesystem")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    assert project_pipeline._artifact_report_path(output_path, config) == (
+        "translated/directx/kernel.hlsl"
+    )
 
 
 def test_parallel_translation_preserves_failure_order(tmp_path):


### PR DESCRIPTION
### Summary

Adds opt-in bounded process concurrency to project translation while preserving the existing sequential default and deterministic report contract.

### Related Issue

Refs #1865

Support issue traceability: no issue closed

### Changes

- Adds `translate_project(..., max_workers=N)` and `translate-project --workers N`.
- Isolates independent artifact jobs in spawned worker processes with at most `N` jobs in flight.
- Keeps artifact, diagnostic, and checkpoint completion ordering aligned with the canonical project plan.
- Keeps report assembly, artifact validation, and optional toolchain execution in the parent process.
- Rejects colliding planned output paths before concurrent translation starts.
- Covers named variants, selected Metal entries, dispatch artifact plans, failed artifacts, checkpoints, resume, queue bounds, and CLI forwarding.
- Documents worker behavior, interruption semantics, and plugin discovery constraints.
- Updates batch-translation support evidence and generated support artifacts.

### Testing

- `.venv/bin/python -m pytest -n auto -q`
  - 17,159 passed, 223 skipped
- Project translation regression surface
  - 1,267 passed
- Pinned MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`
  - `binary.metal`
  - DirectX and OpenGL
  - `ss_Addfloat32` and `vv_Addfloat32`
  - Four translated artifacts, zero failures, zero diagnostics
  - Identical generated sizes with one and two workers
- `tools/support_matrix.py check`
- `tools/support_signals.py check`
- `tools/sync_support_issues.py --dry-run --repo CrossGL/crosstl`
- `.venv/bin/pre-commit run --all-files`

### Checklist

- [x] Tests cover new or changed code
- [ ] Linked the issue with a closing keyword (not applicable; #1865 remains open)
- [x] Added `Support issue traceability: no issue closed`
- [x] Only touched files related to the issue
- [x] Everything builds and runs locally
