### PR TITLE
Integrate bounded LayerNorm dispatch into MLX frontier

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -539,18 +539,22 @@ jobs:
               GEMV_REPORT_WORKGROUP_SIZE_RULE,
               GEMV_WORKGROUP_SIZE_RULE,
               MLX_DIRECTX_BFLOAT16_LOWERING_EVIDENCE,
+              MLX_DIRECTX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS,
+              MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
+              MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT,
               MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS,
               MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES,
-              MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES,
               MLX_DIRECTX_VULKAN_FRONTIER_SOURCES,
               MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_CODE,
               MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE,
-              MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS,
-              MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
-              MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE,
               MLX_GEMV_SHA256,
               MLX_GEMV_SOURCE,
               MLX_GEMV_SOURCE_SIZE_BYTES,
+              MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
+              MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY,
+              MLX_LAYER_NORM_DISPATCH_VARIANTS,
+              MLX_LAYER_NORM_SHA256,
+              MLX_LAYER_NORM_SOURCE,
               MLX_OPENGL_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
               MLX_OPENGL_FRONTIER_SOURCES,
               MLX_OPENGL_INDEX_RANGE_ASSERTION_EXPRESSIONS,
@@ -567,11 +571,13 @@ jobs:
           directx_entry_point_counts = dict(
               MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
           )
-          directx_frontier_count = len(directx_frontier_sources)
+          directx_artifact_count = MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT
           directx_entry_point_count = sum(directx_entry_point_counts.values())
-          directx_blocked_sources = set(MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES)
+          directx_blocked_sources = set(
+              MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+          )
           directx_blocked_entry_point_counts = dict(
-              MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS
+              MLX_DIRECTX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS
           )
           directx_blocked_entry_point_count = sum(
               directx_blocked_entry_point_counts.values()
@@ -628,7 +634,9 @@ jobs:
               raise SystemExit("blocked frontier must track issue #1537")
           if (
               set(scope["directxTranslatedFrontierSources"])
-              != set(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES)
+              != directx_frontier_sources
+              or scope["directxTranslatedFrontierArtifactCount"]
+              != directx_artifact_count
               or set(scope["directxWorkgroupBlockedFrontierSources"])
               != directx_blocked_sources
               or set(scope["vulkanTranslatedFrontierSources"])
@@ -637,8 +645,8 @@ jobs:
               != set(MLX_OPENGL_TRANSLATED_FRONTIER_SOURCES)
               or set(scope["openglWorkgroupBlockedFrontierSources"])
               != opengl_blocked_sources
-              or scope["dynamicWorkgroupTrackedIssue"]
-              != MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE
+              or scope["hostDispatchImportResolvedIssue"]
+              != MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
           ):
               raise SystemExit("target-split frontier scope accounting is incomplete")
           check_records = payload.get("checks")
@@ -760,10 +768,12 @@ jobs:
           directx = checks["directx-frontier"]
           if (
               directx["status"]
-              != "passed-with-expected-workgroup-blockers"
+              != "passed-with-bounded-dispatch-and-pending-contracts"
               or set(directx["sources"]) != vulkan_frontier_sources
+              or directx["artifactCount"]
+              != directx_artifact_count + len(directx_blocked_sources)
               or set(directx["translatedSources"]) != directx_frontier_sources
-              or directx["translatedArtifactCount"] != directx_frontier_count
+              or directx["translatedArtifactCount"] != directx_artifact_count
               or set(directx["workgroupBlockedSources"])
               != directx_blocked_sources
               or directx["workgroupBlockedArtifactCount"]
@@ -771,11 +781,14 @@ jobs:
               or set(directx["directxToolchainSources"])
               != directx_frontier_sources
               or directx["directxToolchainArtifactCount"]
-              != directx_frontier_count
+              != directx_artifact_count
               or directx["directxToolchainExpectedEntryPointCounts"]
               != directx_entry_point_counts
               or directx["directxToolchainExpectedEntryPointCount"]
               != directx_entry_point_count
+              or directx["trackedIssues"] != []
+              or directx["resolvedIssues"]
+              != [MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE]
           ):
               raise SystemExit("DirectX frontier accounting is incomplete")
           if set(directx["dynamicWorkgroupDispatchEvidence"]) != directx_blocked_sources:
@@ -785,7 +798,8 @@ jobs:
               != MLX_DIRECTX_BFLOAT16_LOWERING_EVIDENCE
           ):
               raise SystemExit("DirectX bfloat16 lowering evidence is incomplete")
