### PR TITLE
Prove pinned MLX quantized OpenGL lowering

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -20,6 +20,7 @@ on:
       - "tests/test_mlx_dispatch_contract_fixture.py"
       - "tests/test_mlx_layer_norm_directx_proof.py"
       - "tests/test_mlx_quantized_directx_proof.py"
+      - "tests/test_mlx_quantized_opengl_proof.py"
       - "tests/test_mlx_porting_harness.py"
       - "tests/test_translator/test_codegen/test_GLSL_codegen.py"
       - "tests/test_translator/test_codegen/test_SPIRV_codegen.py"
@@ -50,6 +51,7 @@ on:
       - "tests/test_mlx_dispatch_contract_fixture.py"
       - "tests/test_mlx_layer_norm_directx_proof.py"
       - "tests/test_mlx_quantized_directx_proof.py"
+      - "tests/test_mlx_quantized_opengl_proof.py"
       - "tests/test_mlx_porting_harness.py"
       - "tests/test_translator/test_codegen/test_GLSL_codegen.py"
       - "tests/test_translator/test_codegen/test_SPIRV_codegen.py"
@@ -275,6 +277,16 @@ jobs:
           python demos/integrations/mlx/prove_copy_opengl.py \
             --mlx-root mlx-upstream \
             --work-dir .crosstl-mlx-porting/copy-opengl
