### PR TITLE
Terminate interrupted project translation workers

### DIFF
--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import uuid
 from collections import Counter, deque
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass, field, replace
@@ -9660,6 +9661,7 @@ class _ProjectTranslationWorkerContext:
     preserve_source_suffix: frozenset[tuple[str, str]]
     format_output: bool
     output_dir_blocked: bool
+    publication_staging_token: str
 
 
 _PROJECT_TRANSLATION_WORKER_CONTEXT: _ProjectTranslationWorkerContext | None = None
@@ -9706,6 +9708,7 @@ def _run_project_translation_worker(
             suppress_target_diagnostics=True,
             output_dir_blocked_override=context.output_dir_blocked,
             deferred_publications=deferred_publications,
+            publication_staging_token=context.publication_staging_token,
         )
     except BaseException:
         for publication in deferred_publications:
@@ -10147,6 +10150,56 @@ def _cleanup_project_artifact_translation_result(
         _cleanup_deferred_project_artifact_publication(publication)
 
 
+def _terminate_project_translation_executor(executor: ProcessPoolExecutor) -> None:
+    terminate_workers = getattr(executor, "terminate_workers", None)
+    if callable(terminate_workers):
+        terminate_workers()
+        executor.shutdown(wait=True)
+        return
+
+    # Python releases before 3.14 expose no public force-stop operation.
+    processes = getattr(executor, "_processes", None)
+    if isinstance(processes, Mapping):
+        for process in tuple(processes.values()):
+            try:
+                if process.is_alive():
+                    process.terminate()
+            except Exception:
+                continue
+    executor.shutdown(wait=True)
+
+
+def _cleanup_project_translation_staging_for_requests(
+    config: ProjectConfig,
+    requests: Iterable[_ProjectArtifactTranslationRequest],
+    *,
+    staging_token: str,
+) -> None:
+    searched: set[tuple[Path, str]] = set()
+    for request in requests:
+        report_path = request.coordinate.get("path")
+        if not isinstance(report_path, str) or not report_path:
+            continue
+        output_path = Path(report_path)
+        if not output_path.is_absolute():
+            output_path = config.root / output_path
+        key = (output_path.parent, output_path.name)
+        if key in searched:
+            continue
+        searched.add(key)
+        staging_prefix = f".{output_path.name}.{staging_token}."
+        try:
+            candidates = tuple(output_path.parent.iterdir())
+        except OSError:
+            continue
+        for staging_directory in candidates:
+            if not staging_directory.name.startswith(
+                staging_prefix
+            ) or not staging_directory.name.endswith(".tmp"):
+                continue
+            shutil.rmtree(staging_directory, ignore_errors=True)
+
+
 def _publish_project_artifact_translation_result(
     config: ProjectConfig,
     request: _ProjectArtifactTranslationRequest,
@@ -10257,10 +10310,14 @@ def _translate_project_jobs_concurrently(
         preserve_source_suffix=frozenset(preserve_source_suffix),
         format_output=format_output,
         output_dir_blocked=output_dir_blocked,
+        publication_staging_token=uuid.uuid4().hex,
     )
     executor: ProcessPoolExecutor | None = None
     scheduled: deque[_ScheduledProjectArtifactTranslation] = deque()
-    unconsumed_futures: set[Future[_ProjectArtifactTranslationResult]] = set()
+    unconsumed_futures: dict[
+        Future[_ProjectArtifactTranslationResult],
+        _ProjectArtifactTranslationRequest,
+    ] = {}
     plan_exhausted = False
 
     def schedule_available() -> None:
@@ -10299,7 +10356,7 @@ def _translate_project_jobs_concurrently(
                 _run_project_translation_worker,
                 item.request,
             )
-            unconsumed_futures.add(future)
+            unconsumed_futures[future] = item.request
             scheduled.append(
                 _ScheduledProjectArtifactTranslation(item=item, future=future)
             )
@@ -10330,7 +10387,7 @@ def _translate_project_jobs_concurrently(
                     item.request,
                     result,
                 )
-                unconsumed_futures.discard(future)
+                unconsumed_futures.pop(future, None)
                 checkpoint_run.complete(
                     item.request.coordinate,
                     result.artifacts,
@@ -10343,6 +10400,15 @@ def _translate_project_jobs_concurrently(
         for scheduled_item in scheduled:
             if scheduled_item.future is not None:
                 scheduled_item.future.cancel()
+        if executor is not None:
+            try:
+                _terminate_project_translation_executor(executor)
+            except Exception:
+                try:
+                    executor.shutdown(wait=True)
+                except Exception:
+                    pass
+            executor = None
         raise
     finally:
         try:
@@ -10350,6 +10416,11 @@ def _translate_project_jobs_concurrently(
                 executor.shutdown(wait=True)
         finally:
             _cleanup_unconsumed_project_translation_futures(unconsumed_futures)
+            _cleanup_project_translation_staging_for_requests(
+                config,
+                unconsumed_futures.values(),
+                staging_token=context.publication_staging_token,
+            )
 
 
 def _validate_project_translation_checkpoint_path(
@@ -25565,6 +25636,7 @@ def _translate_project_impl(
     suppress_target_diagnostics: bool = False,
     output_dir_blocked_override: bool | None = None,
     deferred_publications: list[_DeferredProjectArtifactPublication] | None = None,
+    publication_staging_token: str | None = None,
 ) -> ProjectPortabilityReport:
     format_output = _bool_arg(format_output, field_name="format_output")
     validate = _bool_arg(validate, field_name="validate")
@@ -25952,10 +26024,13 @@ def _translate_project_impl(
                 published_output_path = output_path
                 try:
                     published_output_path.parent.mkdir(parents=True, exist_ok=True)
+                    publication_staging_prefix = f".{published_output_path.name}."
+                    if publication_staging_token is not None:
+                        publication_staging_prefix += f"{publication_staging_token}."
                     publication_staging_directory = Path(
                         tempfile.mkdtemp(
                             dir=published_output_path.parent,
-                            prefix=f".{published_output_path.name}.",
+                            prefix=publication_staging_prefix,
                             suffix=".tmp",
                         )
                     )

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -236,11 +236,13 @@ Artifact validation and optional toolchain smoke checks run only after all
 translation jobs have returned, avoiding nested toolchain concurrency.
 
 An interruption stops further submission, cancels work that has not started,
-and waits for already running workers to finish in their staging directories.
-The coordinator removes staging for every unconsumed result, leaving previously
-published outputs unchanged. Completed checkpoint records remain available for
-a verified resume, and only coordinator-published results are recorded as
-complete.
+and terminates pool processes that are still translating. Each concurrent run
+adds a private token to its staging directories. After the pool settles, the
+coordinator removes unconsumed results and any token-owned staging left by a
+terminated process without touching another invocation's files. Previously
+published outputs remain unchanged. Completed checkpoint records remain
+available for a verified resume, and only coordinator-published results are
+recorded as complete.
 An ordinary worker failure raises ``ProjectTranslationWorkerError`` with the
 source, target, output path, optional entry point, original exception type, and
 original exception attached for programmatic inspection. An enabled checkpoint

--- a/tests/test_translator/test_project_translation_concurrency.py
+++ b/tests/test_translator/test_project_translation_concurrency.py
@@ -353,6 +353,113 @@ def test_parallel_translation_bounds_submitted_work(tmp_path, monkeypatch):
     }
 
 
+def test_worker_limit_one_uses_sequential_execution(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _write_project(repo, unit_count=2)
+
+    class UnexpectedExecutor:
+        def __init__(self, **_kwargs):
+            raise AssertionError("max_workers=1 must not construct a worker pool")
+
+    monkeypatch.setattr(
+        project_pipeline,
+        "ProcessPoolExecutor",
+        UnexpectedExecutor,
+    )
+
+    report = translate_project(
+        ProjectConfig(
+            root=repo,
+            targets=("directx",),
+            output_dir="translated",
+        ),
+        format_output=False,
+        max_workers=1,
+    ).to_json()
+
+    assert report["summary"]["translatedCount"] == 2
+
+
+def test_parallel_validation_starts_after_worker_pool_shutdown(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    _write_project(repo, unit_count=2)
+    executor_state = {"shutdown": False}
+    validation_state = {"artifacts": False, "toolchains": False}
+
+    class ImmediateFuture:
+        def __init__(self, result):
+            self._result = result
+
+        def result(self):
+            return self._result
+
+        def cancel(self):
+            return False
+
+    class ImmediateExecutor:
+        def __init__(self, *, initializer, initargs, **_kwargs):
+            initializer(*initargs)
+
+        def submit(self, function, request):
+            return ImmediateFuture(function(request))
+
+        def shutdown(self, *, wait):
+            assert wait is True
+            executor_state["shutdown"] = True
+
+    def validate_artifacts(_artifacts, _targets, _config):
+        assert executor_state["shutdown"] is True
+        validation_state["artifacts"] = True
+        return {
+            "toolchains": [],
+            "artifacts": [],
+            "_diagnostics": [],
+        }
+
+    def run_toolchains(_artifacts, _root):
+        assert executor_state["shutdown"] is True
+        validation_state["toolchains"] = True
+        return []
+
+    monkeypatch.setattr(
+        project_pipeline,
+        "ProcessPoolExecutor",
+        ImmediateExecutor,
+    )
+    monkeypatch.setattr(
+        project_pipeline,
+        "_validate_artifacts",
+        validate_artifacts,
+    )
+    monkeypatch.setattr(
+        project_pipeline,
+        "_run_toolchain_smoke",
+        run_toolchains,
+    )
+
+    report = translate_project(
+        ProjectConfig(
+            root=repo,
+            targets=("directx",),
+            output_dir="translated",
+        ),
+        format_output=False,
+        validate=True,
+        run_toolchains=True,
+        max_workers=2,
+    ).to_json()
+
+    assert report["summary"]["translatedCount"] == 2
+    assert executor_state["shutdown"] is True
+    assert validation_state == {
+        "artifacts": True,
+        "toolchains": True,
+    }
+
+
 def test_parallel_translation_publishes_only_when_results_are_consumed(
     tmp_path,
     monkeypatch,
@@ -436,6 +543,7 @@ def test_parallel_worker_failure_removes_deferred_staging(
         preserve_source_suffix=frozenset(),
         format_output=False,
         output_dir_blocked=False,
+        publication_staging_token="test",
     )
     monkeypatch.setattr(
         project_pipeline,
@@ -474,6 +582,59 @@ def test_worker_failure_error_reports_entry_point():
 
     assert error.original_error is original_error
     assert "entry point 'copy'" in str(error)
+
+
+def test_executor_termination_uses_supported_pool_api():
+    state = {"terminated": False, "shutdown": False}
+
+    class Executor:
+        def terminate_workers(self):
+            state["terminated"] = True
+
+        def shutdown(self, *, wait):
+            assert wait is True
+            assert state["terminated"] is True
+            state["shutdown"] = True
+
+    project_pipeline._terminate_project_translation_executor(Executor())
+
+    assert state == {
+        "terminated": True,
+        "shutdown": True,
+    }
+
+
+def test_executor_termination_supports_legacy_pool_processes():
+    state = {"terminated": [], "shutdown": False}
+
+    class Process:
+        def __init__(self, name, *, alive):
+            self.name = name
+            self.alive = alive
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            state["terminated"].append(self.name)
+
+    class Executor:
+        def __init__(self):
+            self._processes = {
+                1: Process("active", alive=True),
+                2: Process("complete", alive=False),
+            }
+
+        def shutdown(self, *, wait):
+            assert wait is True
+            state["shutdown"] = True
+
+    project_pipeline._terminate_project_translation_executor(Executor())
+
+    assert state == {
+        "terminated": ["active"],
+        "shutdown": True,
+    }
 
 
 def test_parallel_worker_failure_reports_coordinate_and_checkpoint(
@@ -585,21 +746,26 @@ def test_parallel_translation_interrupt_discards_unconsumed_staging(
         remap_path.write_bytes(f'{{"previous": {index}}}\n'.encode())
         previous_outputs[artifact_path] = artifact_path.read_bytes()
         previous_outputs[remap_path] = remap_path.read_bytes()
+    unrelated_staging = output_dir / ".shader-0.hlsl.unrelated.tmp"
+    unrelated_staging.mkdir()
 
     checkpoint_path = tmp_path / "translation-checkpoint.json"
-    executor_state = {"submitted": 0, "shutdown": False}
+    executor_state = {
+        "submitted": 0,
+        "terminated": False,
+        "shutdown": False,
+    }
 
     class InterruptingFuture:
         def __init__(self, result, *, interrupt):
             self._result = result
             self._interrupt = interrupt
-            self._result_calls = 0
 
         def result(self):
-            self._result_calls += 1
-            if self._interrupt and self._result_calls == 1:
+            if self._interrupt and not executor_state["terminated"]:
                 raise KeyboardInterrupt("translation interrupted")
-            assert executor_state["shutdown"] is True
+            if executor_state["terminated"]:
+                raise RuntimeError("worker terminated")
             return self._result
 
         def cancel(self):
@@ -607,17 +773,29 @@ def test_parallel_translation_interrupt_discards_unconsumed_staging(
 
     class InterruptingExecutor:
         def __init__(self, *, initializer, initargs, **_kwargs):
+            self._context = initargs[0]
             initializer(*initargs)
 
         def submit(self, function, request):
             executor_state["submitted"] += 1
+            result = function(request)
+            assert result.publications
+            assert all(
+                f".{self._context.publication_staging_token}."
+                in publication.staging_directory.name
+                for publication in result.publications
+            )
             return InterruptingFuture(
-                function(request),
+                result,
                 interrupt=executor_state["submitted"] == 1,
             )
 
+        def terminate_workers(self):
+            executor_state["terminated"] = True
+
         def shutdown(self, *, wait):
             assert wait is True
+            assert executor_state["terminated"] is True
             executor_state["shutdown"] = True
 
     monkeypatch.setattr(
@@ -638,9 +816,14 @@ def test_parallel_translation_interrupt_discards_unconsumed_staging(
             checkpoint_path=checkpoint_path,
         )
 
-    assert executor_state == {"submitted": 2, "shutdown": True}
+    assert executor_state == {
+        "submitted": 2,
+        "terminated": True,
+        "shutdown": True,
+    }
     assert {path: path.read_bytes() for path in previous_outputs} == previous_outputs
-    assert list(output_dir.glob(".*.tmp")) == []
+    assert list(output_dir.glob(".*.tmp")) == [unrelated_staging]
+    assert unrelated_staging.is_dir()
     checkpoint = load_project_translation_checkpoint(checkpoint_path)
     assert checkpoint["state"] == "interrupted"
     assert checkpoint["plan"]["completedCount"] == 0


### PR DESCRIPTION
## Summary

- terminate active project translation workers after interruption or coordinator failure
- scope cleanup to invocation-owned staging directories while preserving prior outputs and unrelated staging
- retain deterministic interruption coordinates and defer validation until the worker pool has shut down

## Verification

- `python -m pytest -q -n auto` (`17176 passed, 223 skipped`)
- focused project concurrency, publication, and checkpoint tests (`51 passed`)
- support matrix and support signal checks
- support evidence audit (`957/957`)
- Python 3.8 syntax validation
- `pre-commit run --all-files`

Support issue traceability: no issue closed

Related: #1865