-          for source, expected_evidence in MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE.items():
+          for source in directx_blocked_sources:
+              expected_evidence = MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE[source]
               observed_evidence = directx["dynamicWorkgroupDispatchEvidence"][source]
               if (
                   any(
@@ -804,14 +818,46 @@ jobs:
                   raise SystemExit(
                       f"DirectX workgroup blocker evidence changed for {source}"
                   )
-          if directx_blocked_entry_point_count != 106:
-              raise SystemExit("expected 106 fail-closed DirectX compute entries")
+          if directx_blocked_entry_point_count != 94:
+              raise SystemExit("expected 94 fail-closed DirectX compute entries")
+          layer_norm = directx["layerNormDispatchEvidence"]
+          expected_layer_norm_status = (
+              "translated-dxc-validated"
+              if os.environ["RUNNER_OS"] == "Windows"
+              else "translated"
+          )
+          expected_layer_norm_validated = (
+              len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+              if os.environ["RUNNER_OS"] == "Windows"
+              else 0
+          )
+          if (
+              layer_norm["status"] != expected_layer_norm_status
+              or layer_norm["source"] != MLX_LAYER_NORM_SOURCE
+              or layer_norm["sourceSha256"] != MLX_LAYER_NORM_SHA256
+              or layer_norm["target"] != "directx"
+              or layer_norm["dispatchContract"]["contentIdentity"]
+              != MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY
+              or layer_norm["dispatchContract"]["variantCount"]
+              != len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+              or layer_norm["dispatchContract"]["resolvedIssue"]
+              != MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
+              or layer_norm["artifactCount"]
+              != len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+              or set(layer_norm["variants"])
+              != set(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+              or layer_norm["dxcValidatedArtifactCount"]
+              != expected_layer_norm_validated
+              or layer_norm["runtimeExecutionAttempted"] is not False
+              or layer_norm["numericalParityClaimed"] is not False
+          ):
+              raise SystemExit("LayerNorm dispatch frontier evidence is incomplete")
           if os.environ["RUNNER_OS"] == "Windows":
               if (
                   directx["directxToolchainRequired"] is not True
                   or directx["directxValidationStatus"] != "validated"
                   or directx["directxToolchainValidatedArtifactCount"]
-                  != directx_frontier_count
+                  != directx_artifact_count
                   or set(directx["directxToolchainValidatedSources"])
                   != directx_frontier_sources
                   or directx["directxToolchainValidatedEntryPointCounts"]
@@ -1040,8 +1086,9 @@ jobs:
               != len(opengl_blocked_sources)
               or set(opengl["toolchainSources"])
               != opengl_toolchain_frontier_sources
-              or opengl["trackedIssues"]
-              != [MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE]
+              or opengl["trackedIssues"] != []
+              or opengl["resolvedIssues"]
+              != [MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE]
               or opengl["runtimeIntegrationIncluded"] is not False
           ):
               raise SystemExit(

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -65,9 +65,11 @@ The current harness verifies:
   `layer_norm.metal`, `logsumexp.metal`, `random.metal`, `rms_norm.metal`,
   `rope.metal`, `scaled_dot_product_attention.metal`, `softmax.metal`, and
   `ternary.metal`. Vulkan must translate and structurally validate all 11.
-  DirectX emits the five sources whose aggregate entries do not require a
-  runtime-selected workgroup size and records exact expected failures for the
-  other six. Each blocked report must retain the pinned total specialization
+  DirectX emits five aggregate artifacts whose entries do not require a
+  runtime-selected workgroup size, plus two entry-scoped `layer_norm.metal`
+  artifacts selected by the checked-in host dispatch contract. It records exact
+  expected failures for the other five sources. Each blocked report must retain
+  the pinned total specialization
   count and exactly match its diagnostic entry names to the materialized host
   names, with no additional diagnostics. Separate configs prevent DirectX
   workgroup contracts from being silently ignored by Vulkan, where project
@@ -88,10 +90,13 @@ The current harness verifies:
   dispatch uses runtime axis and pipeline-limit operands unavailable to source
   materialization;
 - DirectX HLSL compiler checks with official DXC v1.9.2602.24 on Windows CI for
-  the emitted five-source frontier: `arange.metal`, `binary_two.metal`,
-  `random.metal`, `rope.metal`, and `ternary.metal`. At the pinned revision the
-  gate compiles every generated compute entry: 11, 225, 2, 18, and 212 entries
-  respectively, for 468 generated compute entries in total. The
+  the seven-artifact frontier representing six pinned sources: `arange.metal`,
+  `binary_two.metal`, two bounded `layer_norm.metal` entries, `random.metal`,
+  `rope.metal`, and `ternary.metal`. At the pinned revision the gate compiles
+  11, 225, 2, 2, 18, and 212 entries respectively, for 470 generated compute
+  entries in total. Each LayerNorm entry is emitted independently with its
+  host-derived workgroup size, specialization constants, and exact subgroup
+  width. The
   pinned rope translation supplies required function constant IDs through the
   quoted `"1"`, `"2"`, and `"3"` selectors in
   `[project.specialization_constants]` and materializes the concrete DirectX
@@ -106,10 +111,10 @@ The current harness verifies:
   `random.metal` entries; broader union layouts remain tracked by
   [#1696](https://github.com/CrossGL/crosstl/issues/1696), and runtime dispatch
   metadata remains tracked by
-  [#1542](https://github.com/CrossGL/crosstl/issues/1542). The six excluded
-  aggregate sources cover 106 compute entries and are asserted as failed
-  artifacts until their host dispatch contracts can be imported under
-  [#1793](https://github.com/CrossGL/crosstl/issues/1793);
+  [#1542](https://github.com/CrossGL/crosstl/issues/1542). Host dispatch contract
+  import was completed under [#1793](https://github.com/CrossGL/crosstl/issues/1793).
+  The five pending aggregate sources cover 94 compute entries and are asserted
+  as failed artifacts until bounded dispatch manifests are supplied;
   no placeholder workgroup size is restored. `fence.metal` is
   excluded because its DirectX translation intentionally fails under
   [#1537](https://github.com/CrossGL/crosstl/issues/1537) before DXC. This gate
@@ -280,18 +285,18 @@ compile with DXC. Separate native tests translate and execute the reduced
 immutable lookup fixture and the pinned source's generated uint32 arange entry
 through Direct3D 12. The arange test is numerical evidence for that one source,
 entry, dtype, dispatch shape, and fixture only; it does not turn the frontier
-compiler gate into a general runtime-parity claim. The five emitted DirectX
+compiler gate into a general runtime-parity claim. The five aggregate DirectX
 frontier artifacts carry exact per-source bfloat16 report evidence. All five
 report `status=exact`, `approximationUsed=false`, a `uint-low-16-bits` register
-representation, and round-to-nearest, ties-to-even conversion. All five emitted
-sources require native `uint16` storage declarations and report the
+representation, and round-to-nearest, ties-to-even conversion. All five
+aggregate sources require native `uint16` storage declarations and report the
 `directx.native-16bit-types` capability. The harness compares each artifact's
 `bfloat16Lowering` and `requiredCapabilities` fields with this pinned contract
 and fails closed if either field is missing or changes. Native-profile bfloat
 helpers now use exact `uint16_t` boundaries, and the two selected
 `random.metal` entries compile without the promotion warnings tracked by
 [#1799](https://github.com/CrossGL/crosstl/issues/1799). DXC reports zero
-warnings across all 468 entry-point runs in the five-source emitted frontier.
+warnings across all 470 entry-point runs in the seven-artifact emitted frontier.
 The harness records this as a warning-clean contract and rejects any newly
 observed warning. Contextual destination conversion under
 [#1801](https://github.com/CrossGL/crosstl/issues/1801) is resolved for the
@@ -307,7 +312,7 @@ resolved for the pinned frontier. The float16 assignment is emitted as
 arangefloat16_step));`. All 11 arange entries compile without the
 destination-conversion warning previously tracked by #1801 and with DXC profile
 `cs_6_2`, `-enable-16bit-types`, and `-WX`. This preserves the resolved int16
-destination-conversion evidence. The aggregate five-source frontier therefore
+destination-conversion evidence. The five-source aggregate portion therefore
 has compiler acceptance and a warning-clean diagnostic contract. This is
 storage, conversion, report, and compiler evidence only; it does not execute a
 bfloat16 workload or establish runtime or numerical parity. On macOS CI, the
@@ -719,11 +724,12 @@ array aliases remain tracked in
 `arg_reduce.metal` materializes all 24 host-named entries. Vulkan emits the
 aggregate artifact, while DirectX and OpenGL full-source packaging fails closed
 with `project.translate.workgroup-size-entry-ambiguous` because the pinned host
-selects axis and pipeline limits at runtime. Importing that dispatch contract is
-tracked by [#1793](https://github.com/CrossGL/crosstl/issues/1793). Focused entry
-lowering preserves address-space pointer provenance, fixed private-array extents,
-and target dispatch dimensions, but does not establish an aggregate DirectX or
-OpenGL artifact frontier. Entry-scoped packaging remains tracked in
+selects axis and pipeline limits at runtime. Project dispatch contract import
+was completed under [#1793](https://github.com/CrossGL/crosstl/issues/1793), but
+no bounded `arg_reduce.metal` manifest is supplied by this integration. Focused
+entry lowering preserves address-space pointer provenance, fixed private-array
+extents, and target dispatch dimensions, but does not establish an aggregate
+DirectX or OpenGL artifact frontier. Entry-scoped packaging remains tracked in
 [#1523](https://github.com/CrossGL/crosstl/issues/1523).
 The reduced reference-accessor fixture covers three non-template paths. The
 mutable scalar call returns the direct `val_frags[i * width + j]` lvalue and
@@ -830,6 +836,15 @@ axis-size-8192 workload described above. Only the VJP record applies function
 constant `20` (`has_w=true`), matching the pinned host dispatch; the forward
 record carries no function constant. These records do not prove runtime
 execution, numerical parity, looped variants, or the full MLX test suite.
+
+The project-porting harness consumes this contract against the unchanged pinned
+`layer_norm.metal` source and requires two deterministic DirectX artifacts. It
+checks source and contract identities, entry-scoped execution provenance,
+host-derived workgroup sizes, function-constant values, exact subgroup-width
+enforcement, generated hashes, and artifact paths. Windows CI compiles both
+artifacts with DXC `cs_6_6` and warnings as errors. This extends the bounded
+proof into the repository-level project report; it does not add runtime
+execution or numerical parity.
 
 Validate the fixture schema, provenance, deterministic identities, and bounded
 evaluation with:

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -3,20 +3,20 @@
   "repository": "https://github.com/ml-explore/mlx",
   "commit": "4367c73b60541ddd5a266ce4644fd93d20223b6e",
   "frontier_status": {
-    "status": "target-split-with-expected-workgroup-blockers",
+    "status": "target-split-with-bounded-dispatch-and-pending-contracts",
     "scope": "target-split-frontier",
     "sources": 11,
     "targets": [
       "directx",
       "vulkan"
     ],
-    "artifacts": 22,
-    "translated_artifacts": 16,
-    "failed_artifacts": 6,
+    "artifacts": 23,
+    "translated_artifacts": 18,
+    "failed_artifacts": 5,
     "target_artifacts": {
       "directx": {
-        "translated": 5,
-        "failed": 6
+        "translated": 7,
+        "failed": 5
       },
       "vulkan": {
         "translated": 11,
@@ -26,7 +26,14 @@
     "structural_validation_status": "validated",
     "semantic_readiness_status": "not-established",
     "workgroup_blocked_diagnostic": "project.translate.workgroup-size-entry-ambiguous",
-    "workgroup_blocked_by": "https://github.com/CrossGL/crosstl/issues/1793",
+    "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
+    "pending_host_dispatch_sources": [
+      "mlx/backend/metal/kernels/arg_reduce.metal",
+      "mlx/backend/metal/kernels/logsumexp.metal",
+      "mlx/backend/metal/kernels/rms_norm.metal",
+      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
+      "mlx/backend/metal/kernels/softmax.metal"
+    ],
     "excluded_blocked_sources": [
       "mlx/backend/metal/kernels/fence.metal"
     ],
@@ -119,7 +126,7 @@
       "opengl"
     ],
     "workgroup_blocked_diagnostic": "project.translate.workgroup-size-entry-ambiguous",
-    "workgroup_blocked_by": "https://github.com/CrossGL/crosstl/issues/1793",
+    "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
     "template_materialization_status": "materialized",
     "specialization_count": 51,
     "unsupported_specialization_count": 0,
@@ -162,7 +169,7 @@
     ],
     "workgroup_blocked_artifact_count": 5,
     "workgroup_blocked_diagnostic": "project.translate.workgroup-size-entry-ambiguous",
-    "workgroup_blocked_by": "https://github.com/CrossGL/crosstl/issues/1793",
+    "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
     "clean_project_diagnostic_count": 0,
     "glslang_compiled_artifact_count": 3,
     "spirv_validated_artifact_count": 3,
@@ -1472,15 +1479,15 @@
     "runtime_parity_claimed": false
   },
   "directx_toolchain_status": {
-    "status": "passing-with-expected-workgroup-blockers",
-    "note": "Windows CI compiles all 468 generated compute entries in the five-source emitted DirectX HLSL frontier below with zero DXC warnings. Six runtime-selected workgroup sources covering 106 entries fail before emission; no placeholder workgroup size is applied. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity.",
+    "status": "passing-with-bounded-dispatch-and-pending-contracts",
+    "note": "Windows CI compiles 470 generated compute entries across seven DirectX HLSL artifacts from six pinned sources with zero DXC warnings. LayerNorm contributes two entry-scoped artifacts selected by a replayable host dispatch contract. Five sources covering 94 aggregate entries still fail before emission because no bounded host dispatch manifest is configured; no placeholder workgroup size is applied. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity.",
     "compiler": {
       "name": "dxc",
       "version": "v1.9.2602.24"
     },
     "warning_evidence": {
       "status": "warning-clean",
-      "validatedRunCount": 468,
+      "validatedRunCount": 470,
       "warningRunCount": 0,
       "observedWarningCount": 0,
       "uniqueContractCount": 0,
@@ -1710,6 +1717,59 @@
       "runtime_execution_attempted": false,
       "numerical_parity_claimed": false
     },
+    "layer_norm_dispatch_frontier": {
+      "status": "translated-dxc-validated",
+      "source": "mlx/backend/metal/kernels/layer_norm.metal",
+      "source_sha256": "2d243f5abea7353929f9bc838ceb5a98e52a452dfc29609ad4d5974447ea689f",
+      "target": "directx",
+      "dispatch_contract": {
+        "path": "demos/integrations/mlx/contracts/layer_norm.dispatch.json",
+        "sha256": "17924e1eb885da0b91bed4ac67df39a72ab2f9448a40988efef2efd1f0f1bc93",
+        "content_identity": "sha256:527140d8720a414ff5eaeb670ee9312571c5ca1a13460353d0c177193f5a8f98",
+        "variant_count": 2,
+        "resolved_issue": "https://github.com/CrossGL/crosstl/issues/1793"
+      },
+      "artifact_count": 2,
+      "variants": {
+        "layer_normfloat32": {
+          "artifact_id": "sha256:6c2a76fa651fc945ff5f320801d70b925a3b289c2927990ab4161535edc8d6bf",
+          "dispatch_variant_id": "sha256:9f67f3aa323b6a35566bcce84c678121ba050a49843e10187bd5abf4ab3dd01c",
+          "workgroup_size": [
+            544,
+            1,
+            1
+          ],
+          "subgroup_width": 32,
+          "subgroup_width_enforcement": "WaveSize(32)",
+          "specialization_constants": {},
+          "generated_hlsl": {
+            "sha256": "8806341c2edcbfac4083ce4df7f4a18449125f828303b6c83e6460268418b2f3",
+            "size_bytes": 5831
+          }
+        },
+        "vjp_layer_normfloat32": {
+          "artifact_id": "sha256:7f6bf28c1536b59c8bd51d9f55dc80cb337698f15e1433f378e1692625e45d54",
+          "dispatch_variant_id": "sha256:eed664cf712ef3aeb953e3539389a6f3adcd853d8374aa16da343055080edbf1",
+          "workgroup_size": [
+            1024,
+            1,
+            1
+          ],
+          "subgroup_width": 32,
+          "subgroup_width_enforcement": "WaveSize(32)",
+          "specialization_constants": {
+            "20": true
+          },
+          "generated_hlsl": {
+            "sha256": "c565a0fc1bde31d3d04210f1a62be2bf96a703c8dcf8d1be51a73093a0a4a45f",
+            "size_bytes": 8802
+          }
+        }
+      },
+      "dxc_validated_artifact_count": 2,
+      "runtime_execution_attempted": false,
+      "numerical_parity_claimed": false
+    },
     "specialization_constants": {
       "1": false,
       "2": false,
@@ -1725,14 +1785,16 @@
     "expected_entry_point_counts": {
       "mlx/backend/metal/kernels/arange.metal": 11,
       "mlx/backend/metal/kernels/binary_two.metal": 225,
+      "mlx/backend/metal/kernels/layer_norm.metal": 2,
       "mlx/backend/metal/kernels/random.metal": 2,
       "mlx/backend/metal/kernels/rope.metal": 18,
       "mlx/backend/metal/kernels/ternary.metal": 212
     },
-    "expected_entry_point_count": 468,
+    "expected_entry_point_count": 470,
     "dxc_validated_sources": [
       "mlx/backend/metal/kernels/arange.metal",
       "mlx/backend/metal/kernels/binary_two.metal",
+      "mlx/backend/metal/kernels/layer_norm.metal",
       "mlx/backend/metal/kernels/random.metal",
       "mlx/backend/metal/kernels/rope.metal",
       "mlx/backend/metal/kernels/ternary.metal"
@@ -1801,7 +1863,6 @@
     },
     "workgroup_blocked_sources": [
       "mlx/backend/metal/kernels/arg_reduce.metal",
-      "mlx/backend/metal/kernels/layer_norm.metal",
       "mlx/backend/metal/kernels/logsumexp.metal",
       "mlx/backend/metal/kernels/rms_norm.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
@@ -1809,15 +1870,14 @@
     ],
     "workgroup_blocked_entry_point_counts": {
       "mlx/backend/metal/kernels/arg_reduce.metal": 24,
-      "mlx/backend/metal/kernels/layer_norm.metal": 12,
       "mlx/backend/metal/kernels/logsumexp.metal": 6,
       "mlx/backend/metal/kernels/rms_norm.metal": 12,
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": 42,
       "mlx/backend/metal/kernels/softmax.metal": 10
     },
-    "workgroup_blocked_entry_point_count": 106,
+    "workgroup_blocked_entry_point_count": 94,
     "workgroup_blocked_diagnostic": "project.translate.workgroup-size-entry-ambiguous",
-    "workgroup_blocked_by": "https://github.com/CrossGL/crosstl/issues/1793",
+    "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
     "dispatch_evidence": {
       "mlx/backend/metal/kernels/arg_reduce.metal": {
         "specializationCount": 51,
@@ -1836,30 +1896,6 @@
         "materializationParameters": [
           "N_READS",
           "Op",
-          "T"
-        ]
-      },
-      "mlx/backend/metal/kernels/layer_norm.metal": {
-        "specializationCount": 16,
-        "hostSource": "mlx/backend/metal/normalization.cpp",
-        "hostLines": "248-297,346-422",
-        "dispatchFormulas": [
-          "forward block: [32 * ceil_div(ceil_div(axis_size, 8), 32), 1, 1]",
-          "forward looped: [maxTotalThreadsPerThreadgroup, 1, 1]",
-          "VJP block: [32 * ceil_div(ceil_div(axis_size, 8), 32), 1, 1]",
-          "VJP looped: [maxTotalThreadsPerThreadgroup, 1, 1]"
-        ],
-        "dispatchSelection": [
-          "forward block when axis_size <= 6656; looped when axis_size > 6656",
-          "VJP block when axis_size <= 8192; looped when axis_size > 8192"
-        ],
-        "runtimeOperands": [
-          "axis_size",
-          "forward_or_vjp_entry",
-          "maxTotalThreadsPerThreadgroup"
-        ],
-        "materializationParameters": [
-          "N_READS",
           "T"
         ]
       },
@@ -1956,12 +1992,11 @@
       }
     },
     "directx_toolchain_gaps": {
-      "mlx/backend/metal/kernels/arg_reduce.metal": "runtime-selected workgroup size is unavailable to source materialization and fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/layer_norm.metal": "runtime-selected workgroup size is unavailable to source materialization and fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/logsumexp.metal": "runtime-selected workgroup size is unavailable to source materialization and fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/rms_norm.metal": "runtime-selected workgroup size is unavailable to source materialization and fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": "runtime-selected pass and shape determine the workgroup size, which is unavailable to source materialization; translation fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/softmax.metal": "runtime-selected workgroup size is unavailable to source materialization and fails with project.translate.workgroup-size-entry-ambiguous (https://github.com/CrossGL/crosstl/issues/1793)",
+      "mlx/backend/metal/kernels/arg_reduce.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
+      "mlx/backend/metal/kernels/logsumexp.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
+      "mlx/backend/metal/kernels/rms_norm.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
+      "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": "no bounded host dispatch manifest is configured for the runtime-selected pass, shape, and device architecture; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
+      "mlx/backend/metal/kernels/softmax.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
       "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)"
     },
     "native_runtime_executed": false,
@@ -2181,7 +2216,6 @@
     "https://github.com/CrossGL/crosstl/issues/1671",
     "https://github.com/CrossGL/crosstl/issues/1696",
     "https://github.com/CrossGL/crosstl/issues/1735",
-    "https://github.com/CrossGL/crosstl/issues/1793",
     "https://github.com/CrossGL/crosstl/issues/1786",
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1462",
@@ -2226,6 +2260,7 @@
   ],
   "resolved_issues": [
     "https://github.com/CrossGL/crosstl/issues/1515",
+    "https://github.com/CrossGL/crosstl/issues/1793",
     "https://github.com/CrossGL/crosstl/issues/1576",
     "https://github.com/CrossGL/crosstl/issues/1829",
     "https://github.com/CrossGL/crosstl/issues/1826",

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -1724,7 +1724,7 @@
       "target": "directx",
       "dispatch_contract": {
         "path": "demos/integrations/mlx/contracts/layer_norm.dispatch.json",
-        "sha256": "17924e1eb885da0b91bed4ac67df39a72ab2f9448a40988efef2efd1f0f1bc93",
+        "normalized_sha256": "17924e1eb885da0b91bed4ac67df39a72ab2f9448a40988efef2efd1f0f1bc93",
         "content_identity": "sha256:527140d8720a414ff5eaeb670ee9312571c5ca1a13460353d0c177193f5a8f98",
         "variant_count": 2,
         "resolved_issue": "https://github.com/CrossGL/crosstl/issues/1793"

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -20,6 +20,7 @@ from crosstl.project import (
     build_project_test_runner_plan,
     build_runtime_artifact_manifest,
     execute_project_test_runner_plan,
+    load_dispatch_contract,
     load_project_translation_checkpoint,
     native_runtime_parity_adapters,
 )
@@ -48,6 +49,44 @@ MLX_GEMV_SOURCE = "mlx/backend/metal/kernels/gemv.metal"
 MLX_GEMV_SHA256 = "c34db77e61c1fea01f7f5d319a0bec1029a253e54d66bbce9009f32fe828ce9f"
 MLX_GEMV_SOURCE_SIZE_BYTES = 5383
 MLX_LAYER_NORM_SOURCE = "mlx/backend/metal/kernels/layer_norm.metal"
+MLX_LAYER_NORM_SHA256 = (
+    "2d243f5abea7353929f9bc838ceb5a98e52a452dfc29609ad4d5974447ea689f"
+)
+MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE = (
+    Path(__file__).resolve().parent / "contracts" / "layer_norm.dispatch.json"
+)
+MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256 = (
+    "17924e1eb885da0b91bed4ac67df39a72ab2f9448a40988efef2efd1f0f1bc93"
+)
+MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY = (
+    "sha256:527140d8720a414ff5eaeb670ee9312571c5ca1a13460353d0c177193f5a8f98"
+)
+MLX_LAYER_NORM_DISPATCH_VARIANTS = {
+    "layer_normfloat32": {
+        "artifactId": (
+            "sha256:6c2a76fa651fc945ff5f320801d70b925a3b289c2927990ab4161535edc8d6bf"
+        ),
+        "dispatchVariantId": (
+            "sha256:9f67f3aa323b6a35566bcce84c678121ba050a49843e10187bd5abf4ab3dd01c"
+        ),
+        "workgroupSize": [544, 1, 1],
+        "subgroupWidth": 32,
+        "specializationConstants": {},
+        "specializationCount": 3,
+    },
+    "vjp_layer_normfloat32": {
+        "artifactId": (
+            "sha256:7f6bf28c1536b59c8bd51d9f55dc80cb337698f15e1433f378e1692625e45d54"
+        ),
+        "dispatchVariantId": (
+            "sha256:eed664cf712ef3aeb953e3539389a6f3adcd853d8374aa16da343055080edbf1"
+        ),
+        "workgroupSize": [1024, 1, 1],
+        "subgroupWidth": 32,
+        "specializationConstants": {"20": True},
+        "specializationCount": 4,
+    },
+}
 MLX_LOGSUMEXP_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
 MLX_METAL_ROUNDTRIP_SOURCE = MLX_FENCE_SOURCE
 MLX_RANDOM_SOURCE = "mlx/backend/metal/kernels/random.metal"
@@ -102,6 +141,11 @@ MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES = (
     MLX_RMS_NORM_SOURCE,
     MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE,
     MLX_SOFTMAX_SOURCE,
+)
+MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES = tuple(
+    source
+    for source in MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+    if source != MLX_LAYER_NORM_SOURCE
 )
 MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES = tuple(
     source
@@ -224,16 +268,28 @@ MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS = {
     MLX_SOFTMAX_SOURCE: 10,
     MLX_TERNARY_SOURCE: 212,
 }
-# DXC compiles only sources whose pinned host dispatch does not require a runtime
-# workgroup-size variant. Dynamic sources remain explicit failed artifact records.
-MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
+# Aggregate artifacts retain every source entry when one workgroup contract applies.
+# LayerNorm contributes two bounded, entry-scoped host-dispatch artifacts.
+MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = tuple(
+    source
+    for source in MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
+    if source in MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
+    or source == MLX_LAYER_NORM_SOURCE
+)
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
-    source: MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS[source]
+    source: (
+        len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+        if source == MLX_LAYER_NORM_SOURCE
+        else MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS[source]
+    )
     for source in MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
 }
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT = sum(
     MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
 )
+MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT = len(
+    MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
+) + len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
 MLX_DIRECTX_TOOLCHAIN_WARNING_CONTRACTS: tuple[dict[str, Any], ...] = ()
 DIRECTX_TOOLCHAIN_WARNING_TRACKED_ISSUES: tuple[str, ...] = ()
 MLX_DIRECTX_TOOLCHAIN_WARNING_EVIDENCE = {
@@ -315,6 +371,10 @@ MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS = {
     source: MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS[source]
     for source in MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
 }
+MLX_DIRECTX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS = {
+    source: MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS[source]
+    for source in MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+}
 MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_CODE = (
     "project.translate.workgroup-size-entry-ambiguous"
 )
@@ -323,7 +383,9 @@ MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_MESSAGE = (
     "emitted entry points do not declare a shared source size. Select one entry "
     "point or emit independently specialized artifacts."
 )
-MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE = "https://github.com/CrossGL/crosstl/issues/1793"
+MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE = (
+    "https://github.com/CrossGL/crosstl/issues/1793"
+)
 MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE = {
     MLX_ARG_REDUCE_SOURCE: {
         "specializationCount": 51,
@@ -886,7 +948,6 @@ RUNTIME_READINESS_PLAN_DIAGNOSTIC_CODES = frozenset(
 FULL_CORPUS_TRACKED_ISSUES = (
     *FRONTIER_VALIDATION_TRACKED_ISSUES,
     *DIRECTX_TOOLCHAIN_WARNING_TRACKED_ISSUES,
-    MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE,
     *FULL_CORPUS_TRANSLATION_TRACKED_ISSUES,
     *FULL_CORPUS_VALIDATION_TRACKED_ISSUES,
     *OPENGL_ARANGE_VALIDATION_TRACKED_ISSUES,
@@ -901,6 +962,7 @@ FULL_CORPUS_TRACKED_ISSUES = (
 )
 RESOLVED_FRONTIER_ISSUES = (
     OPENGL_QUANTIZED_INDEX_TYPE_RESOLVED_ISSUE,
+    MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
     "https://github.com/CrossGL/crosstl/issues/1576",
     "https://github.com/CrossGL/crosstl/issues/1799",
     "https://github.com/CrossGL/crosstl/issues/1800",
@@ -1285,6 +1347,7 @@ def _write_project_config(
     entry_points: Mapping[str, str] | None = None,
     workgroup_size_rules: Mapping[str, Sequence[str | int]] | None = None,
     index_range_assertions: Sequence[Mapping[str, str | int]] | None = None,
+    dispatch_contracts: Sequence[str] | None = None,
 ) -> None:
     include_values = [include] if isinstance(include, str) else list(include)
     include_list = ", ".join(json.dumps(value) for value in include_values)
@@ -1296,11 +1359,11 @@ def _write_project_config(
         'include_dirs = ["."]',
         f"targets = [{target_list}]",
         f'output_dir = "{output_dir}"',
-        "",
-        "[project.sources]",
-        '"**/*.metal" = "metal"',
-        "",
     ]
+    if dispatch_contracts:
+        contract_list = ", ".join(json.dumps(path) for path in dispatch_contracts)
+        lines.append(f"dispatch_contracts = [{contract_list}]")
+    lines.extend(("", "[project.sources]", '"**/*.metal" = "metal"', ""))
     for assertion in index_range_assertions or ():
         lines.append("[[project.index_range_assertions]]")
         for field in ("source", "function", "expression", "minimum", "maximum"):
@@ -1334,6 +1397,71 @@ def _write_project_config(
                 lines.append(f"{key} = {value}")
             lines.append("")
     path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _prepare_layer_norm_dispatch_contract(
+    mlx_root: Path,
+    work_dir: Path,
+) -> dict[str, Any]:
+    source_path = MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE
+    _require(
+        source_path.is_file(), f"LayerNorm dispatch contract is missing: {source_path}"
+    )
+    _require(
+        _sha256(source_path) == MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256,
+        "LayerNorm dispatch contract content changed",
+    )
+    layer_norm_source = mlx_root / MLX_LAYER_NORM_SOURCE
+    _require(
+        layer_norm_source.is_file()
+        and _sha256(layer_norm_source) == MLX_LAYER_NORM_SHA256,
+        "pinned LayerNorm source identity changed",
+    )
+
+    manifest = load_dispatch_contract(source_path)
+    content_identity = manifest.content_identity.to_json()
+    expected_identity = {
+        "algorithm": "sha256",
+        "value": MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY.removeprefix("sha256:"),
+    }
+    _require(
+        content_identity == expected_identity,
+        "LayerNorm dispatch contract identity changed",
+    )
+    evaluation = manifest.evaluate().to_json()
+    variants = evaluation.get("variants")
+    variants_by_entry = {
+        variant.get("entryPoint"): variant
+        for variant in variants or []
+        if isinstance(variant, Mapping)
+    }
+    _require(
+        isinstance(variants, list)
+        and len(variants) == len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+        and set(variants_by_entry) == set(MLX_LAYER_NORM_DISPATCH_VARIANTS),
+        "LayerNorm dispatch contract variant set changed",
+    )
+    for entry_point, expected in MLX_LAYER_NORM_DISPATCH_VARIANTS.items():
+        variant = variants_by_entry[entry_point]
+        _require(
+            variant.get("artifactId") == expected["artifactId"]
+            and variant.get("variantId") == expected["dispatchVariantId"]
+            and variant.get("source") == MLX_LAYER_NORM_SOURCE
+            and variant.get("workgroupSize") == expected["workgroupSize"]
+            and variant.get("subgroupWidth") == expected["subgroupWidth"]
+            and variant.get("specializationConstants")
+            == expected["specializationConstants"],
+            f"LayerNorm dispatch contract changed for {entry_point}",
+        )
+
+    destination = work_dir / "contracts" / "layer_norm.dispatch.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source_path, destination)
+    return {
+        "path": _relpath(destination, mlx_root),
+        "contentIdentity": content_identity,
+        "variantCount": len(variants),
+    }
 
 
 def _write_reference_accessor_project_config(path: Path, output_dir: str) -> None:
@@ -3367,6 +3495,310 @@ def _require_clean_frontier_report(
     return artifacts_by_source
 
 
+def _require_layer_norm_dispatch_frontier_report(
+    mlx_root: Path,
+    output_dir: Path,
+    payload: Mapping[str, Any],
+    *,
+    contract: Mapping[str, Any],
+    validated: bool,
+) -> tuple[dict[str, Mapping[str, Any]], dict[str, Any], list[Mapping[str, Any]]]:
+    project = payload.get("project")
+    contract_records = (
+        project.get("dispatchContracts") if isinstance(project, Mapping) else None
+    )
+    _require(
+        isinstance(project, Mapping)
+        and project.get("includePatterns") == [MLX_LAYER_NORM_SOURCE]
+        and project.get("targets") == ["directx"]
+        and project.get("dispatchContractFiles") == [contract["path"]]
+        and project.get("dispatchContractCount") == 1
+        and project.get("dispatchVariantCount") == len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+        and isinstance(contract_records, list)
+        and len(contract_records) == 1,
+        "LayerNorm dispatch frontier project metadata changed",
+    )
+    contract_record = contract_records[0]
+    expected_manifest_path = str((mlx_root / str(contract["path"])).resolve())
+    _require(
+        isinstance(contract_record, Mapping)
+        and contract_record.get("path") == contract["path"]
+        and contract_record.get("schemaVersion") == 1
+        and contract_record.get("contentIdentity") == contract["contentIdentity"]
+        and contract_record.get("manifest", {}).get("provenance", {}).get("commit")
+        == MLX_COMMIT
+        and contract_record.get("evaluation", {}).get("manifestSource")
+        == expected_manifest_path
+        and contract_record.get("evaluation", {}).get("variantCount")
+        == len(MLX_LAYER_NORM_DISPATCH_VARIANTS),
+        "LayerNorm dispatch frontier did not retain replayable manifest provenance",
+    )
+
+    summary = payload.get("summary")
+    artifact_count = len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+    _require(
+        isinstance(summary, Mapping)
+        and summary.get("unitCount") == 1
+        and summary.get("artifactCount") == artifact_count
+        and summary.get("translatedCount") == artifact_count
+        and summary.get("failedCount") == 0
+        and summary.get("diagnosticCounts") == {"error": 0, "note": 0, "warning": 0}
+        and summary.get("artifactsByTarget", {}).get("directx")
+        == {
+            "artifactCount": artifact_count,
+            "translatedCount": artifact_count,
+            "failedCount": 0,
+        }
+        and payload.get("diagnostics") == [],
+        "LayerNorm dispatch frontier accounting changed",
+    )
+    units = payload.get("units")
+    _require(
+        isinstance(units, list)
+        and len(units) == 1
+        and units[0].get("path") == MLX_LAYER_NORM_SOURCE
+        and units[0].get("sourceBackend") == "metal"
+        and units[0].get("sourceHash")
+        == {"algorithm": "sha256", "value": MLX_LAYER_NORM_SHA256},
+        "LayerNorm dispatch frontier source identity changed",
+    )
+
+    dispatch_plan = project.get("dispatchArtifactPlan")
+    planned_artifacts = (
+        dispatch_plan.get("artifacts") if isinstance(dispatch_plan, Mapping) else None
+    )
+    _require(
+        isinstance(dispatch_plan, Mapping)
+        and dispatch_plan.get("kind") == "crosstl-dispatch-artifact-plan"
+        and dispatch_plan.get("schemaVersion") == 1
+        and dispatch_plan.get("sourceUnitCount") == 1
+        and dispatch_plan.get("artifactCount") == artifact_count
+        and dispatch_plan.get("dispatchVariantCount") == artifact_count
+        and isinstance(planned_artifacts, list)
+        and len(planned_artifacts) == artifact_count,
+        "LayerNorm dispatch artifact plan changed",
+    )
+    plan_by_entry = {
+        record.get("entryPoint"): record
+        for record in planned_artifacts
+        if isinstance(record, Mapping)
+    }
+    _require(
+        set(plan_by_entry) == set(MLX_LAYER_NORM_DISPATCH_VARIANTS),
+        "LayerNorm dispatch artifact plan entry set changed",
+    )
+
+    artifacts = payload.get("artifacts")
+    _require(
+        isinstance(artifacts, list) and len(artifacts) == artifact_count,
+        "LayerNorm dispatch artifact records are incomplete",
+    )
+    output_root = output_dir.resolve()
+    artifacts_by_entry: dict[str, Mapping[str, Any]] = {}
+    generated_evidence: dict[str, Any] = {}
+    for artifact in artifacts:
+        entry = artifact.get("entryPoint") if isinstance(artifact, Mapping) else None
+        entry_point = entry.get("source") if isinstance(entry, Mapping) else None
+        _require(
+            isinstance(entry_point, str)
+            and entry_point in MLX_LAYER_NORM_DISPATCH_VARIANTS
+            and entry_point not in artifacts_by_entry,
+            "LayerNorm dispatch artifact entry identity changed",
+        )
+        expected = MLX_LAYER_NORM_DISPATCH_VARIANTS[entry_point]
+        plan = plan_by_entry[entry_point]
+        variant_name = "dispatch-" + expected["artifactId"].removeprefix("sha256:")
+        _require(
+            artifact.get("source") == MLX_LAYER_NORM_SOURCE
+            and artifact.get("sourceBackend") == "metal"
+            and artifact.get("sourceHash")
+            == {"algorithm": "sha256", "value": MLX_LAYER_NORM_SHA256}
+            and artifact.get("target") == "directx"
+            and artifact.get("status") == "translated"
+            and artifact.get("variant") == variant_name
+            and entry.get("target") == "CSMain"
+            and entry.get("stage") == "compute"
+            and artifact.get("dispatchArtifact") == plan
+            and plan.get("artifactId") == expected["artifactId"]
+            and plan.get("dispatchVariantIds") == [expected["dispatchVariantId"]]
+            and plan.get("manifestContentIdentities")
+            == [MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY]
+            and plan.get("source") == MLX_LAYER_NORM_SOURCE
+            and plan.get("workgroupSize") == expected["workgroupSize"]
+            and plan.get("subgroupWidth") == expected["subgroupWidth"]
+            and plan.get("specializationConstants")
+            == expected["specializationConstants"],
+            f"LayerNorm dispatch artifact contract changed for {entry_point}",
+        )
+
+        execution = artifact.get("execution")
+        execution_entries = (
+            execution.get("entryPoints") if isinstance(execution, Mapping) else None
+        )
+        _require(
+            isinstance(execution, Mapping)
+            and execution.get("sourceEntryPoints") == [entry_point]
+            and execution.get("provenance", {}).get("kind") == "host-dispatch-contract"
+            and execution.get("provenance", {}).get("artifactId")
+            == expected["artifactId"]
+            and execution.get("subgroupWidthProvenance", {}).get("kind")
+            == "host-dispatch-contract"
+            and execution.get("subgroupWidthEnforcement")
+            == {
+                "mechanism": "hlsl-wave-size-attribute",
+                "minimumShaderModel": "6.6",
+                "entryProfiles": [{"entryPoint": "CSMain", "profile": "cs_6_6"}],
+            }
+            and isinstance(execution_entries, list)
+            and len(execution_entries) == 1
+            and execution_entries[0].get("sourceEntryPoint") == entry_point
+            and execution_entries[0].get("materializedEntryPoint") == entry_point
+            and execution_entries[0].get("targetEntryPoint") == "CSMain"
+            and execution_entries[0].get("workgroupSize") == expected["workgroupSize"]
+            and execution_entries[0].get("subgroupWidth") == expected["subgroupWidth"],
+            f"LayerNorm execution metadata changed for {entry_point}",
+        )
+
+        constants = artifact.get("specializationConstants") or []
+        constants_by_id = {
+            str(record.get("id")): record
+            for record in constants
+            if isinstance(record, Mapping)
+        }
+        _require(
+            set(constants_by_id) == set(expected["specializationConstants"]),
+            f"LayerNorm specialization inputs changed for {entry_point}",
+        )
+        for constant_id, value in expected["specializationConstants"].items():
+            record = constants_by_id[constant_id]
+            _require(
+                record.get("concreteValue") is value
+                and record.get("deferred") is False
+                and record.get("valueProvenance", {}).get("kind")
+                == "host-dispatch-contract"
+                and record.get("valueProvenance", {}).get("artifactId")
+                == expected["artifactId"],
+                f"LayerNorm specialization provenance changed for {entry_point}",
+            )
+
+        materialization = artifact.get("templateMaterialization")
+        specializations = (
+            materialization.get("specializations")
+            if isinstance(materialization, Mapping)
+            else None
+        )
+        host_names = [
+            record.get("hostName")
+            for record in specializations or []
+            if isinstance(record, Mapping) and record.get("hostName") is not None
+        ]
+        _require(
+            isinstance(materialization, Mapping)
+            and materialization.get("status") == "materialized"
+            and materialization.get("specializationCount")
+            == expected["specializationCount"]
+            and isinstance(specializations, list)
+            and len(specializations) == expected["specializationCount"]
+            and materialization.get("unsupported") == []
+            and host_names == [entry_point],
+            f"LayerNorm materialization changed for {entry_point}",
+        )
+
+        artifact_path_value = artifact.get("path")
+        _require(
+            isinstance(artifact_path_value, str) and artifact_path_value,
+            f"LayerNorm artifact path is missing for {entry_point}",
+        )
+        artifact_path = (mlx_root / artifact_path_value).resolve()
+        _require(
+            _is_relative_to(artifact_path, output_root) and artifact_path.is_file(),
+            f"LayerNorm artifact is missing or escaped output for {entry_point}",
+        )
+        generated = artifact_path.read_text(encoding="utf-8")
+        generated_hash = _sha256(artifact_path)
+        _require(
+            artifact.get("generatedHash")
+            == {"algorithm": "sha256", "value": generated_hash}
+            and artifact.get("generatedSizeBytes") == artifact_path.stat().st_size
+            and len(re.findall(r"\bvoid\s+CSMain\s*\(", generated)) == 1
+            and re.search(r"\[\s*WaveSize\s*\(\s*32\s*\)\s*\]", generated) is not None
+            and re.search(
+                r"\[\s*numthreads\s*\(\s*{}\s*,\s*1\s*,\s*1\s*\)\s*\]".format(
+                    expected["workgroupSize"][0]
+                ),
+                generated,
+            )
+            is not None,
+            f"LayerNorm generated HLSL contract changed for {entry_point}",
+        )
+        if expected["specializationConstants"]:
+            _require(
+                re.search(r"\bstatic\s+const\s+bool\s+has_w\s*=\s*true\s*;", generated)
+                is not None,
+                "LayerNorm VJP artifact did not materialize has_w=true",
+            )
+        else:
+            _require(
+                re.search(r"\bhas_w\b", generated) is None,
+                "LayerNorm forward artifact retained an unreachable function constant",
+            )
+        generated_evidence[entry_point] = {
+            "artifactId": expected["artifactId"],
+            "dispatchVariantId": expected["dispatchVariantId"],
+            "workgroupSize": list(expected["workgroupSize"]),
+            "subgroupWidth": expected["subgroupWidth"],
+            "specializationConstants": dict(expected["specializationConstants"]),
+            "generatedHlsl": {
+                "sha256": generated_hash,
+                "sizeBytes": artifact_path.stat().st_size,
+            },
+        }
+        artifacts_by_entry[entry_point] = artifact
+
+    toolchain_runs: list[Mapping[str, Any]] = []
+    if validated:
+        validation = payload.get("validation")
+        runs = (
+            validation.get("toolchainRuns") if isinstance(validation, Mapping) else None
+        )
+        _require(
+            isinstance(validation, Mapping)
+            and isinstance(validation.get("summary"), Mapping)
+            and validation["summary"].get("failedCount") == 0
+            and isinstance(runs, list),
+            "LayerNorm dispatch DXC validation changed",
+        )
+        toolchain_runs = [
+            run
+            for run in runs
+            if isinstance(run, Mapping) and run.get("target") == "directx"
+        ]
+        _require(
+            len(toolchain_runs) == artifact_count
+            and all(run.get("status") == "ok" for run in toolchain_runs),
+            "LayerNorm dispatch DXC did not validate both artifacts",
+        )
+
+    evidence = {
+        "status": "translated-dxc-validated" if validated else "translated",
+        "source": MLX_LAYER_NORM_SOURCE,
+        "sourceSha256": MLX_LAYER_NORM_SHA256,
+        "target": "directx",
+        "dispatchContract": {
+            "path": contract["path"],
+            "contentIdentity": MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY,
+            "variantCount": artifact_count,
+            "resolvedIssue": MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
+        },
+        "artifactCount": artifact_count,
+        "variants": generated_evidence,
+        "dxcValidatedArtifactCount": len(toolchain_runs),
+        "runtimeExecutionAttempted": False,
+        "numericalParityClaimed": False,
+    }
+    return artifacts_by_entry, evidence, toolchain_runs
+
+
 def _require_directx_bfloat16_lowering_evidence(
     artifacts_by_source: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, dict[str, Any]]:
@@ -3653,6 +4085,7 @@ def _run_frontier_project(
     check: bool = True,
     specialization_constants: Mapping[str, bool | int | float] | None = None,
     index_range_assertions: Sequence[Mapping[str, str | int]] | None = None,
+    dispatch_contracts: Sequence[str] | None = None,
 ) -> tuple[CommandResult, dict[str, Any], Path, Path]:
     config_path = config_dir / f"{command_name}.toml"
     report_path = report_dir / f"{command_name}.json"
@@ -3666,6 +4099,7 @@ def _run_frontier_project(
         output_dir=_relpath(output_dir, mlx_root),
         specialization_constants=specialization_constants,
         index_range_assertions=index_range_assertions,
+        dispatch_contracts=dispatch_contracts,
     )
     command = [
         python,
@@ -3723,6 +4157,37 @@ def _translate_directx_frontier(
         clean_artifacts
     )
 
+    layer_norm_contract = _prepare_layer_norm_dispatch_contract(mlx_root, work_dir)
+    layer_norm_output_dir = work_dir / "out-directx-layer-norm-dispatch-frontier"
+    (
+        _layer_norm_result,
+        layer_norm_payload,
+        _layer_norm_config,
+        layer_norm_report_path,
+    ) = _run_frontier_project(
+        mlx_root=mlx_root,
+        config_dir=config_dir,
+        report_dir=report_dir,
+        log_dir=log_dir,
+        python=python,
+        command_name="directx-layer-norm-dispatch-frontier",
+        target="directx",
+        sources=(MLX_LAYER_NORM_SOURCE,),
+        output_dir=layer_norm_output_dir,
+        dispatch_contracts=(str(layer_norm_contract["path"]),),
+    )
+    (
+        layer_norm_artifacts,
+        layer_norm_evidence,
+        _layer_norm_runs,
+    ) = _require_layer_norm_dispatch_frontier_report(
+        mlx_root,
+        layer_norm_output_dir,
+        layer_norm_payload,
+        contract=layer_norm_contract,
+        validated=False,
+    )
+
     blocked_output_dir = work_dir / "out-directx-workgroup-frontier"
     blocked_result, blocked_payload, _blocked_config, blocked_report_path = (
         _run_frontier_project(
@@ -3733,7 +4198,7 @@ def _translate_directx_frontier(
             python=python,
             command_name="directx-workgroup-frontier",
             target="directx",
-            sources=MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
+            sources=MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
             output_dir=blocked_output_dir,
             validate=True,
             check=False,
@@ -3749,7 +4214,7 @@ def _translate_directx_frontier(
         blocked_output_dir,
         blocked_payload,
         target="directx",
-        sources=MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
+        sources=MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
         validated=True,
     )
 
@@ -3765,7 +4230,7 @@ def _translate_directx_frontier(
                 python=python,
                 command_name="validate-directx-frontier-toolchain",
                 target="directx",
-                sources=MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES,
+                sources=MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES,
                 output_dir=toolchain_output_dir,
                 run_toolchains=True,
                 specialization_constants=MLX_FRONTIER_SPECIALIZATION_CONSTANTS,
@@ -3776,7 +4241,7 @@ def _translate_directx_frontier(
             toolchain_output_dir,
             toolchain_payload,
             target="directx",
-            sources=MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES,
+            sources=MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES,
         )
         _require_directx_bfloat16_lowering_evidence(artifacts)
         validation = toolchain_payload.get("validation")
@@ -3786,12 +4251,48 @@ def _translate_directx_frontier(
         _require(
             isinstance(runs, list), "DirectX frontier toolchainRuns must be a list"
         )
-        directx_runs = [
+        aggregate_runs = [
             run
             for run in runs
             if isinstance(run, Mapping) and run.get("target") == "directx"
         ]
-        artifact_paths = {artifact["path"] for artifact in artifacts.values()}
+        layer_norm_toolchain_output = (
+            work_dir / "out-directx-layer-norm-dispatch-toolchain"
+        )
+        (
+            _layer_norm_toolchain_result,
+            layer_norm_toolchain_payload,
+            _layer_norm_toolchain_config,
+            _layer_norm_toolchain_report,
+        ) = _run_frontier_project(
+            mlx_root=mlx_root,
+            config_dir=config_dir,
+            report_dir=report_dir,
+            log_dir=log_dir,
+            python=python,
+            command_name="validate-directx-layer-norm-dispatch-toolchain",
+            target="directx",
+            sources=(MLX_LAYER_NORM_SOURCE,),
+            output_dir=layer_norm_toolchain_output,
+            run_toolchains=True,
+            dispatch_contracts=(str(layer_norm_contract["path"]),),
+        )
+        (
+            layer_norm_artifacts,
+            layer_norm_evidence,
+            layer_norm_runs,
+        ) = _require_layer_norm_dispatch_frontier_report(
+            mlx_root,
+            layer_norm_toolchain_output,
+            layer_norm_toolchain_payload,
+            contract=layer_norm_contract,
+            validated=True,
+        )
+        directx_runs = [*aggregate_runs, *layer_norm_runs]
+        artifact_paths = {
+            *(artifact["path"] for artifact in artifacts.values()),
+            *(artifact["path"] for artifact in layer_norm_artifacts.values()),
+        }
         validated_paths = {
             run.get("path") for run in directx_runs if run.get("status") == "ok"
         }
@@ -3803,6 +4304,10 @@ def _translate_directx_frontier(
     directx_entry_points_by_source: dict[str, list[str]] = {
         source: [] for source in MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
     }
+    layer_norm_entry_by_path = {
+        artifact["path"]: entry_point
+        for entry_point, artifact in layer_norm_artifacts.items()
+    }
     for run in directx_runs:
         if run.get("status") != "ok":
             continue
@@ -3811,7 +4316,11 @@ def _translate_directx_frontier(
             source in directx_entry_points_by_source,
             f"DirectX toolchain validation reported an unexpected source: {source}",
         )
-        entry_point = _directx_toolchain_entry_point(run)
+        entry_point = (
+            layer_norm_entry_by_path.get(run.get("path"))
+            if source == MLX_LAYER_NORM_SOURCE
+            else _directx_toolchain_entry_point(run)
+        )
         _require(
             entry_point is not None,
             "DirectX toolchain validation did not record a compute entry command",
@@ -3847,22 +4356,29 @@ def _translate_directx_frontier(
     warning_evidence = _directx_toolchain_warning_evidence(directx_runs)
     return {
         "name": "directx-frontier",
-        "status": "passed-with-expected-workgroup-blockers",
+        "status": "passed-with-bounded-dispatch-and-pending-contracts",
         "scope": "target-split-frontier",
         "report": _relpath(report_path, mlx_root),
+        "layerNormDispatchReport": _relpath(layer_norm_report_path, mlx_root),
         "workgroupBlockedReport": _relpath(blocked_report_path, mlx_root),
         "sources": list(MLX_DIRECTX_VULKAN_FRONTIER_SOURCES),
         "unitCount": len(MLX_DIRECTX_VULKAN_FRONTIER_SOURCES),
-        "artifactCount": len(MLX_DIRECTX_VULKAN_FRONTIER_SOURCES),
-        "translatedSources": list(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES),
-        "translatedArtifactCount": len(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES),
-        "workgroupBlockedSources": list(MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES),
-        "workgroupBlockedArtifactCount": len(MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES),
+        "artifactCount": (
+            len(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES)
+            + len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+            + len(MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES)
+        ),
+        "translatedSources": list(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+        "translatedArtifactCount": MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT,
+        "workgroupBlockedSources": list(MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES),
+        "workgroupBlockedArtifactCount": len(
+            MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+        ),
         "target": "directx",
         "toolchainRuns": len(directx_runs),
         "directxToolchainRequired": require_directx_toolchain,
         "directxToolchainSources": list(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
-        "directxToolchainArtifactCount": len(MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES),
+        "directxToolchainArtifactCount": MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT,
         "directxToolchainExpectedEntryPointCounts": dict(
             MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
         ),
@@ -3870,7 +4386,9 @@ def _translate_directx_frontier(
             MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT
         ),
         "directxToolchainValidatedSources": directx_validated_sources,
-        "directxToolchainValidatedArtifactCount": len(directx_validated_sources),
+        "directxToolchainValidatedArtifactCount": (
+            MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT if directx_runs else 0
+        ),
         "directxToolchainValidatedEntryPointCounts": (
             directx_validated_entry_point_counts
         ),
@@ -3884,13 +4402,14 @@ def _translate_directx_frontier(
         "contextualNarrowingEvidence": MLX_DIRECTX_CONTEXTUAL_NARROWING_EVIDENCE,
         "native16BitArithmeticEvidence": MLX_DIRECTX_NATIVE_16_BIT_ARITHMETIC_EVIDENCE,
         "bfloat16LoweringEvidence": bfloat16_lowering_evidence,
+        "layerNormDispatchEvidence": layer_norm_evidence,
         "dynamicWorkgroupDispatchEvidence": dispatch_evidence,
         "semanticReadinessStatus": "not-established",
         "trackedIssues": [
-            MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE,
             *FRONTIER_VALIDATION_TRACKED_ISSUES,
             *DIRECTX_TOOLCHAIN_WARNING_TRACKED_ISSUES,
         ],
+        "resolvedIssues": [MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE],
         "runtimeParityClaimed": False,
     }
 
@@ -4440,7 +4959,8 @@ def _check_opengl_frontier(
             "runtimeEnforced": False,
         },
         "dynamicWorkgroupDispatchEvidence": dispatch_evidence,
-        "trackedIssues": [MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE],
+        "trackedIssues": [],
+        "resolvedIssues": [MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE],
         "runtimeIntegrationIncluded": False,
     }
 
@@ -7101,10 +7621,13 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             "blockedFrontierSources": list(MLX_BLOCKED_REDUCED_FRONTIER_SOURCES),
             "blockedFrontierIssues": list(FENCE_CONTRACT_TRACKED_ISSUES),
             "directxTranslatedFrontierSources": list(
-                MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
+                MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+            ),
+            "directxTranslatedFrontierArtifactCount": (
+                MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT
             ),
             "directxWorkgroupBlockedFrontierSources": list(
-                MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+                MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
             ),
             "vulkanTranslatedFrontierSources": list(
                 MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
@@ -7115,7 +7638,7 @@ def run_checks(args: argparse.Namespace) -> dict[str, Any]:
             "openglWorkgroupBlockedFrontierSources": list(
                 MLX_OPENGL_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
             ),
-            "dynamicWorkgroupTrackedIssue": MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE,
+            "hostDispatchImportResolvedIssue": MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
             "fullCorpusTargets": list(FULL_CORPUS_TARGETS),
             "fullCorpusExpectedUnitCount": EXPECTED_METAL_KERNEL_COUNT,
             "fullCorpusExpectedArtifactCount": FULL_CORPUS_EXPECTED_ARTIFACT_COUNT,

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -55,7 +55,7 @@ MLX_LAYER_NORM_SHA256 = (
 MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE = (
     Path(__file__).resolve().parent / "contracts" / "layer_norm.dispatch.json"
 )
-MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256 = (
+MLX_LAYER_NORM_DISPATCH_NORMALIZED_SHA256 = (
     "17924e1eb885da0b91bed4ac67df39a72ab2f9448a40988efef2efd1f0f1bc93"
 )
 MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY = (
@@ -1209,6 +1209,11 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _normalized_text_sha256(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
 def _probe_native_metal_toolchain(
     mlx_root: Path,
     work_dir: Path,
@@ -1408,8 +1413,9 @@ def _prepare_layer_norm_dispatch_contract(
         source_path.is_file(), f"LayerNorm dispatch contract is missing: {source_path}"
     )
     _require(
-        _sha256(source_path) == MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256,
-        "LayerNorm dispatch contract content changed",
+        _normalized_text_sha256(source_path)
+        == MLX_LAYER_NORM_DISPATCH_NORMALIZED_SHA256,
+        "LayerNorm dispatch contract normalized content changed",
     )
     layer_norm_source = mlx_root / MLX_LAYER_NORM_SOURCE
     _require(

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,9 +1,11 @@
+import ast
 import copy
 import importlib.util
 import json
 import re
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -2440,10 +2442,14 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "MLX checkout proof does not match the pinned revision" in mlx_porting
     assert "fence contract accounting must be 3 failed, 0 emitted" in mlx_porting
     assert "MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES" in mlx_porting
+    assert "MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT" in mlx_porting
     assert "MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS" in mlx_porting
     assert "MLX_DIRECTX_BFLOAT16_LOWERING_EVIDENCE" in mlx_porting
     assert "MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE" in mlx_porting
-    assert "MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS" in mlx_porting
+    assert "MLX_DIRECTX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS" in mlx_porting
+    assert "MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES" in mlx_porting
+    assert "MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE" in mlx_porting
+    assert "MLX_LAYER_NORM_DISPATCH_VARIANTS" in mlx_porting
     assert 'checks["directx-frontier"]' in mlx_porting
     assert 'checks["vulkan-frontier"]' in mlx_porting
     assert 'directx["directxToolchainArtifactCount"]' in mlx_porting
@@ -2455,7 +2461,8 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert 'directx["bfloat16LoweringEvidence"]' in mlx_porting
     assert "DirectX bfloat16 lowering evidence is incomplete" in mlx_porting
     assert "DirectX workgroup blocker evidence changed" in mlx_porting
-    assert "expected 106 fail-closed DirectX compute entries" in mlx_porting
+    assert "expected 94 fail-closed DirectX compute entries" in mlx_porting
+    assert "LayerNorm dispatch frontier evidence is incomplete" in mlx_porting
     assert "matched-materialized-host-names" in mlx_porting
     assert "DirectX frontier toolchain must validate every configured" in mlx_porting
     assert "source artifact and compute entry" in mlx_porting
@@ -2661,6 +2668,31 @@ def test_mlx_platform_runtime_workflow_preserves_pinned_checkout():
     assert '"tests/test_ci_workflows.py"' in workflow
     assert '"tests/test_tools/test_ci_workflows.py"' not in workflow
     assert "continue-on-error" not in workflow
+
+
+def test_mlx_frontier_accounting_workflow_imports_available_harness_symbols():
+    workflow = _workflow_texts()["mlx-project-porting.yml"]
+    step_start = workflow.index("- name: Verify MLX frontier accounting")
+    command_marker = "          python - <<'PY'\n"
+    script_start = workflow.index(command_marker, step_start) + len(command_marker)
+    script_end = workflow.index("\n          PY", script_start)
+    script = textwrap.dedent(workflow[script_start:script_end])
+    tree = ast.parse(script)
+    harness_import = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "demos.integrations.mlx.run_mlx_porting"
+    )
+    harness = __import__(
+        "demos.integrations.mlx.run_mlx_porting",
+        fromlist=["run_mlx_porting"],
+    )
+
+    missing = sorted(
+        alias.name for alias in harness_import.names if not hasattr(harness, alias.name)
+    )
+    assert missing == []
 
 
 def test_mlx_platform_runtime_wires_directx_graph_device_proof():

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -152,6 +152,43 @@ def test_layer_norm_dispatch_contract_preparation_copies_verified_manifest(
     }
 
 
+def test_layer_norm_dispatch_contract_accepts_crlf_checkout(tmp_path, monkeypatch):
+    module = _load_harness()
+    mlx_root = tmp_path / "mlx"
+    source_path = mlx_root / module.MLX_LAYER_NORM_SOURCE
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("kernel void layer_norm_fixture() {}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "MLX_LAYER_NORM_SHA256",
+        hashlib.sha256(source_path.read_bytes()).hexdigest(),
+    )
+    contract_source = tmp_path / "layer_norm.dispatch.json"
+    normalized = module.MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE.read_text(
+        encoding="utf-8"
+    )
+    contract_source.write_bytes(normalized.replace("\n", "\r\n").encode("utf-8"))
+    monkeypatch.setattr(
+        module,
+        "MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE",
+        contract_source,
+    )
+
+    contract = module._prepare_layer_norm_dispatch_contract(
+        mlx_root,
+        mlx_root / ".crosstl-mlx-porting",
+    )
+
+    copied_path = mlx_root / contract["path"]
+    assert copied_path.read_bytes() == contract_source.read_bytes()
+    assert contract["contentIdentity"] == {
+        "algorithm": "sha256",
+        "value": module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY.removeprefix(
+            "sha256:"
+        ),
+    }
+
+
 def _load_rms_norm_fixture_metadata():
     return json.loads(
         (
@@ -2190,7 +2227,7 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert layer_norm["source_sha256"] == module.MLX_LAYER_NORM_SHA256
     assert layer_norm["dispatch_contract"] == {
         "path": "demos/integrations/mlx/contracts/layer_norm.dispatch.json",
-        "sha256": module.MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256,
+        "normalized_sha256": module.MLX_LAYER_NORM_DISPATCH_NORMALIZED_SHA256,
         "content_identity": module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY,
         "variant_count": len(module.MLX_LAYER_NORM_DISPATCH_VARIANTS),
         "resolved_issue": module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -89,6 +89,69 @@ def test_project_config_writer_emits_general_index_range_assertions(tmp_path):
     ) == len(assertions)
 
 
+def test_project_config_writer_emits_dispatch_contracts(tmp_path):
+    from crosstl.project import load_project_config
+
+    module = _load_harness()
+    config_path = tmp_path / "frontier.toml"
+    contract_path = "contracts/layer_norm.dispatch.json"
+    installed_contract = tmp_path / contract_path
+    installed_contract.parent.mkdir(parents=True)
+    installed_contract.write_bytes(
+        module.MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE.read_bytes()
+    )
+
+    module._write_project_config(
+        config_path,
+        include=module.MLX_LAYER_NORM_SOURCE,
+        targets=("directx",),
+        output_dir="generated",
+        dispatch_contracts=(contract_path,),
+    )
+
+    config = load_project_config(tmp_path, config_path)
+    assert config.dispatch_contracts == [contract_path]
+    assert f'dispatch_contracts = ["{contract_path}"]' in config_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_layer_norm_dispatch_contract_preparation_copies_verified_manifest(
+    tmp_path, monkeypatch
+):
+    module = _load_harness()
+    mlx_root = tmp_path / "mlx"
+    source_path = mlx_root / module.MLX_LAYER_NORM_SOURCE
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("kernel void layer_norm_fixture() {}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "MLX_LAYER_NORM_SHA256",
+        hashlib.sha256(source_path.read_bytes()).hexdigest(),
+    )
+
+    contract = module._prepare_layer_norm_dispatch_contract(
+        mlx_root,
+        mlx_root / ".crosstl-mlx-porting",
+    )
+
+    copied_path = mlx_root / contract["path"]
+    assert (
+        copied_path.read_bytes()
+        == module.MLX_LAYER_NORM_DISPATCH_CONTRACT_SOURCE.read_bytes()
+    )
+    assert contract == {
+        "path": ".crosstl-mlx-porting/contracts/layer_norm.dispatch.json",
+        "contentIdentity": {
+            "algorithm": "sha256",
+            "value": module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY.removeprefix(
+                "sha256:"
+            ),
+        },
+        "variantCount": len(module.MLX_LAYER_NORM_DISPATCH_VARIANTS),
+    }
+
+
 def _load_rms_norm_fixture_metadata():
     return json.loads(
         (
@@ -1923,23 +1986,26 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
 
     frontier = expected_gaps["frontier_status"]
     assert frontier["sources"] == len(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
-    assert frontier["artifacts"] == len(
-        module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
-    ) * len(frontier["targets"])
-    assert frontier["status"] == "target-split-with-expected-workgroup-blockers"
+    assert frontier["artifacts"] == 23
+    assert frontier["status"] == (
+        "target-split-with-bounded-dispatch-and-pending-contracts"
+    )
     assert frontier["scope"] == "target-split-frontier"
-    assert frontier["translated_artifacts"] == 16
-    assert frontier["failed_artifacts"] == 6
+    assert frontier["translated_artifacts"] == 18
+    assert frontier["failed_artifacts"] == 5
     assert frontier["target_artifacts"] == {
-        "directx": {"translated": 5, "failed": 6},
+        "directx": {"translated": 7, "failed": 5},
         "vulkan": {"translated": 11, "failed": 0},
     }
     assert frontier["semantic_readiness_status"] == "not-established"
     assert frontier["workgroup_blocked_diagnostic"] == (
         module.MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_CODE
     )
-    assert frontier["workgroup_blocked_by"] == (
-        module.MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE
+    assert frontier["host_dispatch_import_resolved_by"] == (
+        module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
+    )
+    assert frontier["pending_host_dispatch_sources"] == list(
+        module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
     )
     assert frontier["excluded_blocked_sources"] == [module.MLX_FENCE_SOURCE]
     assert frontier["runtime_integration_included"] is False
@@ -1979,8 +2045,8 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert arg_reduce["workgroup_blocked_diagnostic"] == (
         module.MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_CODE
     )
-    assert arg_reduce["workgroup_blocked_by"] == (
-        module.MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE
+    assert arg_reduce["host_dispatch_import_resolved_by"] == (
+        module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
     )
 
     opengl_frontier = expected_gaps["opengl_frontier_status"]
@@ -2118,6 +2184,22 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert "issues/1537" in directx_gaps[module.MLX_FENCE_SOURCE]
     assert "issues/1695" not in json.dumps(directx_gaps)
     assert "issues/1518" not in json.dumps(directx_gaps)
+    layer_norm = directx["layer_norm_dispatch_frontier"]
+    assert layer_norm["status"] == "translated-dxc-validated"
+    assert layer_norm["source"] == module.MLX_LAYER_NORM_SOURCE
+    assert layer_norm["source_sha256"] == module.MLX_LAYER_NORM_SHA256
+    assert layer_norm["dispatch_contract"] == {
+        "path": "demos/integrations/mlx/contracts/layer_norm.dispatch.json",
+        "sha256": module.MLX_LAYER_NORM_DISPATCH_CONTRACT_SHA256,
+        "content_identity": module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY,
+        "variant_count": len(module.MLX_LAYER_NORM_DISPATCH_VARIANTS),
+        "resolved_issue": module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
+    }
+    assert layer_norm["artifact_count"] == len(module.MLX_LAYER_NORM_DISPATCH_VARIANTS)
+    assert set(layer_norm["variants"]) == set(module.MLX_LAYER_NORM_DISPATCH_VARIANTS)
+    assert layer_norm["dxc_validated_artifact_count"] == 2
+    assert layer_norm["runtime_execution_attempted"] is False
+    assert layer_norm["numerical_parity_claimed"] is False
     assert directx["native_runtime_executed"] is False
     assert directx["runtime_parity_claimed"] is False
 
@@ -4166,6 +4248,191 @@ def _write_clean_frontier_report(
             },
         },
         "units": units,
+        "artifacts": artifacts,
+        "diagnostics": [],
+        "validation": {
+            "summary": {"failedCount": 0},
+            "toolchainRuns": list(toolchain_runs),
+        },
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+    return report
+
+
+def _write_layer_norm_dispatch_report(
+    module,
+    mlx_root,
+    output_dir,
+    report_path,
+    *,
+    contract,
+    toolchain_runs=(),
+):
+    unit = {
+        "id": module.MLX_LAYER_NORM_SOURCE,
+        "path": module.MLX_LAYER_NORM_SOURCE,
+        "sourceBackend": "metal",
+        "sourceHash": {
+            "algorithm": "sha256",
+            "value": module.MLX_LAYER_NORM_SHA256,
+        },
+        "sourceSizeBytes": 4096,
+    }
+    artifacts = []
+    planned_artifacts = []
+    for entry_point, expected in module.MLX_LAYER_NORM_DISPATCH_VARIANTS.items():
+        variant = "dispatch-" + expected["artifactId"].removeprefix("sha256:")
+        generated_path = (
+            output_dir
+            / "directx"
+            / variant
+            / "mlx/backend/metal/kernels/layer_norm"
+            / f"{entry_point}.hlsl"
+        )
+        generated_path.parent.mkdir(parents=True, exist_ok=True)
+        generated_lines = [
+            f"[numthreads({expected['workgroupSize'][0]}, 1, 1)]",
+            "[WaveSize(32)]",
+        ]
+        if expected["specializationConstants"]:
+            generated_lines.insert(0, "static const bool has_w = true;")
+        generated_lines.extend(("void CSMain() {", "}", ""))
+        generated_path.write_text("\n".join(generated_lines), encoding="utf-8")
+        generated_hash = hashlib.sha256(generated_path.read_bytes()).hexdigest()
+        plan = {
+            "artifactId": expected["artifactId"],
+            "dispatchVariantIds": [expected["dispatchVariantId"]],
+            "entryPoint": entry_point,
+            "manifestContentIdentities": [
+                module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY
+            ],
+            "source": module.MLX_LAYER_NORM_SOURCE,
+            "specializationConstants": dict(expected["specializationConstants"]),
+            "subgroupWidth": expected["subgroupWidth"],
+            "variant": variant,
+            "workgroupSize": list(expected["workgroupSize"]),
+        }
+        planned_artifacts.append(plan)
+        constants = [
+            {
+                "id": int(constant_id),
+                "concreteValue": value,
+                "deferred": False,
+                "valueProvenance": {
+                    "kind": "host-dispatch-contract",
+                    "artifactId": expected["artifactId"],
+                },
+            }
+            for constant_id, value in expected["specializationConstants"].items()
+        ]
+        specializations = [{"hostName": entry_point}]
+        specializations.extend(
+            {"materializedName": f"helper_{index}"}
+            for index in range(expected["specializationCount"] - 1)
+        )
+        artifacts.append(
+            {
+                "source": module.MLX_LAYER_NORM_SOURCE,
+                "sourceBackend": "metal",
+                "sourceHash": unit["sourceHash"],
+                "sourceSizeBytes": unit["sourceSizeBytes"],
+                "target": "directx",
+                "status": "translated",
+                "variant": variant,
+                "path": generated_path.relative_to(mlx_root).as_posix(),
+                "generatedHash": {
+                    "algorithm": "sha256",
+                    "value": generated_hash,
+                },
+                "generatedSizeBytes": generated_path.stat().st_size,
+                "entryPoint": {
+                    "source": entry_point,
+                    "target": "CSMain",
+                    "stage": "compute",
+                },
+                "dispatchArtifact": plan,
+                "execution": {
+                    "sourceEntryPoints": [entry_point],
+                    "provenance": {
+                        "kind": "host-dispatch-contract",
+                        "artifactId": expected["artifactId"],
+                    },
+                    "subgroupWidthProvenance": {
+                        "kind": "host-dispatch-contract",
+                    },
+                    "subgroupWidthEnforcement": {
+                        "mechanism": "hlsl-wave-size-attribute",
+                        "minimumShaderModel": "6.6",
+                        "entryProfiles": [
+                            {"entryPoint": "CSMain", "profile": "cs_6_6"}
+                        ],
+                    },
+                    "entryPoints": [
+                        {
+                            "sourceEntryPoint": entry_point,
+                            "materializedEntryPoint": entry_point,
+                            "targetEntryPoint": "CSMain",
+                            "workgroupSize": list(expected["workgroupSize"]),
+                            "subgroupWidth": expected["subgroupWidth"],
+                        }
+                    ],
+                },
+                "specializationConstants": constants,
+                "templateMaterialization": {
+                    "status": "materialized",
+                    "specializationCount": expected["specializationCount"],
+                    "specializations": specializations,
+                    "unsupported": [],
+                },
+            }
+        )
+
+    artifact_count = len(artifacts)
+    identity = contract["contentIdentity"]
+    report = {
+        "project": {
+            "includePatterns": [module.MLX_LAYER_NORM_SOURCE],
+            "targets": ["directx"],
+            "dispatchContractFiles": [contract["path"]],
+            "dispatchContractCount": 1,
+            "dispatchVariantCount": artifact_count,
+            "dispatchContracts": [
+                {
+                    "path": contract["path"],
+                    "schemaVersion": 1,
+                    "contentIdentity": identity,
+                    "manifest": {"provenance": {"commit": module.MLX_COMMIT}},
+                    "evaluation": {
+                        "manifestSource": str((mlx_root / contract["path"]).resolve()),
+                        "variantCount": artifact_count,
+                    },
+                }
+            ],
+            "dispatchArtifactPlan": {
+                "kind": "crosstl-dispatch-artifact-plan",
+                "schemaVersion": 1,
+                "sourceUnitCount": 1,
+                "artifactCount": artifact_count,
+                "dispatchVariantCount": artifact_count,
+                "artifacts": planned_artifacts,
+            },
+        },
+        "summary": {
+            "unitCount": 1,
+            "artifactCount": artifact_count,
+            "translatedCount": artifact_count,
+            "failedCount": 0,
+            "diagnosticCounts": {"error": 0, "note": 0, "warning": 0},
+            "artifactsByTarget": {
+                "directx": {
+                    "artifactCount": artifact_count,
+                    "translatedCount": artifact_count,
+                    "failedCount": 0,
+                }
+            },
+        },
+        "units": [unit],
         "artifacts": artifacts,
         "diagnostics": [],
         "validation": {
@@ -7306,7 +7573,22 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     for directory in (config_dir, report_dir, log_dir):
         directory.mkdir(parents=True)
 
-    directx_toolchain_count = len(module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES)
+    directx_toolchain_count = module.MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT
+    layer_norm_contract = {
+        "path": ".crosstl-mlx-porting/contracts/layer_norm.dispatch.json",
+        "contentIdentity": {
+            "algorithm": "sha256",
+            "value": module.MLX_LAYER_NORM_DISPATCH_CONTENT_IDENTITY.removeprefix(
+                "sha256:"
+            ),
+        },
+        "variantCount": len(module.MLX_LAYER_NORM_DISPATCH_VARIANTS),
+    }
+    monkeypatch.setattr(
+        module,
+        "_prepare_layer_norm_dispatch_contract",
+        lambda *_args: layer_norm_contract,
+    )
     commands = []
 
     def warning_stderr(source, relative_path):
@@ -7338,10 +7620,51 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
                 mlx_root,
                 work_dir / "out-directx-workgroup-frontier",
                 target="directx",
-                sources=module.MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
+                sources=module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES,
                 validated=True,
             )
             returncode = 1
+        elif "layer-norm-dispatch" in name:
+            is_toolchain = name.startswith("validate-")
+            output_dir = work_dir / (
+                "out-directx-layer-norm-dispatch-toolchain"
+                if is_toolchain
+                else "out-directx-layer-norm-dispatch-frontier"
+            )
+            report = _write_layer_norm_dispatch_report(
+                module,
+                mlx_root,
+                output_dir,
+                report_dir / f"{name}.json",
+                contract=layer_norm_contract,
+            )
+            if is_toolchain:
+                toolchain_runs = [
+                    {
+                        "source": module.MLX_LAYER_NORM_SOURCE,
+                        "target": "directx",
+                        "path": artifact["path"],
+                        "command": [
+                            "dxc",
+                            "-T",
+                            "cs_6_6",
+                            "-E",
+                            "CSMain",
+                            artifact["path"],
+                        ],
+                        "status": "ok",
+                        "stderr": "",
+                    }
+                    for artifact in report["artifacts"]
+                ]
+                _write_layer_norm_dispatch_report(
+                    module,
+                    mlx_root,
+                    output_dir,
+                    report_dir / f"{name}.json",
+                    contract=layer_norm_contract,
+                    toolchain_runs=toolchain_runs,
+                )
         else:
             is_toolchain = name == "validate-directx-frontier-toolchain"
             output_dir = (
@@ -7351,7 +7674,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
             )
             toolchain_runs = []
             if is_toolchain:
-                for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES:
+                for source in module.MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES:
                     artifact_path = (output_dir / "directx" / Path(source)).with_suffix(
                         ".hlsl"
                     )
@@ -7407,7 +7730,7 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     )
 
     assert result["toolchainRuns"] == (module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT)
-    assert result["status"] == "passed-with-expected-workgroup-blockers"
+    assert result["status"] == "passed-with-bounded-dispatch-and-pending-contracts"
     assert result["directxToolchainRequired"] is True
     assert result["directxToolchainSources"] == list(
         module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
@@ -7443,16 +7766,28 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert result["bfloat16LoweringEvidence"] == (
         module.MLX_DIRECTX_BFLOAT16_LOWERING_EVIDENCE
     )
+    assert result["layerNormDispatchEvidence"]["status"] == ("translated-dxc-validated")
+    assert result["layerNormDispatchEvidence"]["artifactCount"] == 2
+    assert result["layerNormDispatchEvidence"]["dxcValidatedArtifactCount"] == 2
+    assert set(result["layerNormDispatchEvidence"]["variants"]) == set(
+        module.MLX_LAYER_NORM_DISPATCH_VARIANTS
+    )
     assert result["workgroupBlockedSources"] == list(
-        module.MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+        module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
     )
     assert all(
         evidence["sourceEntryPointIdentityStatus"] == "matched-materialized-host-names"
         for evidence in result["dynamicWorkgroupDispatchEvidence"].values()
     )
-    assert commands[1][0] == "directx-workgroup-frontier"
-    assert commands[2][0] == "validate-directx-frontier-toolchain"
-    assert "--run-toolchains" in commands[2][1]
+    assert [name for name, _command in commands] == [
+        "directx-frontier",
+        "directx-layer-norm-dispatch-frontier",
+        "directx-workgroup-frontier",
+        "validate-directx-frontier-toolchain",
+        "validate-directx-layer-norm-dispatch-toolchain",
+    ]
+    assert "--run-toolchains" in commands[3][1]
+    assert "--run-toolchains" in commands[4][1]
     toolchain_config = (
         config_dir / "validate-directx-frontier-toolchain.toml"
     ).read_text(encoding="utf-8")
@@ -7460,8 +7795,14 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert "[project.specialization_constants]" in toolchain_config
     for selector, value in module.MLX_FRONTIER_SPECIALIZATION_CONSTANTS.items():
         assert f"{json.dumps(selector)} = {json.dumps(value)}" in toolchain_config
-    for source in module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES:
+    for source in module.MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES:
         assert source in toolchain_config
+    assert module.MLX_LAYER_NORM_SOURCE not in toolchain_config
+    layer_norm_config = (
+        config_dir / "validate-directx-layer-norm-dispatch-toolchain.toml"
+    ).read_text(encoding="utf-8")
+    assert module.MLX_LAYER_NORM_SOURCE in layer_norm_config
+    assert layer_norm_contract["path"] in layer_norm_config
 
 
 def test_directx_toolchain_warning_contract_rejects_new_warning():
@@ -7589,6 +7930,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     expected_sources = (
         module.MLX_ARANGE_SOURCE,
         module.MLX_BINARY_TWO_SOURCE,
+        module.MLX_LAYER_NORM_SOURCE,
         module.MLX_RANDOM_SOURCE,
         module.MLX_ROPE_SOURCE,
         module.MLX_TERNARY_SOURCE,
@@ -7602,6 +7944,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
     assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS == {
         module.MLX_ARANGE_SOURCE: 11,
         module.MLX_BINARY_TWO_SOURCE: 225,
+        module.MLX_LAYER_NORM_SOURCE: 2,
         module.MLX_RANDOM_SOURCE: 2,
         module.MLX_ROPE_SOURCE: 18,
         module.MLX_TERNARY_SOURCE: 212,
@@ -7614,11 +7957,12 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
         module.MLX_SOFTMAX_SOURCE: 10,
     }
-    assert len(expected_sources) == 5
+    assert len(expected_sources) == 6
     assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == sum(
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
     )
-    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 468
+    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 470
+    assert module.MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT == 7
     assert sum(module.MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS.values()) == 106
     assert {
         source: evidence["specializationCount"]
@@ -7643,25 +7987,29 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS
     )
     assert directx_status["workgroup_blocked_sources"] == list(
-        module.MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+        module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
     )
     assert directx_status["workgroup_blocked_entry_point_counts"] == (
-        module.MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS
+        module.MLX_DIRECTX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS
     )
     assert directx_status["workgroup_blocked_diagnostic"] == (
         module.MLX_DYNAMIC_WORKGROUP_DIAGNOSTIC_CODE
     )
-    assert directx_status["workgroup_blocked_by"] == (
-        module.MLX_DYNAMIC_WORKGROUP_TRACKED_ISSUE
+    assert directx_status["host_dispatch_import_resolved_by"] == (
+        module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
     )
     assert directx_status["dispatch_evidence"] == (
-        module.MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE
+        {
+            source: module.MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE[source]
+            for source in module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+        }
     )
     assert module.MLX_DYNAMIC_WORKGROUP_DISPATCH_EVIDENCE[
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE
     ]["hostLines"].endswith("613-640,685-753")
     assert set(directx_status["directx_toolchain_gaps"]) == (
-        set(module.MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES) | {module.MLX_FENCE_SOURCE}
+        set(module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES)
+        | {module.MLX_FENCE_SOURCE}
     )
     assert {
         f"https://github.com/CrossGL/crosstl/issues/{issue}"
@@ -7690,13 +8038,12 @@ def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
     normalized_readme = " ".join(readme.split())
 
     assert "official DXC v1.9.2602.24 on Windows CI" in readme
-    assert (
-        "the emitted five-source frontier: `arange.metal`, `binary_two.metal`,"
-        in normalized_readme
+    assert "seven-artifact frontier representing six pinned sources" in (
+        normalized_readme
     )
-    assert "11, 225, 2, 18, and 212 entries respectively" in normalized_readme
-    assert "468 generated compute entries" in normalized_readme
-    assert "six excluded aggregate sources cover 106 compute entries" in (
+    assert "11, 225, 2, 2, 18, and 212 entries respectively" in normalized_readme
+    assert "470 generated compute entries" in normalized_readme
+    assert "five pending aggregate sources cover 94 compute entries" in (
         normalized_readme
     )
     assert "no placeholder workgroup size is restored" in normalized_readme
@@ -7705,7 +8052,7 @@ def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
     assert "`uint-low-16-bits` register representation" in normalized_readme
     assert "round-to-nearest, ties-to-even conversion" in normalized_readme
     assert "`directx.native-16bit-types` capability" in normalized_readme
-    assert "All five emitted sources require" in normalized_readme
+    assert "All five aggregate sources require" in normalized_readme
     assert "fails closed if either field is missing or changes" in normalized_readme
     assert "storage, conversion, report, and compiler evidence only" in (
         normalized_readme
@@ -7735,7 +8082,7 @@ def test_selected_quantized_frontiers_record_current_target_boundaries():
     assert "profile `cs_6_0`, no `-enable-16bit-types`, and `-WX` passes" in (
         normalized_readme
     )
-    assert "zero warnings across all 468 entry-point runs" in normalized_readme
+    assert "zero warnings across all 470 entry-point runs" in normalized_readme
     assert "records this as a warning-clean contract" in normalized_readme
     assert "rejects any newly observed warning" in normalized_readme
     assert "two selected `random.metal` entries compile without" in normalized_readme
@@ -8774,10 +9121,16 @@ def test_run_checks_reduced_frontier_includes_runtime_readiness(tmp_path, monkey
         "https://github.com/CrossGL/crosstl/issues/1537"
     ]
     assert result["scope"]["directxTranslatedFrontierSources"] == list(
-        module.MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
+        module.MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
+    )
+    assert result["scope"]["directxTranslatedFrontierArtifactCount"] == (
+        module.MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT
     )
     assert result["scope"]["directxWorkgroupBlockedFrontierSources"] == list(
-        module.MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+        module.MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
+    )
+    assert result["scope"]["hostDispatchImportResolvedIssue"] == (
+        module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
     )
     assert result["scope"]["vulkanTranslatedFrontierSources"] == list(
         module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES


### PR DESCRIPTION
## Summary

- consume the pinned LayerNorm host dispatch contract in the MLX project-porting harness
- emit two deterministic, entry-scoped DirectX artifacts from the unchanged upstream `layer_norm.metal` source
- verify source, contract, artifact, specialization, workgroup, subgroup, and provenance identities in the project report
- require both bounded artifacts to compile with DXC `cs_6_6` and warnings as errors on Windows CI
- retain structured failures for five sources that do not yet have bounded dispatch manifests

## Scope

The project frontier now represents six pinned MLX sources with seven DirectX artifacts. Five sources retain their aggregate artifacts. LayerNorm contributes separate `layer_normfloat32` and `vjp_layer_normfloat32` artifacts selected by `demos/integrations/mlx/contracts/layer_norm.dispatch.json`.

The forward artifact uses workgroup size `[544, 1, 1]` with no function constants. The VJP artifact uses `[1024, 1, 1]` and materializes function constant `20` as `true`. Both require a 32-lane subgroup and emit `[WaveSize(32)]`. The harness validates deterministic artifact and dispatch identities, exact source and generated hashes, entry-scoped execution metadata, and host-dispatch provenance.

The DirectX compiler frontier increases from 468 to 470 generated entry runs across seven artifacts. `arg_reduce.metal`, `logsumexp.metal`, `rms_norm.metal`, `scaled_dot_product_attention.metal`, and `softmax.metal` continue to fail closed with `project.translate.workgroup-size-entry-ambiguous` because this integration does not yet provide bounded manifests for their runtime-selected dispatches.

This remains translation, report, and compiler evidence. It does not execute either LayerNorm shader, establish numerical parity, port the MLX host runtime, or run the MLX test suite against DirectX.

## Verification

- `python -m pytest -q -n auto`: 17,301 passed, 225 skipped
- focused MLX integration and workflow tests: 240 passed
- macOS frontier validator replayed against the generated CI report
- `pre-commit run --all-files`
- `tools/support_matrix.py check`
- `tools/sync_support_issues.py --repo CrossGL/crosstl --dry-run`
- real project translation of the pinned MLX checkout at `4367c73b60541ddd5a266ce4644fd93d20223b6e`

Support issue traceability: no issue closed

Related: #1793