+
+      - name: Prove pinned MLX quantized OpenGL lowering
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python demos/integrations/mlx/prove_quantized_opengl.py \
+            --mlx-root mlx-upstream \
+            --work-dir .crosstl-mlx-porting/quantized-opengl \
+            --require-opengl-toolchain
 
       - name: Prove Direct3D immutable lookup numerical execution
         if: runner.os == 'Windows'

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -506,13 +506,20 @@ parameter `x_thread`. This is tracked by the cross-target fixed-array alias
 contract in [#1497](https://github.com/CrossGL/crosstl/issues/1497). No target
 artifact is emitted, so native validation is not run for this entry.
 
-A selected OpenGL replay of the same entry stops fail-closed with
-`project.translate.opengl-index-type-unsupported` at `w[in_index + i]`. The
-source index is `uint64_t`, the legal target index is `uint`, and the source
-range is unproven. [#1515](https://github.com/CrossGL/crosstl/issues/1515)
-tracks the generalized index-width normalization contract. No OpenGL target
-artifact is emitted and native validation is not run. Neither selected replay
-establishes runtime execution or numerical parity.
+The selected `affine_quantize_float_gs_32_b_2` entry also translates to a
+5,107-byte GLSL artifact with no project diagnostics. The project configuration
+supplies three source-qualified index-range assertions for `in_index + i`,
+`gindex`, and `out_index / writes_per_reduce`, each with inclusive bounds
+`[0, 2147483647]`.
+These are explicit host/runtime portability preconditions used to justify legal
+GLSL `uint` subscripts; they are not inferred or enforced at runtime. The
+generated artifact preserves the subgroup minimum, maximum, shuffle-down, and
+quantization operations. Linux CI compiles it for OpenGL/SPIR-V 1.3 with
+`glslangValidator` and validates the resulting module with `spirv-val`.
+[#1515](https://github.com/CrossGL/crosstl/issues/1515) records the completed
+general index-width normalization contract. This evidence establishes selected
+entry translation and native toolchain acceptance only. It does not establish
+OpenGL runtime integration, MLX test execution, or numerical parity.
 
 CrossGL/crosstl#1659 is complete; resource-register relocation no longer blocks
 the selected aggregate DirectX replay. The checked-in evidence also records

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -271,7 +271,7 @@
     "runtime_parity_claimed": false
   },
   "opengl_quantized_frontier_status": {
-    "status": "blocked-as-expected",
+    "status": "translated-glslang-spirv-val-validated",
     "commit": "4367c73b60541ddd5a266ce4644fd93d20223b6e",
     "source": "mlx/backend/metal/kernels/quantized.metal",
     "target": "opengl",
@@ -279,33 +279,63 @@
     "project_translation": {
       "unit_count": 1,
       "artifact_record_count": 1,
-      "translated_count": 0,
-      "failed_count": 1,
-      "emitted_target_file_count": 0,
-      "project_diagnostic_count": 1
+      "translated_count": 1,
+      "failed_count": 0,
+      "emitted_target_file_count": 1,
+      "project_diagnostic_count": 0
     },
     "materialization": {
       "reachable_specialization_count": 6,
       "concrete_specialization_count": 3,
       "pruned_candidate_count": 110861
     },
-    "diagnostic": {
-      "code": "project.translate.opengl-index-type-unsupported",
-      "missing_capability": "opengl.index-width-normalization",
-      "message": "OpenGL cannot preserve subscript index type 'uint64_t' for 'w': index range unproven",
-      "index_conversion": {
-        "indexed_value": "w",
-        "index_expression": "in_index + i",
-        "source_type": "uint64_t",
-        "target_type": "uint",
-        "range_status": "unproven",
-        "reason": "index-range-unproven"
-      }
+    "index_range_assertion_evidence": {
+      "assertion_count": 3,
+      "assertions": [
+        {
+          "source": "mlx/backend/metal/kernels/quantized.metal",
+          "expression": "in_index + i",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        {
+          "source": "mlx/backend/metal/kernels/quantized.metal",
+          "expression": "gindex",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        {
+          "source": "mlx/backend/metal/kernels/quantized.metal",
+          "expression": "out_index / writes_per_reduce",
+          "minimum": 0,
+          "maximum": 2147483647
+        }
+      ],
+      "inclusive_bounds": {
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "contract_kind": "explicit-host-runtime-portability-preconditions",
+      "inferred": false,
+      "runtime_enforced": false
     },
-    "artifact_emitted": false,
-    "native_validation_attempted": false,
-    "native_validation_status": "not-run-no-artifact",
-    "blocked_by": [
+    "generated_glsl": {
+      "sha256": "7808f9f35bab56c1f415dea1a669225c68447cb32f9147ab1c4b04b975543aa3",
+      "size_bytes": 5107
+    },
+    "required_capabilities": [],
+    "artifact_emitted": true,
+    "native_validation_attempted": true,
+    "native_validation_status": "passed",
+    "toolchain_validation": {
+      "compiler": "glslangValidator",
+      "compiler_target": "OpenGL/SPIR-V 1.3",
+      "validator": "spirv-val",
+      "validator_target": "SPIR-V 1.3",
+      "status": "passed",
+      "observed_failure_count": 0
+    },
+    "resolved_by": [
       "https://github.com/CrossGL/crosstl/issues/1515"
     ],
     "runtime_execution_attempted": false,
@@ -1975,7 +2005,6 @@
       "https://github.com/CrossGL/crosstl/issues/1479",
       "https://github.com/CrossGL/crosstl/issues/1490",
       "https://github.com/CrossGL/crosstl/issues/1497",
-      "https://github.com/CrossGL/crosstl/issues/1515",
       "https://github.com/CrossGL/crosstl/issues/1544",
       "https://github.com/CrossGL/crosstl/issues/1546",
       "https://github.com/CrossGL/crosstl/issues/1554",
@@ -2089,7 +2118,6 @@
     "https://github.com/CrossGL/crosstl/issues/1490",
     "https://github.com/CrossGL/crosstl/issues/1497",
     "https://github.com/CrossGL/crosstl/issues/1491",
-    "https://github.com/CrossGL/crosstl/issues/1515",
     "https://github.com/CrossGL/crosstl/issues/1517",
     "https://github.com/CrossGL/crosstl/issues/1518",
     "https://github.com/CrossGL/crosstl/issues/1519",
@@ -2123,6 +2151,7 @@
     "https://github.com/CrossGL/crosstl/issues/1660"
   ],
   "resolved_issues": [
+    "https://github.com/CrossGL/crosstl/issues/1515",
     "https://github.com/CrossGL/crosstl/issues/1576",
     "https://github.com/CrossGL/crosstl/issues/1829",
     "https://github.com/CrossGL/crosstl/issues/1826",

--- a/demos/integrations/mlx/prove_quantized_opengl.py
+++ b/demos/integrations/mlx/prove_quantized_opengl.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Prove one pinned MLX quantized kernel as an OpenGL artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from crosstl.project import ProjectConfig, translate_project
+
+MLX_REPOSITORY = "https://github.com/ml-explore/mlx"
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_KERNEL_ROOT = "mlx/backend/metal/kernels"
+MLX_QUANTIZED_SOURCE = f"{MLX_KERNEL_ROOT}/quantized.metal"
+MLX_QUANTIZED_HEADER = f"{MLX_KERNEL_ROOT}/quantized.h"
+MLX_QUANTIZED_ENTRY_POINT = "affine_quantize_float_gs_32_b_2"
+
+PINNED_FILE_SHA256 = {
+    MLX_QUANTIZED_SOURCE: (
+        "292aab5a98e3fc047b8ed91343fc10b66e5a92e12c258cde168929520ab2abfd"
+    ),
+    MLX_QUANTIZED_HEADER: (
+        "4da52bf4ee688165a65b84c52a5f4e82efcae7f69e8c74d9ee3e00bef463c99f"
+    ),
+}
+
+TARGET = "opengl"
+TEMPLATE_SPECIALIZATION_LIMIT = 128
+MATERIALIZATION_WORK_LIMIT = 4096
+REACHABLE_SPECIALIZATION_COUNT = 6
+CONCRETE_SPECIALIZATION_COUNT = 3
+PRUNED_CANDIDATE_COUNT = 110861
+INDEX_RANGE_MINIMUM = 0
+INDEX_RANGE_MAXIMUM = 2147483647
+INDEX_RANGE_EXPRESSIONS = (
+    "in_index + i",
+    "gindex",
+    "out_index / writes_per_reduce",
+)
+INDEX_RANGE_ASSERTIONS = tuple(
+    {
+        "source": MLX_QUANTIZED_SOURCE,
+        "expression": expression,
+        "minimum": INDEX_RANGE_MINIMUM,
+        "maximum": INDEX_RANGE_MAXIMUM,
+    }
+    for expression in INDEX_RANGE_EXPRESSIONS
+)
+DEFAULT_WORK_DIR = ".crosstl-mlx-porting/quantized-opengl"
+SUMMARY_FILENAME = "summary.json"
+
+NON_RUNTIME_CLAIMS = {
+    "runtimeExecution": False,
+    "numericalParity": False,
+    "mlxUnitTests": False,
+    "fullMlxTestSuite": False,
+}
+
+_GENERATED_SEMANTIC_SENTINELS = {
+    "minimumReduction": "w_min = subgroupMin(w_min);",
+    "maximumReduction": "w_max = subgroupMax(w_max);",
+    "scaleCalculation": "float scale = max(((w_max - w_min) / n_bins), eps);",
+    "edgeRounding": "float q0 = round((edge / scale));",
+    "quantization": (
+        "uint val = bitfieldExtract(uint(min(round(((w_thread[i] - bias) / "
+        "scale)), n_bins)), 0, 8);"
+    ),
+    "subgroupPacking": "uint sval = subgroupShuffleDown(val, j);",
+}
+_GENERATED_INDEX_SENTINELS = {
+    "in_index + i": "w[uint((in_index + uint64_t(i)))]",
+    "gindex": ("scales[uint(gindex)]", "biases[uint(gindex)]"),
+    "out_index / writes_per_reduce": (
+        "out_[uint((out_index / uint64_t(writes_per_reduce)))]"
+    ),
+}
+
+
+class MlxQuantizedOpenGLProofError(RuntimeError):
+    """Raised when the pinned quantized OpenGL proof contract is not met."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise MlxQuantizedOpenGLProofError(message)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _relpath(path: Path, root: Path) -> str:
+    resolved = path.resolve()
+    resolved_root = root.resolve()
+    _require(
+        _is_relative_to(resolved, resolved_root),
+        f"proof path must stay inside the MLX checkout: {resolved}",
+    )
+    return resolved.relative_to(resolved_root).as_posix()
+
+
+def _resolve_work_dir(mlx_root: Path, value: str | None) -> Path:
+    candidate = Path(value) if value else Path(DEFAULT_WORK_DIR)
+    if not candidate.is_absolute():
+        candidate = mlx_root / candidate
+    resolved = candidate.resolve()
+    root = mlx_root.resolve()
+    _require(
+        resolved != root and _is_relative_to(resolved, root),
+        f"work directory must be inside the MLX checkout: {resolved}",
+    )
+    return resolved
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _git_revision(mlx_root: Path) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(mlx_root), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise MlxQuantizedOpenGLProofError(
+            f"could not resolve the MLX checkout revision: {exc}"
+        ) from exc
+    _require(
+        completed.returncode == 0,
+        "could not resolve the MLX checkout revision: " + completed.stderr.strip(),
+    )
+    return completed.stdout.strip()
+
+
+def _verify_checkout(mlx_root: Path) -> dict[str, Any]:
+    root = mlx_root.resolve()
+    _require(root.is_dir(), f"MLX checkout does not exist: {root}")
+    revision = _git_revision(root)
+    _require(
+        revision == MLX_COMMIT,
+        f"MLX checkout must be pinned to {MLX_COMMIT}; found {revision}",
+    )
+
+    files = []
+    for relative_path, expected_hash in PINNED_FILE_SHA256.items():
+        path = (root / relative_path).resolve()
+        _require(
+            _is_relative_to(path, root) and path.is_file(),
+            f"pinned MLX file is missing or outside the checkout: {relative_path}",
+        )
+        actual_hash = _sha256(path)
+        _require(
+            actual_hash == expected_hash,
+            f"pinned MLX file SHA-256 mismatch for {relative_path}: "
+            f"expected {expected_hash}, found {actual_hash}",
+        )
+        files.append(
+            {
+                "path": relative_path,
+                "kind": "source" if relative_path == MLX_QUANTIZED_SOURCE else "header",
+                "hash": {"algorithm": "sha256", "value": actual_hash},
+            }
+        )
+    return {"status": "passed", "commit": revision, "files": files}
+
+
+def _run_command(
+    name: str,
+    command: Sequence[str],
+    *,
+    log_dir: Path,
+    timeout_seconds: int = 180,
+) -> dict[str, Any]:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = log_dir / f"{name}.stdout"
+    stderr_path = log_dir / f"{name}.stderr"
+    try:
+        completed = subprocess.run(
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        returncode = 124
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        stderr += f"\n{name} timed out after {timeout_seconds} seconds.\n"
+    except OSError as exc:
+        returncode = 127
+        stdout = ""
+        stderr = str(exc)
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    return {
+        "name": name,
+        "command": list(command),
+        "returncode": returncode,
+        "stdoutPath": stdout_path,
+        "stderrPath": stderr_path,
+    }
+
+
+def _project_config(mlx_root: Path, work_dir: Path) -> ProjectConfig:
+    return ProjectConfig(
+        root=mlx_root,
+        source_roots=(MLX_KERNEL_ROOT,),
+        include_patterns=(MLX_QUANTIZED_SOURCE,),
+        targets=(TARGET,),
+        output_dir=_relpath(work_dir / "artifacts", mlx_root),
+        source_overrides={MLX_QUANTIZED_SOURCE: "metal"},
+        entry_points={MLX_QUANTIZED_SOURCE: MLX_QUANTIZED_ENTRY_POINT},
+        include_dirs=(".",),
+        source_options={
+            "metal": {
+                "max_template_specializations": TEMPLATE_SPECIALIZATION_LIMIT,
+                "max_template_materialization_work": MATERIALIZATION_WORK_LIMIT,
+            }
+        },
+        index_range_assertions=INDEX_RANGE_ASSERTIONS,
+    )
+
+
+def _translate_report(config: ProjectConfig, *, report_path: Path) -> dict[str, Any]:
+    try:
+        payload = translate_project(
+            config,
+            format_output=False,
+            validate=False,
+        ).to_json()
+    except Exception as exc:  # noqa: BLE001
+        raise MlxQuantizedOpenGLProofError(
+            f"OpenGL project translation raised {type(exc).__name__}: {exc}"
+        ) from exc
+    _require(isinstance(payload, Mapping), "project report must be a JSON object")
+    normalized = dict(payload)
+    _write_json(report_path, normalized)
+    return normalized
+
+
+def _require_translation_summary(payload: Mapping[str, Any]) -> None:
+    summary = payload.get("summary")
+    _require(isinstance(summary, Mapping), "project report summary is missing")
+    _require(
+        summary.get("unitCount") == 1
+        and summary.get("targetCount") == 1
+        and summary.get("artifactCount") == 1
+        and summary.get("translatedCount") == 1
+        and summary.get("failedCount") == 0
+        and summary.get("skippedCount") == 0
+        and summary.get("diagnosticCounts") == {"error": 0, "note": 0, "warning": 0},
+        "pinned quantized.metal report must contain one translated artifact "
+        "and no diagnostics",
+    )
+    _require(
+        payload.get("diagnostics") == [],
+        "pinned quantized.metal translation emitted diagnostics",
+    )
+
+
+def _require_index_range_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
+    project = payload.get("project")
+    expected = [dict(assertion) for assertion in INDEX_RANGE_ASSERTIONS]
+    _require(
+        isinstance(project, Mapping)
+        and project.get("indexRangeAssertionCount") == len(expected)
+        and project.get("indexRangeAssertions") == expected,
+        "project report did not preserve the exact quantized index-range contract",
+    )
+    return {
+        "status": "configured",
+        "assertions": expected,
+        "assertionCount": len(expected),
+        "contractKind": "explicit-host-runtime-portability-preconditions",
+        "inferred": False,
+        "runtimeEnforced": False,
+    }
+
+
+def _translated_artifact(
+    payload: Mapping[str, Any],
+    *,
+    mlx_root: Path,
+    work_dir: Path,
+) -> tuple[Mapping[str, Any], Path]:
+    _require(
+        payload.get("kind") == "crosstl-project-portability-report",
+        "translation did not produce a project portability report",
+    )
+    _require_translation_summary(payload)
+    artifacts = payload.get("artifacts")
+    _require(
+        isinstance(artifacts, list)
+        and len(artifacts) == 1
+        and isinstance(artifacts[0], Mapping),
+        "project report must contain exactly one OpenGL artifact record",
+    )
+    artifact = artifacts[0]
+    _require(
+        artifact.get("source") == MLX_QUANTIZED_SOURCE
+        and artifact.get("sourceBackend") == "metal"
+        and artifact.get("target") == TARGET
+        and artifact.get("status") == "translated"
+        and artifact.get("sourceHash")
+        == {
+            "algorithm": "sha256",
+            "value": PINNED_FILE_SHA256[MLX_QUANTIZED_SOURCE],
+        }
+        and artifact.get("provenance")
+        == {"pipeline": "entry-scoped-translate", "intermediate": "crossgl"}
+        and artifact.get("requiredCapabilities") == [],
+        "OpenGL artifact provenance does not match pinned quantized.metal",
+    )
+    _require(
+        artifact.get("entryPoint")
+        == {
+            "source": MLX_QUANTIZED_ENTRY_POINT,
+            "target": "main",
+            "stage": "compute",
+        },
+        "selected quantized entry-point identity was not preserved",
+    )
+    materialization = artifact.get("templateMaterialization")
+    specializations = (
+        materialization.get("specializations")
+        if isinstance(materialization, Mapping)
+        else None
+    )
+    accounting = (
+        materialization.get("accounting")
+        if isinstance(materialization, Mapping)
+        else None
+    )
+    _require(
+        isinstance(materialization, Mapping)
+        and materialization.get("status") == "materialized"
+        and materialization.get("specializationCount") == CONCRETE_SPECIALIZATION_COUNT
+        and materialization.get("unsupported") == []
+        and isinstance(specializations, list)
+        and len(specializations) == CONCRETE_SPECIALIZATION_COUNT
+        and isinstance(accounting, Mapping)
+        and accounting.get("reachableSpecializationCount")
+        == REACHABLE_SPECIALIZATION_COUNT
+        and accounting.get("prunedCandidateCount") == PRUNED_CANDIDATE_COUNT,
+        "quantized specialization accounting changed",
+    )
+    selected_specializations = [
+        specialization
+        for specialization in specializations
+        if isinstance(specialization, Mapping)
+        and specialization.get("name") == "affine_quantize"
+        and specialization.get("hostName") == MLX_QUANTIZED_ENTRY_POINT
+    ]
+    _require(
+        len(selected_specializations) == 1
+        and selected_specializations[0].get("materializedName")
+        == MLX_QUANTIZED_ENTRY_POINT
+        and selected_specializations[0].get("parameters")
+        == {"T": "float", "bits": "2", "group_size": "32"},
+        "selected affine_quantize<float, 32, 2> specialization changed",
+    )
+
+    artifact_path = (mlx_root / str(artifact.get("path", ""))).resolve()
+    _require(
+        _is_relative_to(artifact_path, work_dir.resolve()) and artifact_path.is_file(),
+        f"generated GLSL is missing or outside the work directory: {artifact_path}",
+    )
+    _require(
+        artifact_path.suffix == ".glsl"
+        and artifact.get("generatedHash")
+        == {"algorithm": "sha256", "value": _sha256(artifact_path)}
+        and artifact.get("generatedSizeBytes") == artifact_path.stat().st_size,
+        "generated GLSL identity does not match the project report",
+    )
+    return artifact, artifact_path
+
+
+def _validate_generated_glsl(artifact_path: Path) -> dict[str, Any]:
+    source = artifact_path.read_text(encoding="utf-8")
+    _require(
+        source.count("#version 450 core") == 1
+        and source.count("void main()") == 1
+        and (
+            "layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;" in source
+        ),
+        "generated GLSL compute entry-point contract is incomplete",
+    )
+    required_extensions = (
+        "GL_ARB_gpu_shader_int64",
+        "GL_KHR_shader_subgroup_basic",
+        "GL_KHR_shader_subgroup_arithmetic",
+        "GL_KHR_shader_subgroup_shuffle_relative",
+    )
+    _require(
+        all(
+            f"#extension {extension} : require" in source
+            for extension in required_extensions
+        ),
+        "generated GLSL extension contract is incomplete",
+    )
+    _require(
+        all(sentinel in source for sentinel in _GENERATED_SEMANTIC_SENTINELS.values()),
+        "generated GLSL no longer preserves the selected quantization computation",
+    )
+    for expression, sentinels in _GENERATED_INDEX_SENTINELS.items():
+        values = (sentinels,) if isinstance(sentinels, str) else sentinels
+        _require(
+            all(source.count(sentinel) == 1 for sentinel in values),
+            f"generated GLSL index normalization changed for {expression!r}",
+        )
+    return {
+        "status": "passed",
+        "entryPoint": "main",
+        "requiredExtensions": list(required_extensions),
+        "semanticOperations": list(_GENERATED_SEMANTIC_SENTINELS),
+        "normalizedIndexExpressions": list(INDEX_RANGE_EXPRESSIONS),
+    }
+
+
+def _compile_and_validate(
+    artifact_path: Path,
+    *,
+    glslang: str | None,
+    spirv_val: str | None,
+    mlx_root: Path,
+    work_dir: Path,
+    log_dir: Path,
+    required: bool,
+) -> dict[str, Any]:
+    missing = [
+        name
+        for name, path in (
+            ("glslangValidator", glslang),
+            ("spirv-val", spirv_val),
+        )
+        if path is None
+    ]
+    common = {
+        "required": required,
+        "compiler": "glslangValidator",
+        "compilerTarget": "OpenGL/SPIR-V 1.3",
+        "validator": "spirv-val",
+        "validatorTarget": "SPIR-V 1.3",
+    }
+    if missing:
+        _require(
+            not required,
+            "OpenGL quantized proof requires these tools: " + ", ".join(missing),
+        )
+        return {
+            **common,
+            "available": False,
+            "status": "not-required",
+            "reason": "toolchain-unavailable",
+            "missingTools": missing,
+            "compiledArtifactCount": 0,
+        }
+
+    output_path = work_dir / "native" / "opengl" / f"{MLX_QUANTIZED_ENTRY_POINT}.spv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.unlink(missing_ok=True)
+    compile_result = _run_command(
+        "compile-quantized-opengl",
+        [
+            str(glslang),
+            "--target-env",
+            "opengl",
+            "--target-env",
+            "spirv1.3",
+            "-S",
+            "comp",
+            str(artifact_path),
+            "-o",
+            str(output_path),
+        ],
+        log_dir=log_dir,
+    )
+    _require(
+        compile_result["returncode"] == 0,
+        "glslangValidator rejected the generated quantized artifact",
+    )
+    _require(
+        output_path.is_file() and output_path.stat().st_size > 0,
+        "glslangValidator did not emit a nonempty quantized SPIR-V module",
+    )
+    validation_result = _run_command(
+        "validate-quantized-opengl",
+        [str(spirv_val), "--target-env", "spv1.3", str(output_path)],
+        log_dir=log_dir,
+    )
+    _require(
+        validation_result["returncode"] == 0,
+        "spirv-val rejected the generated quantized module",
+    )
+    runs = [
+        {
+            "name": result["name"],
+            "command": result["command"],
+            "returncode": result["returncode"],
+            "stdout": _relpath(result["stdoutPath"], mlx_root),
+            "stderr": _relpath(result["stderrPath"], mlx_root),
+        }
+        for result in (compile_result, validation_result)
+    ]
+    return {
+        **common,
+        "available": True,
+        "status": "compiled-and-validated",
+        "artifact": _relpath(artifact_path, mlx_root),
+        "compiledArtifact": _relpath(output_path, mlx_root),
+        "compiledArtifactHash": {
+            "algorithm": "sha256",
+            "value": _sha256(output_path),
+        },
+        "compiledArtifactCount": 1,
+        "runs": runs,
+    }
+
+
+def run_proof(
+    mlx_root: Path,
+    work_dir: Path,
+    *,
+    require_opengl_toolchain: bool = False,
+    clean: bool = True,
+) -> dict[str, Any]:
+    root = mlx_root.resolve()
+    resolved_work_dir = _resolve_work_dir(root, str(work_dir))
+    provenance = _verify_checkout(root)
+    if clean and resolved_work_dir.exists():
+        shutil.rmtree(resolved_work_dir)
+    report_dir = resolved_work_dir / "reports"
+    log_dir = resolved_work_dir / "logs"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = report_dir / "quantized-metal-selected-entry.json"
+    payload = _translate_report(
+        _project_config(root, resolved_work_dir),
+        report_path=report_path,
+    )
+    index_ranges = _require_index_range_contract(payload)
+    artifact, artifact_path = _translated_artifact(
+        payload,
+        mlx_root=root,
+        work_dir=resolved_work_dir,
+    )
+    generated_checks = _validate_generated_glsl(artifact_path)
+    toolchain = _compile_and_validate(
+        artifact_path,
+        glslang=shutil.which("glslangValidator"),
+        spirv_val=shutil.which("spirv-val"),
+        mlx_root=root,
+        work_dir=resolved_work_dir,
+        log_dir=log_dir,
+        required=require_opengl_toolchain,
+    )
+
+    summary = {
+        "schema_version": 1,
+        "kind": "crosstl-mlx-quantized-opengl-toolchain-proof",
+        "repository": {
+            "name": "ml-explore/mlx",
+            "url": MLX_REPOSITORY,
+            "commit": MLX_COMMIT,
+        },
+        "scope": {
+            "translation": {
+                "source": MLX_QUANTIZED_SOURCE,
+                "selectedEntryPoint": MLX_QUANTIZED_ENTRY_POINT,
+                "sourceBackend": "metal",
+                "sourceOverride": "metal",
+                "includeDirectories": ["."],
+                "target": TARGET,
+                "projectTranslationApi": "crosstl.project.translate_project",
+                "materializationLimits": {
+                    "maxTemplateSpecializations": TEMPLATE_SPECIALIZATION_LIMIT,
+                    "maxTemplateMaterializationWork": MATERIALIZATION_WORK_LIMIT,
+                },
+                "indexRangeContract": index_ranges,
+            },
+            "toolchain": {
+                "compiler": "glslangValidator",
+                "validator": "spirv-val",
+                "required": require_opengl_toolchain,
+            },
+            "runtime": {
+                "executionAttempted": False,
+                "backendIntegrationAttempted": False,
+                "mlxTestsRun": False,
+            },
+            "numerical": {
+                "comparisonAttempted": False,
+                "parityClaimed": False,
+            },
+        },
+        "claims": {
+            "projectTranslation": True,
+            "nativeCompilation": toolchain["status"] == "compiled-and-validated",
+            "spirvValidation": toolchain["status"] == "compiled-and-validated",
+            **NON_RUNTIME_CLAIMS,
+        },
+        "provenance": provenance,
+        "translation": {
+            "status": "passed",
+            "report": _relpath(report_path, root),
+            "artifact": _relpath(artifact_path, root),
+            "artifactHash": artifact["generatedHash"],
+            "artifactSizeBytes": artifact["generatedSizeBytes"],
+            "entryPoint": artifact["entryPoint"],
+            "requiredCapabilities": list(artifact["requiredCapabilities"]),
+            "templateMaterialization": artifact["templateMaterialization"],
+            "indexRangeContract": index_ranges,
+            "generatedChecks": generated_checks,
+        },
+        "toolchain": toolchain,
+        "runtime": {
+            "status": "not-attempted",
+            "reason": "compile-only proof; no OpenGL dispatch or MLX runtime wiring",
+        },
+        "numerical": {
+            "status": "not-attempted",
+            "reason": "no translated kernel execution or reference comparison",
+        },
+        "status": "passed",
+    }
+    _write_json(resolved_work_dir / SUMMARY_FILENAME, summary)
+    return summary
+
+
+def _failure_summary(*, required: bool, error: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "kind": "crosstl-mlx-quantized-opengl-toolchain-proof",
+        "repository": {
+            "name": "ml-explore/mlx",
+            "url": MLX_REPOSITORY,
+            "commit": MLX_COMMIT,
+        },
+        "scope": {
+            "translation": {
+                "source": MLX_QUANTIZED_SOURCE,
+                "selectedEntryPoint": MLX_QUANTIZED_ENTRY_POINT,
+                "target": TARGET,
+                "indexRangeAssertions": [
+                    dict(assertion) for assertion in INDEX_RANGE_ASSERTIONS
+                ],
+            },
+            "toolchain": {
+                "compiler": "glslangValidator",
+                "validator": "spirv-val",
+                "required": required,
+            },
+            "runtime": {"executionAttempted": False, "mlxTestsRun": False},
+            "numerical": {"comparisonAttempted": False, "parityClaimed": False},
+        },
+        "claims": {
+            "projectTranslation": False,
+            "nativeCompilation": False,
+            "spirvValidation": False,
+            **NON_RUNTIME_CLAIMS,
+        },
+        "status": "failed",
+        "error": error,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prove pinned MLX affine_quantize_float_gs_32_b_2 project "
+            "translation and optional required OpenGL toolchain validation."
+        )
+    )
+    parser.add_argument("--mlx-root", required=True, help="Path to the MLX checkout")
+    parser.add_argument(
+        "--work-dir",
+        help=(
+            "Generated report/artifact directory inside the MLX checkout. "
+            f"Defaults to <mlx-root>/{DEFAULT_WORK_DIR}."
+        ),
+    )
+    parser.add_argument(
+        "--require-opengl-toolchain",
+        action="store_true",
+        help=(
+            "Require glslangValidator and spirv-val instead of accepting a "
+            "translation-only proof."
+        ),
+    )
+    parser.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="Keep existing files in the generated work directory.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    mlx_root = Path(args.mlx_root).resolve()
+    try:
+        work_dir = _resolve_work_dir(mlx_root, args.work_dir)
+    except MlxQuantizedOpenGLProofError as exc:
+        print(f"MLX quantized OpenGL proof failed: {exc}", file=sys.stderr)
+        return 1
+
+    summary_path = work_dir / SUMMARY_FILENAME
+    try:
+        run_proof(
+            mlx_root,
+            work_dir,
+            require_opengl_toolchain=args.require_opengl_toolchain,
+            clean=not args.no_clean,
+        )
+    except MlxQuantizedOpenGLProofError as exc:
+        _write_json(
+            summary_path,
+            _failure_summary(
+                required=args.require_opengl_toolchain,
+                error=str(exc),
+            ),
+        )
+        print(f"MLX quantized OpenGL proof failed: {exc}", file=sys.stderr)
+        print(f"Summary: {summary_path}", file=sys.stderr)
+        return 1
+    print(f"MLX quantized OpenGL proof passed: {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -576,16 +576,22 @@ FFT_OPENGL_EXPECTED_POINTER_EVIDENCE = {
     "parameter": "crosstl_ptr_buf",
     "reason": "unprovable-view-access",
 }
-OPENGL_QUANTIZED_INDEX_TYPE_TRACKED_ISSUE = (
+OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE = (
     "https://github.com/CrossGL/crosstl/issues/1515"
 )
-OPENGL_QUANTIZED_EXPECTED_DIAGNOSTIC_CODE = (
-    "project.translate.opengl-index-type-unsupported"
+MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTION_EXPRESSIONS = (
+    "in_index + i",
+    "gindex",
+    "out_index / writes_per_reduce",
 )
-OPENGL_QUANTIZED_EXPECTED_MISSING_CAPABILITY = "opengl.index-width-normalization"
-OPENGL_QUANTIZED_EXPECTED_MESSAGE = (
-    "OpenGL cannot preserve subscript index type 'uint64_t' for 'w': "
-    "index range unproven"
+MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTIONS = tuple(
+    {
+        "source": MLX_QUANTIZED_SOURCE,
+        "expression": expression,
+        "minimum": MLX_OPENGL_INDEX_RANGE_ASSERTION_MINIMUM,
+        "maximum": MLX_OPENGL_INDEX_RANGE_ASSERTION_MAXIMUM,
+    }
+    for expression in MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTION_EXPRESSIONS
 )
 MLX_DIRECTX_QUANTIZED_FRONTIER_EVIDENCE = {
     "status": "translated-dxc-validated",
@@ -682,7 +688,7 @@ MLX_DIRECTX_QUANTIZED_PRIVATE_POINTER_BOUNDARY_EVIDENCE = {
     "numerical_parity_claimed": False,
 }
 MLX_OPENGL_QUANTIZED_FRONTIER_EVIDENCE = {
-    "status": "blocked-as-expected",
+    "status": "translated-glslang-spirv-val-validated",
     "commit": MLX_COMMIT,
     "source": MLX_QUANTIZED_SOURCE,
     "target": "opengl",
@@ -690,33 +696,46 @@ MLX_OPENGL_QUANTIZED_FRONTIER_EVIDENCE = {
     "project_translation": {
         "unit_count": 1,
         "artifact_record_count": 1,
-        "translated_count": 0,
-        "failed_count": 1,
-        "emitted_target_file_count": 0,
-        "project_diagnostic_count": 1,
+        "translated_count": 1,
+        "failed_count": 0,
+        "emitted_target_file_count": 1,
+        "project_diagnostic_count": 0,
     },
     "materialization": {
         "reachable_specialization_count": 6,
         "concrete_specialization_count": 3,
         "pruned_candidate_count": 110861,
     },
-    "diagnostic": {
-        "code": OPENGL_QUANTIZED_EXPECTED_DIAGNOSTIC_CODE,
-        "missing_capability": OPENGL_QUANTIZED_EXPECTED_MISSING_CAPABILITY,
-        "message": OPENGL_QUANTIZED_EXPECTED_MESSAGE,
-        "index_conversion": {
-            "indexed_value": "w",
-            "index_expression": "in_index + i",
-            "source_type": "uint64_t",
-            "target_type": "uint",
-            "range_status": "unproven",
-            "reason": "index-range-unproven",
+    "index_range_assertion_evidence": {
+        "assertion_count": len(MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTIONS),
+        "assertions": [
+            dict(assertion) for assertion in MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTIONS
+        ],
+        "inclusive_bounds": {
+            "minimum": MLX_OPENGL_INDEX_RANGE_ASSERTION_MINIMUM,
+            "maximum": MLX_OPENGL_INDEX_RANGE_ASSERTION_MAXIMUM,
         },
+        "contract_kind": "explicit-host-runtime-portability-preconditions",
+        "inferred": False,
+        "runtime_enforced": False,
     },
-    "artifact_emitted": False,
-    "native_validation_attempted": False,
-    "native_validation_status": "not-run-no-artifact",
-    "blocked_by": [OPENGL_QUANTIZED_INDEX_TYPE_TRACKED_ISSUE],
+    "generated_glsl": {
+        "sha256": "7808f9f35bab56c1f415dea1a669225c68447cb32f9147ab1c4b04b975543aa3",
+        "size_bytes": 5107,
+    },
+    "required_capabilities": [],
+    "artifact_emitted": True,
+    "native_validation_attempted": True,
+    "native_validation_status": "passed",
+    "toolchain_validation": {
+        "compiler": "glslangValidator",
+        "compiler_target": "OpenGL/SPIR-V 1.3",
+        "validator": "spirv-val",
+        "validator_target": "SPIR-V 1.3",
+        "status": "passed",
+        "observed_failure_count": 0,
+    },
+    "resolved_by": [OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE],
     "runtime_execution_attempted": False,
     "numerical_parity_claimed": False,
 }
@@ -729,7 +748,6 @@ FULL_CORPUS_TRANSLATION_TRACKED_ISSUES = (
     "https://github.com/CrossGL/crosstl/issues/1479",
     "https://github.com/CrossGL/crosstl/issues/1490",
     "https://github.com/CrossGL/crosstl/issues/1497",
-    OPENGL_QUANTIZED_INDEX_TYPE_TRACKED_ISSUE,
     "https://github.com/CrossGL/crosstl/issues/1544",
     "https://github.com/CrossGL/crosstl/issues/1546",
     "https://github.com/CrossGL/crosstl/issues/1554",
@@ -820,6 +838,7 @@ FULL_CORPUS_TRACKED_ISSUES = (
     *METAL_ROUNDTRIP_SEMANTIC_TRACKED_ISSUES,
 )
 RESOLVED_FRONTIER_ISSUES = (
+    OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE,
     "https://github.com/CrossGL/crosstl/issues/1576",
     "https://github.com/CrossGL/crosstl/issues/1799",
     "https://github.com/CrossGL/crosstl/issues/1800",

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2423,6 +2423,7 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     )
     assert '"tests/test_mlx_porting_harness.py"' in mlx_porting
     assert '"tests/test_mlx_quantized_directx_proof.py"' in mlx_porting
+    assert '"tests/test_mlx_quantized_opengl_proof.py"' in mlx_porting
     assert '"tests/test_translator/test_codegen/test_SPIRV_codegen.py"' in mlx_porting
     assert '"tests/test_translator/test_codegen/test_directx_codegen.py"' in mlx_porting
     assert (
@@ -2711,6 +2712,16 @@ def test_mlx_project_porting_workflow_runs_quantized_directx_proof_on_windows():
     assert "python demos/integrations/mlx/prove_quantized_directx.py" in mlx_porting
     assert "--work-dir .crosstl-mlx-porting/quantized-directx" in mlx_porting
     assert "--require-directx-toolchain" in mlx_porting
+
+
+def test_mlx_project_porting_workflow_runs_quantized_opengl_proof_on_linux():
+    mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
+
+    assert "name: Prove pinned MLX quantized OpenGL lowering" in mlx_porting
+    assert "if: runner.os == 'Linux'" in mlx_porting
+    assert "python demos/integrations/mlx/prove_quantized_opengl.py" in mlx_porting
+    assert "--work-dir .crosstl-mlx-porting/quantized-opengl" in mlx_porting
+    assert "--require-opengl-toolchain" in mlx_porting
 
 
 def test_mlx_project_porting_workflow_runs_backend_runtime_contracts():

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -2039,8 +2039,13 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
 
     opengl_quantized = expected_gaps["opengl_quantized_frontier_status"]
     assert opengl_quantized == module.MLX_OPENGL_QUANTIZED_FRONTIER_EVIDENCE
-    assert opengl_quantized["artifact_emitted"] is False
-    assert opengl_quantized["native_validation_attempted"] is False
+    assert opengl_quantized["artifact_emitted"] is True
+    assert opengl_quantized["native_validation_attempted"] is True
+    assert opengl_quantized["native_validation_status"] == "passed"
+    assert opengl_quantized["generated_glsl"] == {
+        "sha256": "7808f9f35bab56c1f415dea1a669225c68447cb32f9147ab1c4b04b975543aa3",
+        "size_bytes": 5107,
+    }
 
     directx = expected_gaps["directx_toolchain_status"]
     assert directx["compiler"] == {"name": "dxc", "version": "v1.9.2602.24"}
@@ -7781,13 +7786,15 @@ def test_selected_quantized_frontiers_record_current_target_boundaries():
     assert "`missing-fixed-array-extent`" in readme
     assert "`values_per_thread = 2`" in readme
     assert "No target artifact is emitted" in normalized_readme
-    assert "`project.translate.opengl-index-type-unsupported`" in readme
-    assert "`w[in_index + i]`" in readme
-    assert "source index is `uint64_t`" in normalized_readme
-    assert "legal target index is `uint`" in normalized_readme
-    assert "source range is unproven" in normalized_readme
-    assert "No OpenGL target artifact is emitted" in normalized_readme
-    assert "native validation is not run" in normalized_readme
+    assert "three source-qualified index-range assertions" in normalized_readme
+    assert "`in_index + i`" in readme
+    assert "`gindex`" in readme
+    assert "`out_index / writes_per_reduce`" in readme
+    assert "inclusive bounds `[0, 2147483647]`" in normalized_readme
+    assert "5,107-byte GLSL artifact" in normalized_readme
+    assert "OpenGL/SPIR-V 1.3" in normalized_readme
+    assert "`spirv-val`" in readme
+    assert "not inferred or enforced at runtime" in normalized_readme
     for issue in (1497, 1515, 1799, 1800, 1801, 1802):
         assert f"https://github.com/CrossGL/crosstl/issues/{issue}" in readme
 
@@ -7839,6 +7846,39 @@ def test_selected_quantized_frontiers_record_current_target_boundaries():
     }
     assert directx["runtime_execution_attempted"] is False
     assert directx["numerical_parity_claimed"] is False
+
+    opengl = module.MLX_OPENGL_QUANTIZED_FRONTIER_EVIDENCE
+    assert opengl["status"] == "translated-glslang-spirv-val-validated"
+    assert opengl["project_translation"] == {
+        "unit_count": 1,
+        "artifact_record_count": 1,
+        "translated_count": 1,
+        "failed_count": 0,
+        "emitted_target_file_count": 1,
+        "project_diagnostic_count": 0,
+    }
+    assert opengl["index_range_assertion_evidence"] == {
+        "assertion_count": 3,
+        "assertions": [
+            dict(assertion)
+            for assertion in module.MLX_OPENGL_QUANTIZED_INDEX_RANGE_ASSERTIONS
+        ],
+        "inclusive_bounds": {"minimum": 0, "maximum": 2147483647},
+        "contract_kind": "explicit-host-runtime-portability-preconditions",
+        "inferred": False,
+        "runtime_enforced": False,
+    }
+    assert opengl["toolchain_validation"] == {
+        "compiler": "glslangValidator",
+        "compiler_target": "OpenGL/SPIR-V 1.3",
+        "validator": "spirv-val",
+        "validator_target": "SPIR-V 1.3",
+        "status": "passed",
+        "observed_failure_count": 0,
+    }
+    assert opengl["resolved_by"] == [module.OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE]
+    assert opengl["runtime_execution_attempted"] is False
+    assert opengl["numerical_parity_claimed"] is False
 
     adjacent = module.MLX_DIRECTX_QUANTIZED_PRIVATE_POINTER_BOUNDARY_EVIDENCE
     assert adjacent["selected_entry_point"] == (
@@ -7923,7 +7963,18 @@ def test_closed_project_blockers_are_recorded_as_resolved():
     )
     resolved_issues = {
         f"https://github.com/CrossGL/crosstl/issues/{number}"
-        for number in (1312, 1472, 1476, 1516, 1659, 1672, 1800, 1801, 1802)
+        for number in (
+            1312,
+            1472,
+            1476,
+            1515,
+            1516,
+            1659,
+            1672,
+            1800,
+            1801,
+            1802,
+        )
     }
 
     assert resolved_issues <= set(module.RESOLVED_FRONTIER_ISSUES)
@@ -7961,7 +8012,7 @@ def test_new_pin_resource_profile_workgroup_and_validation_contracts_are_tracked
     arithmetic_conversion_issue = "https://github.com/CrossGL/crosstl/issues/1802"
     static_assertion_issue = "https://github.com/CrossGL/crosstl/issues/1800"
     private_pointer_issue = "https://github.com/CrossGL/crosstl/issues/1497"
-    opengl_index_issue = module.OPENGL_QUANTIZED_INDEX_TYPE_TRACKED_ISSUE
+    opengl_index_issue = module.OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE
 
     assert resource_issue in module.FULL_CORPUS_TRANSLATION_TRACKED_ISSUES
     assert resource_issue in module.FULL_CORPUS_TRACKED_ISSUES
@@ -7978,8 +8029,9 @@ def test_new_pin_resource_profile_workgroup_and_validation_contracts_are_tracked
     assert static_assertion_issue not in module.FULL_CORPUS_TRACKED_ISSUES
     assert private_pointer_issue in module.FULL_CORPUS_TRANSLATION_TRACKED_ISSUES
     assert private_pointer_issue in module.FULL_CORPUS_TRACKED_ISSUES
-    assert opengl_index_issue in module.FULL_CORPUS_TRANSLATION_TRACKED_ISSUES
-    assert opengl_index_issue in module.FULL_CORPUS_TRACKED_ISSUES
+    assert opengl_index_issue not in module.FULL_CORPUS_TRANSLATION_TRACKED_ISSUES
+    assert opengl_index_issue not in module.FULL_CORPUS_TRACKED_ISSUES
+    assert opengl_index_issue in module.RESOLVED_FRONTIER_ISSUES
     assert resolved_frontier_issues <= set(module.RESOLVED_FRONTIER_ISSUES)
     assert resolved_frontier_issues.isdisjoint(module.FULL_CORPUS_TRACKED_ISSUES)
     assert resource_issue not in module.RESOLVED_FRONTIER_ISSUES
@@ -8003,7 +8055,8 @@ def test_new_pin_resource_profile_workgroup_and_validation_contracts_are_tracked
     assert static_assertion_issue in module.RESOLVED_FRONTIER_ISSUES
     assert static_assertion_issue in gaps["resolved_issues"]
     assert private_pointer_issue in gaps["tracked_issues"]
-    assert opengl_index_issue in gaps["tracked_issues"]
+    assert opengl_index_issue not in gaps["tracked_issues"]
+    assert opengl_index_issue in gaps["resolved_issues"]
     assert resolved_frontier_issues <= set(gaps["resolved_issues"])
     assert resolved_frontier_issues.isdisjoint(gaps["tracked_issues"])
     assert resource_issue in gaps["full_corpus_scout"]["translation_blocked_by"]
@@ -8020,7 +8073,7 @@ def test_new_pin_resource_profile_workgroup_and_validation_contracts_are_tracked
         profile_issue,
     ]
     assert private_pointer_issue in gaps["full_corpus_scout"]["translation_blocked_by"]
-    assert opengl_index_issue in gaps["full_corpus_scout"]["translation_blocked_by"]
+    assert opengl_index_issue not in gaps["full_corpus_scout"]["translation_blocked_by"]
     assert resolved_frontier_issues.isdisjoint(
         gaps["full_corpus_scout"]["validation_blocked_by"]
     )

--- a/tests/test_mlx_quantized_opengl_proof.py
+++ b/tests/test_mlx_quantized_opengl_proof.py
@@ -1,0 +1,546 @@
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PROOF_PATH = ROOT / "demos" / "integrations" / "mlx" / "prove_quantized_opengl.py"
+
+EXPECTED_PINNED_HASHES = {
+    "mlx/backend/metal/kernels/quantized.metal": (
+        "292aab5a98e3fc047b8ed91343fc10b66e5a92e12c258cde168929520ab2abfd"
+    ),
+    "mlx/backend/metal/kernels/quantized.h": (
+        "4da52bf4ee688165a65b84c52a5f4e82efcae7f69e8c74d9ee3e00bef463c99f"
+    ),
+}
+
+
+def _load_proof():
+    spec = importlib.util.spec_from_file_location(
+        "mlx_quantized_opengl_proof",
+        PROOF_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synthetic_checkout(module, tmp_path, monkeypatch):
+    mlx_root = tmp_path / "mlx"
+    hashes = {}
+    for index, relative_path in enumerate(module.PINNED_FILE_SHA256):
+        path = mlx_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"pinned fixture {index}: {relative_path}\n", encoding="utf-8")
+        hashes[relative_path] = hashlib.sha256(path.read_bytes()).hexdigest()
+    monkeypatch.setattr(module, "PINNED_FILE_SHA256", hashes)
+    monkeypatch.setattr(module, "_git_revision", lambda _root: module.MLX_COMMIT)
+    return mlx_root
+
+
+def _generated_glsl():
+    return """#version 450 core
+#extension GL_ARB_gpu_shader_int64 : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_shuffle_relative : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+    float val_0 = w[uint((in_index + uint64_t(i)))];
+    w_min = subgroupMin(w_min);
+    w_max = subgroupMax(w_max);
+    float scale = max(((w_max - w_min) / n_bins), eps);
+    float q0 = round((edge / scale));
+    scales[uint(gindex)] = float(scale);
+    biases[uint(gindex)] = float(bias);
+    uint val = bitfieldExtract(uint(min(round(((w_thread[i] - bias) / scale)), n_bins)), 0, 8);
+    uint sval = subgroupShuffleDown(val, j);
+    out_[uint((out_index / uint64_t(writes_per_reduce)))] = output_;
+}
+"""
+
+
+def _translated_payload(module, mlx_root, work_dir, generated=None):
+    artifact_path = work_dir / "artifacts" / "opengl" / "quantized.glsl"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(generated or _generated_glsl(), encoding="utf-8")
+    artifact_hash = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+    assertions = [dict(assertion) for assertion in module.INDEX_RANGE_ASSERTIONS]
+    payload = {
+        "kind": "crosstl-project-portability-report",
+        "project": {
+            "indexRangeAssertionCount": 3,
+            "indexRangeAssertions": assertions,
+        },
+        "summary": {
+            "unitCount": 1,
+            "targetCount": 1,
+            "artifactCount": 1,
+            "translatedCount": 1,
+            "failedCount": 0,
+            "skippedCount": 0,
+            "diagnosticCounts": {"error": 0, "note": 0, "warning": 0},
+        },
+        "diagnostics": [],
+        "artifacts": [
+            {
+                "source": module.MLX_QUANTIZED_SOURCE,
+                "sourceBackend": "metal",
+                "target": "opengl",
+                "status": "translated",
+                "path": artifact_path.relative_to(mlx_root).as_posix(),
+                "sourceHash": {
+                    "algorithm": "sha256",
+                    "value": module.PINNED_FILE_SHA256[module.MLX_QUANTIZED_SOURCE],
+                },
+                "provenance": {
+                    "pipeline": "entry-scoped-translate",
+                    "intermediate": "crossgl",
+                },
+                "requiredCapabilities": [],
+                "entryPoint": {
+                    "source": module.MLX_QUANTIZED_ENTRY_POINT,
+                    "target": "main",
+                    "stage": "compute",
+                },
+                "templateMaterialization": {
+                    "status": "materialized",
+                    "specializationCount": 3,
+                    "specializations": [
+                        {
+                            "name": "affine_quantize",
+                            "hostName": module.MLX_QUANTIZED_ENTRY_POINT,
+                            "materializedName": module.MLX_QUANTIZED_ENTRY_POINT,
+                            "parameters": {
+                                "T": "float",
+                                "bits": "2",
+                                "group_size": "32",
+                            },
+                            "source": "source-instantiation",
+                        },
+                        {
+                            "name": "get_pack_factor",
+                            "materializedName": "get_pack_factor_2_8",
+                            "parameters": {"bits": "2", "wsize": "8"},
+                            "source": "call-site",
+                        },
+                        {
+                            "name": "get_bytes_per_pack",
+                            "materializedName": "get_bytes_per_pack_2",
+                            "parameters": {"bits": "2", "wsize": "8"},
+                            "source": "call-site",
+                        },
+                    ],
+                    "unsupported": [],
+                    "accounting": {
+                        "reachableSpecializationCount": 6,
+                        "prunedCandidateCount": 110861,
+                    },
+                },
+                "generatedHash": {
+                    "algorithm": "sha256",
+                    "value": artifact_hash,
+                },
+                "generatedSizeBytes": artifact_path.stat().st_size,
+            }
+        ],
+    }
+    return payload, artifact_path
+
+
+def test_quantized_opengl_proof_pins_revision_files_entry_and_ranges():
+    module = _load_proof()
+
+    assert module.MLX_COMMIT == "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+    assert module.PINNED_FILE_SHA256 == EXPECTED_PINNED_HASHES
+    assert module.MLX_QUANTIZED_ENTRY_POINT == "affine_quantize_float_gs_32_b_2"
+    assert module.INDEX_RANGE_EXPRESSIONS == (
+        "in_index + i",
+        "gindex",
+        "out_index / writes_per_reduce",
+    )
+    assert [dict(assertion) for assertion in module.INDEX_RANGE_ASSERTIONS] == [
+        {
+            "source": module.MLX_QUANTIZED_SOURCE,
+            "expression": expression,
+            "minimum": 0,
+            "maximum": 2147483647,
+        }
+        for expression in module.INDEX_RANGE_EXPRESSIONS
+    ]
+    assert module.NON_RUNTIME_CLAIMS == {
+        "runtimeExecution": False,
+        "numericalParity": False,
+        "mlxUnitTests": False,
+        "fullMlxTestSuite": False,
+    }
+
+
+def test_quantized_opengl_checkout_fails_closed_on_revision_and_file_drift(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_proof()
+    mlx_root = _synthetic_checkout(module, tmp_path, monkeypatch)
+    assert module._verify_checkout(mlx_root)["status"] == "passed"
+
+    monkeypatch.setattr(module, "_git_revision", lambda _root: "0" * 40)
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="must be pinned"):
+        module._verify_checkout(mlx_root)
+
+    monkeypatch.setattr(module, "_git_revision", lambda _root: module.MLX_COMMIT)
+    header = mlx_root / module.MLX_QUANTIZED_HEADER
+    header.write_text("drifted\n", encoding="utf-8")
+    with pytest.raises(
+        module.MlxQuantizedOpenGLProofError,
+        match=r"SHA-256 mismatch for .*quantized\.h",
+    ):
+        module._verify_checkout(mlx_root)
+
+
+def test_quantized_opengl_paths_and_provenance_fail_closed(tmp_path, monkeypatch):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="inside"):
+        module._resolve_work_dir(mlx_root, str(mlx_root))
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="inside"):
+        module._resolve_work_dir(mlx_root, str(tmp_path / "outside"))
+
+    work_dir = mlx_root / "proof"
+    work_dir.mkdir()
+    marker = work_dir / "existing.txt"
+    marker.write_text("preserve\n", encoding="utf-8")
+    translated = False
+
+    def reject_provenance(_root):
+        raise module.MlxQuantizedOpenGLProofError("provenance drift")
+
+    def unexpected_translation(*_args, **_kwargs):
+        nonlocal translated
+        translated = True
+        raise AssertionError("translation must not run")
+
+    monkeypatch.setattr(module, "_verify_checkout", reject_provenance)
+    monkeypatch.setattr(module, "_translate_report", unexpected_translation)
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="provenance drift"):
+        module.run_proof(mlx_root, work_dir)
+
+    assert marker.read_text(encoding="utf-8") == "preserve\n"
+    assert translated is False
+
+
+def test_quantized_opengl_project_config_uses_public_entry_and_range_contract(tmp_path):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+    config = module._project_config(mlx_root, mlx_root / "proof")
+
+    assert tuple(config.source_roots) == (module.MLX_KERNEL_ROOT,)
+    assert tuple(config.include_patterns) == (module.MLX_QUANTIZED_SOURCE,)
+    assert tuple(config.targets) == ("opengl",)
+    assert tuple(config.include_dirs) == (".",)
+    assert config.source_overrides == {module.MLX_QUANTIZED_SOURCE: "metal"}
+    assert config.entry_points == {
+        module.MLX_QUANTIZED_SOURCE: module.MLX_QUANTIZED_ENTRY_POINT
+    }
+    assert config.source_options == {
+        "metal": {
+            "max_template_specializations": 128,
+            "max_template_materialization_work": 4096,
+        }
+    }
+    assert [assertion.to_json() for assertion in config.index_range_assertions] == [
+        dict(assertion) for assertion in module.INDEX_RANGE_ASSERTIONS
+    ]
+
+
+def test_quantized_opengl_translation_uses_public_project_api(tmp_path, monkeypatch):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+    config = module._project_config(mlx_root, mlx_root / "proof")
+    report_path = mlx_root / "proof" / "report.json"
+    captured = {}
+    expected = {"kind": "crosstl-project-portability-report", "value": 1}
+
+    class FakeReport:
+        def to_json(self):
+            return expected
+
+    def translate_project(config_arg, **kwargs):
+        captured["config"] = config_arg
+        captured["kwargs"] = kwargs
+        return FakeReport()
+
+    monkeypatch.setattr(module, "translate_project", translate_project)
+
+    assert module._translate_report(config, report_path=report_path) == expected
+    assert captured == {
+        "config": config,
+        "kwargs": {"format_output": False, "validate": False},
+    }
+    assert json.loads(report_path.read_text(encoding="utf-8")) == expected
+
+
+def test_quantized_opengl_artifact_and_index_contract_reject_report_drift(tmp_path):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    work_dir = mlx_root / "proof"
+    payload, artifact_path = _translated_payload(module, mlx_root, work_dir)
+
+    assert module._require_index_range_contract(payload)["assertionCount"] == 3
+    artifact, resolved = module._translated_artifact(
+        payload,
+        mlx_root=mlx_root,
+        work_dir=work_dir,
+    )
+    assert artifact["requiredCapabilities"] == []
+    assert resolved == artifact_path
+    assert module._validate_generated_glsl(artifact_path)["status"] == "passed"
+
+    wrong_ranges = copy.deepcopy(payload)
+    wrong_ranges["project"]["indexRangeAssertions"][0]["maximum"] = 2**32 - 1
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="index-range"):
+        module._require_index_range_contract(wrong_ranges)
+
+    wrong_source = copy.deepcopy(payload)
+    wrong_source["artifacts"][0]["source"] = "other.metal"
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="provenance"):
+        module._translated_artifact(
+            wrong_source,
+            mlx_root=mlx_root,
+            work_dir=work_dir,
+        )
+
+    artifact_path.write_text(_generated_glsl() + "// drift\n", encoding="utf-8")
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match="identity"):
+        module._translated_artifact(
+            payload,
+            mlx_root=mlx_root,
+            work_dir=work_dir,
+        )
+
+
+@pytest.mark.parametrize(
+    "removed,message",
+    [
+        ("w_min = subgroupMin(w_min);", "quantization computation"),
+        ("w[uint((in_index + uint64_t(i)))]", "in_index \\+ i"),
+        ("#extension GL_KHR_shader_subgroup_arithmetic : require", "extension"),
+    ],
+)
+def test_quantized_opengl_generated_contract_rejects_semantic_drift(
+    tmp_path,
+    removed,
+    message,
+):
+    module = _load_proof()
+    artifact_path = tmp_path / "quantized.glsl"
+    artifact_path.write_text(_generated_glsl().replace(removed, ""), encoding="utf-8")
+
+    with pytest.raises(module.MlxQuantizedOpenGLProofError, match=message):
+        module._validate_generated_glsl(artifact_path)
+
+
+def test_quantized_opengl_toolchain_targets_opengl_spirv13(tmp_path, monkeypatch):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    work_dir = mlx_root / "proof"
+    log_dir = work_dir / "logs"
+    artifact_path = work_dir / "quantized.glsl"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(_generated_glsl(), encoding="utf-8")
+    commands = []
+
+    def run_command(name, command, *, log_dir, timeout_seconds=180):
+        del timeout_seconds
+        commands.append(list(command))
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stdout_path = log_dir / f"{name}.stdout"
+        stderr_path = log_dir / f"{name}.stderr"
+        stdout_path.write_text("", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        if name == "compile-quantized-opengl":
+            output_path = Path(command[command.index("-o") + 1])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"SPIR-V 1.3")
+        return {
+            "name": name,
+            "command": list(command),
+            "returncode": 0,
+            "stdoutPath": stdout_path,
+            "stderrPath": stderr_path,
+        }
+
+    monkeypatch.setattr(module, "_run_command", run_command)
+    result = module._compile_and_validate(
+        artifact_path,
+        glslang="/tools/glslangValidator",
+        spirv_val="/tools/spirv-val",
+        mlx_root=mlx_root,
+        work_dir=work_dir,
+        log_dir=log_dir,
+        required=True,
+    )
+    output_path = (
+        work_dir / "native" / "opengl" / ("affine_quantize_float_gs_32_b_2.spv")
+    )
+
+    assert commands == [
+        [
+            "/tools/glslangValidator",
+            "--target-env",
+            "opengl",
+            "--target-env",
+            "spirv1.3",
+            "-S",
+            "comp",
+            str(artifact_path),
+            "-o",
+            str(output_path),
+        ],
+        ["/tools/spirv-val", "--target-env", "spv1.3", str(output_path)],
+    ]
+    assert result["status"] == "compiled-and-validated"
+    assert result["compiledArtifactCount"] == 1
+    assert result["compilerTarget"] == "OpenGL/SPIR-V 1.3"
+    assert result["validatorTarget"] == "SPIR-V 1.3"
+
+
+def test_quantized_opengl_toolchain_requirement_fails_closed(tmp_path):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+    artifact_path = mlx_root / "quantized.glsl"
+    artifact_path.write_text(_generated_glsl(), encoding="utf-8")
+
+    optional = module._compile_and_validate(
+        artifact_path,
+        glslang=None,
+        spirv_val=None,
+        mlx_root=mlx_root,
+        work_dir=mlx_root / "proof",
+        log_dir=mlx_root / "proof" / "logs",
+        required=False,
+    )
+    assert optional["status"] == "not-required"
+    assert optional["missingTools"] == ["glslangValidator", "spirv-val"]
+
+    with pytest.raises(
+        module.MlxQuantizedOpenGLProofError, match="requires these tools"
+    ):
+        module._compile_and_validate(
+            artifact_path,
+            glslang=None,
+            spirv_val=None,
+            mlx_root=mlx_root,
+            work_dir=mlx_root / "proof",
+            log_dir=mlx_root / "proof" / "logs",
+            required=True,
+        )
+
+
+def test_quantized_opengl_run_writes_deterministic_compile_only_summary(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_proof()
+    mlx_root = _synthetic_checkout(module, tmp_path, monkeypatch)
+    work_dir = mlx_root / "proof"
+
+    def translate_report(_config, *, report_path):
+        payload, _artifact_path = _translated_payload(module, mlx_root, work_dir)
+        module._write_json(report_path, payload)
+        return payload
+
+    monkeypatch.setattr(module, "_translate_report", translate_report)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+
+    summary = module.run_proof(mlx_root, work_dir)
+    summary_path = work_dir / "summary.json"
+
+    assert summary["status"] == "passed"
+    assert summary["scope"]["translation"]["indexRangeContract"] == {
+        "status": "configured",
+        "assertions": [dict(assertion) for assertion in module.INDEX_RANGE_ASSERTIONS],
+        "assertionCount": 3,
+        "contractKind": "explicit-host-runtime-portability-preconditions",
+        "inferred": False,
+        "runtimeEnforced": False,
+    }
+    assert summary["scope"]["runtime"] == {
+        "executionAttempted": False,
+        "backendIntegrationAttempted": False,
+        "mlxTestsRun": False,
+    }
+    assert summary["claims"] == {
+        "projectTranslation": True,
+        "nativeCompilation": False,
+        "spirvValidation": False,
+        "runtimeExecution": False,
+        "numericalParity": False,
+        "mlxUnitTests": False,
+        "fullMlxTestSuite": False,
+    }
+    assert summary["toolchain"]["status"] == "not-required"
+    assert summary_path.read_text(encoding="utf-8") == (
+        json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    )
+
+
+def test_quantized_opengl_cli_writes_failure_summary_inside_work_dir(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_proof()
+    mlx_root = tmp_path / "mlx"
+    mlx_root.mkdir()
+
+    def fail_run(*_args, **_kwargs):
+        raise module.MlxQuantizedOpenGLProofError("translation failed closed")
+
+    monkeypatch.setattr(module, "run_proof", fail_run)
+    result = module.main(
+        [
+            "--mlx-root",
+            str(mlx_root),
+            "--work-dir",
+            "proof",
+            "--require-opengl-toolchain",
+        ]
+    )
+    summary = json.loads(
+        (mlx_root / "proof" / "summary.json").read_text(encoding="utf-8")
+    )
+
+    assert result == 1
+    assert summary["status"] == "failed"
+    assert summary["scope"]["toolchain"]["required"] is True
+    assert summary["scope"]["runtime"]["executionAttempted"] is False
+    assert summary["scope"]["numerical"]["parityClaimed"] is False
+    assert summary["claims"]["runtimeExecution"] is False
+    assert summary["claims"]["numericalParity"] is False
+
+
+def test_quantized_opengl_cli_exposes_required_toolchain_flag():
+    module = _load_proof()
+    args = module.parse_args(
+        [
+            "--mlx-root",
+            "/tmp/mlx",
+            "--require-opengl-toolchain",
+            "--no-clean",
+        ]
+    )
+
+    assert args.require_opengl_toolchain is True
+    assert args.no_clean is True


### PR DESCRIPTION
## Summary

- add a reproducible project-level proof for the pinned MLX `affine_quantize_float_gs_32_b_2` Metal entry translated to OpenGL GLSL
- preserve and report three explicit host/runtime index-range preconditions used for legal GLSL subscript normalization
- require `glslangValidator` OpenGL/SPIR-V 1.3 compilation and `spirv-val` validation on Linux CI
- update MLX evidence and issue accounting to record the completed index-width contract

## Scope

This proves selected-entry translation and native toolchain acceptance. It does not claim OpenGL runtime integration, MLX unit-test execution, full-suite execution, or numerical parity.

## Validation

- pinned MLX proof: passed translation, semantic checks, OpenGL/SPIR-V compilation, and SPIR-V validation
- focused MLX and workflow tests: 231 passed
- full test suite: 17,260 passed, 225 skipped
- all-file pre-commit: passed
- support matrix check: current
- support issue synchronization dry run: 5 desired issues, 0 extracted failures

Support issue traceability: no issue closed
