### PR TITLE
Add MLX LogSumExp DirectX dispatch and runtime proof

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -173,6 +173,41 @@ jobs:
         if: runner.os == 'Windows'
         run: python -m pip install -e ".[directx-runtime]" pytest-xdist
 
+      - name: Install pinned Windows WARP runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = "SilentlyContinue"
+          $warpVersion = "1.0.20"
+          $warpSha256 = "e5fe5de661ce98b58ef9cfb736e73c0a7a2623d3bbf5f14839b2d55566d87e40"
+          $archive = Join-Path $env:RUNNER_TEMP "microsoft.direct3d.warp.$warpVersion.zip"
+          $warpRoot = Join-Path $env:RUNNER_TEMP "microsoft.direct3d.warp.$warpVersion"
+          $warpUri = "https://api.nuget.org/v3-flatcontainer/microsoft.direct3d.warp/$warpVersion/microsoft.direct3d.warp.$warpVersion.nupkg"
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            try {
+              Invoke-WebRequest -Uri $warpUri -OutFile $archive
+              break
+            } catch {
+              if ($attempt -eq 5) {
+                throw
+              }
+              Write-Warning "WARP download failed on attempt $attempt; retrying."
+              Start-Sleep -Seconds (10 * $attempt)
+            }
+          }
+          $archiveSha256 = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($archiveSha256 -ne $warpSha256) {
+            throw "WARP archive checksum mismatch: expected $warpSha256, got $archiveSha256."
+          }
+          Expand-Archive -Path $archive -DestinationPath $warpRoot -Force
+          $warp = Join-Path $warpRoot "build\native\bin\x64\d3d10warp.dll"
+          if (-not (Test-Path -Path $warp -PathType Leaf)) {
+            throw "d3d10warp.dll not found in WARP package."
+          }
+          $pythonWarp = Join-Path $env:pythonLocation "d3d10warp.dll"
+          Copy-Item -Path $warp -Destination $pythonWarp -Force
+          Write-Host "Installed WARP $((Get-Item $pythonWarp).VersionInfo.FileVersion) beside python.exe."
+
       - name: Install Linux runtime dependencies
         if: runner.os == 'Linux'
         run: |
@@ -188,6 +223,15 @@ jobs:
           git -C mlx-upstream sparse-checkout init --cone
           git -C mlx-upstream sparse-checkout set mlx/backend/metal/kernels
           git -C mlx-upstream checkout "$MLX_COMMIT"
+
+      - name: Prove pinned MLX LogSumExp Direct3D native-loader execution
+        if: runner.os == 'Windows'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_logsumexp_native_loader.py::test_pinned_mlx_logsumexp_executes_through_directx_native_loader
 
       - name: Enumerate pinned MLX Metal entry points
         shell: bash
@@ -388,15 +432,6 @@ jobs:
         run: >-
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_binary_native_loader.py::test_pinned_mlx_binary_add_executes_through_directx_native_loader
-
-      - name: Prove pinned MLX LogSumExp Direct3D native-loader execution
-        if: runner.os == 'Windows'
-        env:
-          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
-          CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER: "1"
-        run: >-
-          python -m pytest -q -n auto
-          tests/test_translator/test_mlx_logsumexp_native_loader.py::test_pinned_mlx_logsumexp_executes_through_directx_native_loader
 
       - name: Prove Direct3D local-struct byte-view native readback
         if: runner.os == 'Windows'

--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -118,10 +118,7 @@ jobs:
           xcrun --sdk macosx metal --version
 
       - name: Validate bounded MLX dispatch contracts
-        run: |
-          python -m pytest -q -n auto \
-            tests/test_mlx_dispatch_contract_fixture.py \
-            tests/test_mlx_logsumexp_dispatch_contract_fixture.py
+        run: python -m pytest -q -n auto tests/test_mlx_dispatch_contract_fixture.py tests/test_mlx_logsumexp_dispatch_contract_fixture.py
 
       - name: Install Linux SPIR-V tools
         if: runner.os == 'Linux'

--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -121,8 +121,7 @@ jobs:
         run: |
           python -m pytest -q -n auto \
             tests/test_mlx_dispatch_contract_fixture.py \
-            tests/test_mlx_logsumexp_dispatch_contract_fixture.py \
-            tests/test_mlx_rms_norm_dispatch_contract_fixture.py
+            tests/test_mlx_logsumexp_dispatch_contract_fixture.py
 
       - name: Install Linux SPIR-V tools
         if: runner.os == 'Linux'

--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -18,6 +18,7 @@ on:
       - "tests/test_mlx_copy_opengl_proof.py"
       - "tests/test_mlx_copy_directx_proof.py"
       - "tests/test_mlx_dispatch_contract_fixture.py"
+      - "tests/test_mlx_logsumexp_dispatch_contract_fixture.py"
       - "tests/test_mlx_rms_norm_dispatch_contract_fixture.py"
       - "tests/test_mlx_layer_norm_directx_proof.py"
       - "tests/test_mlx_quantized_directx_proof.py"
@@ -34,6 +35,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
       - "tests/test_translator/test_runtime_verification.py"
@@ -50,6 +52,7 @@ on:
       - "tests/test_mlx_copy_opengl_proof.py"
       - "tests/test_mlx_copy_directx_proof.py"
       - "tests/test_mlx_dispatch_contract_fixture.py"
+      - "tests/test_mlx_logsumexp_dispatch_contract_fixture.py"
       - "tests/test_mlx_rms_norm_dispatch_contract_fixture.py"
       - "tests/test_mlx_layer_norm_directx_proof.py"
       - "tests/test_mlx_quantized_directx_proof.py"
@@ -66,6 +69,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
       - "tests/test_translator/test_runtime_verification.py"
@@ -113,8 +117,12 @@ jobs:
           fi
           xcrun --sdk macosx metal --version
 
-      - name: Validate bounded MLX dispatch contract
-        run: python -m pytest -q -n auto tests/test_mlx_dispatch_contract_fixture.py
+      - name: Validate bounded MLX dispatch contracts
+        run: |
+          python -m pytest -q -n auto \
+            tests/test_mlx_dispatch_contract_fixture.py \
+            tests/test_mlx_logsumexp_dispatch_contract_fixture.py \
+            tests/test_mlx_rms_norm_dispatch_contract_fixture.py
 
       - name: Install Linux SPIR-V tools
         if: runner.os == 'Linux'
@@ -385,6 +393,15 @@ jobs:
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_binary_native_loader.py::test_pinned_mlx_binary_add_executes_through_directx_native_loader
 
+      - name: Prove pinned MLX LogSumExp Direct3D native-loader execution
+        if: runner.os == 'Windows'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_logsumexp_native_loader.py::test_pinned_mlx_logsumexp_executes_through_directx_native_loader
+
       - name: Prove Direct3D local-struct byte-view native readback
         if: runner.os == 'Windows'
         env:
@@ -557,6 +574,10 @@ jobs:
               MLX_LAYER_NORM_DISPATCH_VARIANTS,
               MLX_LAYER_NORM_SHA256,
               MLX_LAYER_NORM_SOURCE,
+              MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY,
+              MLX_LOGSUMEXP_DISPATCH_VARIANTS,
+              MLX_LOGSUMEXP_SHA256,
+              MLX_LOGSUMEXP_SOURCE,
               MLX_RMS_NORM_DISPATCH_CONTENT_IDENTITY,
               MLX_RMS_NORM_DISPATCH_VARIANTS,
               MLX_RMS_NORM_SHA256,
@@ -824,8 +845,8 @@ jobs:
                   raise SystemExit(
                       f"DirectX workgroup blocker evidence changed for {source}"
                   )
-          if directx_blocked_entry_point_count != 82:
-              raise SystemExit("expected 82 fail-closed DirectX compute entries")
+          if directx_blocked_entry_point_count != 76:
+              raise SystemExit("expected 76 fail-closed DirectX compute entries")
           layer_norm = directx["layerNormDispatchEvidence"]
           expected_layer_norm_status = (
               "translated-dxc-validated"
@@ -858,6 +879,43 @@ jobs:
               or layer_norm["numericalParityClaimed"] is not False
           ):
               raise SystemExit("LayerNorm dispatch frontier evidence is incomplete")
+          logsumexp = directx["logsumexpDispatchEvidence"]
+          expected_logsumexp_status = (
+              "translated-dxc-validated"
+              if os.environ["RUNNER_OS"] == "Windows"
+              else "translated"
+          )
+          expected_logsumexp_validated = (
+              len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+              if os.environ["RUNNER_OS"] == "Windows"
+              else 0
+          )
+          if (
+              logsumexp["status"] != expected_logsumexp_status
+              or logsumexp["source"] != MLX_LOGSUMEXP_SOURCE
+              or logsumexp["sourceSha256"] != MLX_LOGSUMEXP_SHA256
+              or logsumexp["target"] != "directx"
+              or logsumexp["testSources"]
+              != [
+                  "python/tests/test_ops.py::test_logsumexp",
+                  "python/tests/test_autograd.py::test_logsumexp_grad",
+              ]
+              or logsumexp["dispatchContract"]["contentIdentity"]
+              != MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY
+              or logsumexp["dispatchContract"]["variantCount"]
+              != len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+              or logsumexp["dispatchContract"]["resolvedIssue"]
+              != MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE
+              or logsumexp["artifactCount"]
+              != len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+              or set(logsumexp["variants"])
+              != set(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+              or logsumexp["dxcValidatedArtifactCount"]
+              != expected_logsumexp_validated
+              or logsumexp["runtimeExecutionAttempted"] is not False
+              or logsumexp["numericalParityClaimed"] is not False
+          ):
+              raise SystemExit("LogSumExp dispatch frontier evidence is incomplete")
           rms_norm = directx["rmsNormDispatchEvidence"]
           expected_rms_norm_status = (
               "translated-dxc-validated"

--- a/crosstl/translator/codegen/directx_codegen.py
+++ b/crosstl/translator/codegen/directx_codegen.py
@@ -1785,6 +1785,12 @@ class HLSLCodeGen:
     }
     HLSL_WAVE_BASIC_COMPONENT_TYPES = HLSL_WAVE_NUMERIC_COMPONENT_TYPES | {"bool"}
     HLSL_WAVE_SIZE_LANE_COUNTS = {4, 8, 16, 32, 64, 128}
+    HLSL_RESOURCE_POINTER_UNSIGNED_DELTA_TYPES = {
+        "uint",
+        "uint16_t",
+        "uint64_t",
+        "min16uint",
+    }
     # Subgroup/wave builtins (Metal [[thread_index_in_simdgroup]] /
     # [[threads_per_simdgroup]], canonicalised to gl_Subgroup* in CrossGL) have no
     # HLSL system-value semantic; HLSL exposes them only through wave intrinsics.
@@ -14057,7 +14063,12 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         offset_type = "int" if current.get("kind") == "workgroup-pointer" else "int64_t"
         if op in {"+=", "-="}:
             delta = self.generate_expression(value)
-            return f"{offset_name} {op} {offset_type}({delta})"
+            delta_type = (
+                "int"
+                if current.get("kind") == "workgroup-pointer"
+                else self.hlsl_resource_pointer_delta_type(value)
+            )
+            return f"{offset_name} {op} {delta_type}({delta})"
         if op != "=":
             if current.get("kind") == "workgroup-pointer":
                 raise self.hlsl_workgroup_pointer_error(
@@ -14586,6 +14597,15 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
         )
         return f"{lhs} {op} {rhs}"
 
+    def hlsl_resource_pointer_delta_type(self, value):
+        source_type = self.hlsl_source_expression_type(value)
+        mapped_type = self.map_type(source_type) if source_type is not None else ""
+        if mapped_type in self.HLSL_RESOURCE_POINTER_UNSIGNED_DELTA_TYPES:
+            return "uint"
+        if mapped_type == "int64_t":
+            return "int64_t"
+        return "int"
+
     def generate_hlsl_resource_pointer_offset_assignment(self, target, value, op):
         alias_assignment = self.generate_hlsl_resource_pointer_alias_assignment(
             target, value, op
@@ -14623,7 +14643,7 @@ float4x4 __crossgl_inverse_float4_4(float4x4 m) {
             rhs = self.generate_expression(value)
             return (
                 f"int64_t {offset_name} = int64_t({initial_offset})\n"
-                f"{offset_name} {op} int64_t({rhs})"
+                f"{offset_name} {op} {self.hlsl_resource_pointer_delta_type(value)}({rhs})"
             )
 
         if op != "+=":

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -67,9 +67,10 @@ The current harness verifies:
   `ternary.metal`. Vulkan must translate and structurally validate all 11.
   DirectX emits five aggregate artifacts whose entries do not require a
   runtime-selected workgroup size, two entry-scoped `layer_norm.metal`
-  artifacts, and 12 entry-scoped `rms_norm.metal` artifacts selected by
-  checked-in host dispatch contracts. It records exact expected failures for
-  the other four sources. Each blocked report must retain
+  artifacts, two entry-scoped `logsumexp.metal` artifacts, and 12 entry-scoped
+  `rms_norm.metal` artifacts selected by checked-in host dispatch contracts. It
+  records exact expected failures for the other three sources. Each blocked
+  report must retain
   the pinned total specialization
   count and exactly match its diagnostic entry names to the materialized host
   names, with no additional diagnostics. Separate configs prevent DirectX
@@ -91,13 +92,15 @@ The current harness verifies:
   dispatch uses runtime axis and pipeline-limit operands unavailable to source
   materialization;
 - DirectX HLSL compiler checks with official DXC v1.9.2602.24 on Windows CI for
-  the 19-artifact frontier representing seven pinned sources: `arange.metal`,
-  `binary_two.metal`, two bounded `layer_norm.metal` entries, `random.metal`,
-  12 test-derived `rms_norm.metal` entries, `rope.metal`, and `ternary.metal`.
-  At the pinned revision the gate compiles 11, 225, 2, 2, 12, 18, and 212
-  entries respectively, for 482 generated compute entries in total. Each
-  LayerNorm and RMSNorm artifact is emitted independently with its host-derived
-  workgroup size, specialization constants, and exact subgroup width. The
+  the 21-artifact frontier representing eight pinned sources: `arange.metal`,
+  `binary_two.metal`, two bounded `layer_norm.metal` entries, two bounded
+  `logsumexp.metal` entries, `random.metal`, 12 test-derived `rms_norm.metal`
+  entries, `rope.metal`, and `ternary.metal`. At the pinned revision the gate
+  compiles 11, 225, 2, 2, 2, 12, 18, and 212 entries respectively, for 484
+  generated compute entries in total. Each LayerNorm, LogSumExp, and RMSNorm
+  artifact is emitted independently with its host-derived workgroup size and
+  exact subgroup width; specialization constants are retained where required.
+  The
   pinned rope translation supplies required function constant IDs through the
   quoted `"1"`, `"2"`, and `"3"` selectors in
   `[project.specialization_constants]` and materializes the concrete DirectX
@@ -114,7 +117,7 @@ The current harness verifies:
   metadata remains tracked by
   [#1542](https://github.com/CrossGL/crosstl/issues/1542). Host dispatch contract
   import was completed under [#1793](https://github.com/CrossGL/crosstl/issues/1793).
-  The four pending aggregate sources cover 82 compute entries and are asserted
+  The three pending aggregate sources cover 76 compute entries and are asserted
   as failed artifacts until bounded dispatch manifests are supplied;
   no placeholder workgroup size is restored. `fence.metal` is
   excluded because its DirectX translation intentionally fails under
@@ -297,7 +300,7 @@ and fails closed if either field is missing or changes. Native-profile bfloat
 helpers now use exact `uint16_t` boundaries, and the two selected
 `random.metal` entries compile without the promotion warnings tracked by
 [#1799](https://github.com/CrossGL/crosstl/issues/1799). DXC reports zero
-warnings across all 482 entry-point runs in the 19-artifact emitted frontier.
+warnings across all 484 entry-point runs in the 21-artifact emitted frontier.
 The harness records this as a warning-clean contract and rejects any newly
 observed warning. Contextual destination conversion under
 [#1801](https://github.com/CrossGL/crosstl/issues/1801) is resolved for the
@@ -853,6 +856,41 @@ evaluation with:
 ```bash
 .venv/bin/python -m pytest -q -n auto \
   tests/test_mlx_dispatch_contract_fixture.py
+```
+
+The checked-in
+[`contracts/logsumexp.dispatch.json`](contracts/logsumexp.dispatch.json)
+fixture captures two float32 block-reduction workloads from the pinned MLX
+operation and gradient tests. The records use axis sizes 32 and 1025 to exercise
+distinct results of the pinned host formula
+`32 * ceil_div(ceil_div(axis_size, 4), 32)`: workgroup sizes `[32, 1, 1]` and
+`[288, 1, 1]`. Both dispatch one output row, require a 32-lane subgroup, and
+select `block_logsumexp_float32`. The looped path for axis sizes above 4096 and
+the float16 and bfloat16 entries remain outside this bounded contract.
+
+The repository harness evaluates both records against the unchanged pinned
+`logsumexp.metal` source and emits one standalone DirectX artifact per workload.
+It verifies source, contract, dispatch, template-materialization, and artifact
+identities; checks the generated max and sum wave reductions, group barriers,
+exponential, logarithm, output store, workgroup size, and `[WaveSize(32)]`; and
+requires official DXC `cs_6_6` compilation with warnings as errors on Windows.
+This establishes translation and native compiler acceptance for the two listed
+test-derived dispatches.
+
+A separate Windows native-loader test packages the axis-size-32 artifact,
+builds its reflected DirectX ABI, binds 32 nonuniform float32 inputs and the
+axis-size constant, dispatches one 32-thread workgroup, and compares the
+readback with a stable CPU LogSumExp reference under explicit float tolerance.
+That is numerical runtime evidence for one finite workload. It does not redirect
+the MLX runtime, cover the axis-size-1025 artifact or looped reduction path, or
+establish parity for other dtypes, shapes, devices, or the full MLX test suite.
+
+Validate the LogSumExp contract schema, provenance, deterministic identities,
+and bounded workload set with:
+
+```bash
+.venv/bin/python -m pytest -q -n auto \
+  tests/test_mlx_logsumexp_dispatch_contract_fixture.py
 ```
 
 The checked-in

--- a/demos/integrations/mlx/contracts/logsumexp.dispatch.json
+++ b/demos/integrations/mlx/contracts/logsumexp.dispatch.json
@@ -1,0 +1,215 @@
+{
+  "kind": "crosstl-host-dispatch-contract",
+  "schemaVersion": 1,
+  "provenance": {
+    "repository": "https://github.com/ml-explore/mlx",
+    "commit": "4367c73b60541ddd5a266ce4644fd93d20223b6e",
+    "sourceReferences": {
+      "hostDispatch": "mlx/backend/metal/logsumexp.cpp",
+      "kernel": "mlx/backend/metal/kernels/logsumexp.metal"
+    },
+    "scope": {
+      "description": "Pinned float32 LogSumExp unit-test dispatch records.",
+      "blockEntriesIncluded": true,
+      "loopedEntriesIncluded": false,
+      "runtimeExecutionVerified": false,
+      "numericalParityVerified": false
+    }
+  },
+  "inputs": [
+    {
+      "name": "axisSize",
+      "role": "shape",
+      "type": "integer",
+      "provenance": {
+        "hostSymbol": "axis_size"
+      }
+    },
+    {
+      "name": "nRows",
+      "role": "shape",
+      "type": "integer",
+      "provenance": {
+        "hostSymbol": "n_rows"
+      }
+    },
+    {
+      "name": "dtype",
+      "role": "dtype",
+      "type": "string"
+    }
+  ],
+  "workloads": [
+    {
+      "id": "block-float32-axis-32",
+      "values": {
+        "axisSize": 32,
+        "nRows": 1,
+        "dtype": "float32"
+      },
+      "provenance": {
+        "hostFunction": "LogSumExp::eval_gpu",
+        "branch": "block",
+        "testSource": "python/tests/test_ops.py::test_logsumexp",
+        "shape": [
+          2,
+          2,
+          8
+        ],
+        "coveredAxisSizes": [
+          3,
+          4,
+          6,
+          32
+        ],
+        "additionalTestSource": "python/tests/test_autograd.py::test_logsumexp_grad"
+      }
+    },
+    {
+      "id": "block-float32-axis-1025",
+      "values": {
+        "axisSize": 1025,
+        "nRows": 1,
+        "dtype": "float32"
+      },
+      "provenance": {
+        "hostFunction": "LogSumExp::eval_gpu",
+        "branch": "block",
+        "testSource": "python/tests/test_ops.py::test_logsumexp",
+        "shape": [
+          1025
+        ]
+      }
+    }
+  ],
+  "capabilities": [
+    {
+      "name": "simdWidth",
+      "type": "integer",
+      "provenance": {
+        "kernelSymbol": "SIMD_SIZE"
+      }
+    },
+    {
+      "name": "maxThreadsPerWorkgroup",
+      "type": "integer",
+      "provenance": {
+        "requirement": "bounded device record"
+      }
+    }
+  ],
+  "devices": [
+    {
+      "id": "wave32-max1024",
+      "values": {
+        "simdWidth": 32,
+        "maxThreadsPerWorkgroup": 1024
+      },
+      "provenance": {
+        "scope": "bounded wave32 device record"
+      }
+    }
+  ],
+  "contracts": [
+    {
+      "id": "mlx-logsumexp-unit-tests",
+      "source": "mlx/backend/metal/kernels/logsumexp.metal",
+      "provenance": {
+        "hostSource": "mlx/backend/metal/logsumexp.cpp",
+        "kernelSource": "mlx/backend/metal/kernels/logsumexp.metal",
+        "hostFormula": "32 * ceilDiv(ceilDiv(axisSize, 4), 32)",
+        "dispatchNormalization": "block workgroup count derived from dispatch_threads"
+      },
+      "branches": [
+        {
+          "id": "block-float32",
+          "when": {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "args": [
+                  {
+                    "input": "dtype"
+                  },
+                  "float32"
+                ]
+              },
+              {
+                "op": "le",
+                "args": [
+                  {
+                    "input": "axisSize"
+                  },
+                  4096
+                ]
+              },
+              {
+                "op": "eq",
+                "args": [
+                  {
+                    "capability": "simdWidth"
+                  },
+                  32
+                ]
+              },
+              {
+                "op": "eq",
+                "args": [
+                  {
+                    "capability": "maxThreadsPerWorkgroup"
+                  },
+                  1024
+                ]
+              }
+            ]
+          },
+          "entryPoint": "block_logsumexp_float32",
+          "workgroupSize": [
+            {
+              "op": "multiply",
+              "args": [
+                32,
+                {
+                  "op": "ceilDiv",
+                  "args": [
+                    {
+                      "op": "ceilDiv",
+                      "args": [
+                        {
+                          "input": "axisSize"
+                        },
+                        4
+                      ]
+                    },
+                    32
+                  ]
+                }
+              ]
+            },
+            1,
+            1
+          ],
+          "subgroupWidth": {
+            "capability": "simdWidth"
+          },
+          "dispatch": {
+            "workgroupCount": [
+              {
+                "input": "nRows"
+              },
+              1,
+              1
+            ]
+          },
+          "provenance": {
+            "hostFunction": "LogSumExp::eval_gpu",
+            "branch": "block",
+            "loopedLimit": 4096,
+            "readsPerThread": 4
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -10,13 +10,13 @@
       "directx",
       "vulkan"
     ],
-    "artifacts": 34,
-    "translated_artifacts": 30,
-    "failed_artifacts": 4,
+    "artifacts": 35,
+    "translated_artifacts": 32,
+    "failed_artifacts": 3,
     "target_artifacts": {
       "directx": {
-        "translated": 19,
-        "failed": 4
+        "translated": 21,
+        "failed": 3
       },
       "vulkan": {
         "translated": 11,
@@ -29,7 +29,6 @@
     "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
     "pending_host_dispatch_sources": [
       "mlx/backend/metal/kernels/arg_reduce.metal",
-      "mlx/backend/metal/kernels/logsumexp.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
       "mlx/backend/metal/kernels/softmax.metal"
     ],
@@ -1479,14 +1478,14 @@
   },
   "directx_toolchain_status": {
     "status": "passing-with-bounded-dispatch-and-pending-contracts",
-    "note": "Windows CI compiles 482 generated compute entries across 19 DirectX HLSL artifacts from seven pinned sources with zero DXC warnings. LayerNorm contributes two entry-scoped artifacts, and RMSNorm contributes 12 unit-test-derived entry-scoped artifacts selected by replayable host dispatch contracts. Four sources covering 82 aggregate entries still fail before emission because no bounded host dispatch manifest is configured; no placeholder workgroup size is applied. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity.",
+    "note": "Windows CI compiles 484 generated compute entries across 21 DirectX HLSL artifacts from eight pinned sources with zero DXC warnings. LayerNorm and LogSumExp each contribute two entry-scoped artifacts, and RMSNorm contributes 12 unit-test-derived entry-scoped artifacts selected by replayable host dispatch contracts. Three sources covering 76 aggregate entries still fail before emission because no bounded host dispatch manifest is configured; no placeholder workgroup size is applied. This is native compiler validation only and does not establish Direct3D runtime execution or numerical parity.",
     "compiler": {
       "name": "dxc",
       "version": "v1.9.2602.24"
     },
     "warning_evidence": {
       "status": "warning-clean",
-      "validatedRunCount": 482,
+      "validatedRunCount": 484,
       "warningRunCount": 0,
       "observedWarningCount": 0,
       "uniqueContractCount": 0,
@@ -1762,6 +1761,81 @@
           "generated_hlsl": {
             "sha256": "c565a0fc1bde31d3d04210f1a62be2bf96a703c8dcf8d1be51a73093a0a4a45f",
             "size_bytes": 8802
+          }
+        }
+      },
+      "dxc_validated_artifact_count": 2,
+      "runtime_execution_attempted": false,
+      "numerical_parity_claimed": false
+    },
+    "logsumexp_dispatch_frontier": {
+      "status": "translated-dxc-validated",
+      "source": "mlx/backend/metal/kernels/logsumexp.metal",
+      "source_sha256": "f9bec5e1e5a23d20bedf9ff8d29a8c03bbb5144bc5d751bbfe906d32ee894817",
+      "target": "directx",
+      "test_sources": [
+        "python/tests/test_ops.py::test_logsumexp",
+        "python/tests/test_autograd.py::test_logsumexp_grad"
+      ],
+      "dispatch_contract": {
+        "path": "demos/integrations/mlx/contracts/logsumexp.dispatch.json",
+        "normalized_sha256": "b1153ba5a68cb9fdb1bdcb04f552f258c6adaf127e6bcbedd8ef8c152067b3d5",
+        "content_identity": "sha256:db762a188e05786e206d9aa5a340b6f9095a8a3e938b85a7c04836f300e97c95",
+        "variant_count": 2,
+        "resolved_issue": "https://github.com/CrossGL/crosstl/issues/1793"
+      },
+      "artifact_count": 2,
+      "variants": {
+        "block-float32-axis-32": {
+          "entry_point": "block_logsumexp_float32",
+          "artifact_id": "sha256:f51ab67b8a9ad3240e3fbb52f6de00cdf4a8532e58790758e59aa50fb95e2c52",
+          "dispatch_variant_id": "sha256:0a9cafa696d2fddd6284c44673b9120120a70630a0a18714e27284f8a6189c59",
+          "inputs": {
+            "axisSize": 32,
+            "dtype": "float32",
+            "nRows": 1
+          },
+          "workgroup_size": [
+            32,
+            1,
+            1
+          ],
+          "dispatch_workgroup_count": [
+            1,
+            1,
+            1
+          ],
+          "subgroup_width": 32,
+          "subgroup_width_enforcement": "WaveSize(32)",
+          "generated_hlsl": {
+            "sha256": "ce219ef1c7639ef3cdf61d8f4bf2cee8c9253a0f564d9eea8f0e318fbfbc2b49",
+            "size_bytes": 3329
+          }
+        },
+        "block-float32-axis-1025": {
+          "entry_point": "block_logsumexp_float32",
+          "artifact_id": "sha256:ae512c102a88628c05a49f28a872c44ab582bacf74584e8ca7e6ae765263afe0",
+          "dispatch_variant_id": "sha256:35754405ceaa5e50614c3fef95a66390b99580c9bd2394c0ba5279322fde7446",
+          "inputs": {
+            "axisSize": 1025,
+            "dtype": "float32",
+            "nRows": 1
+          },
+          "workgroup_size": [
+            288,
+            1,
+            1
+          ],
+          "dispatch_workgroup_count": [
+            1,
+            1,
+            1
+          ],
+          "subgroup_width": 32,
+          "subgroup_width_enforcement": "WaveSize(32)",
+          "generated_hlsl": {
+            "sha256": "7584a96799944d5a88f34b43d647102195cc13a1a5281778132306b75323e14a",
+            "size_bytes": 3331
           }
         }
       },
@@ -2156,16 +2230,18 @@
       "mlx/backend/metal/kernels/arange.metal": 11,
       "mlx/backend/metal/kernels/binary_two.metal": 225,
       "mlx/backend/metal/kernels/layer_norm.metal": 2,
+      "mlx/backend/metal/kernels/logsumexp.metal": 2,
       "mlx/backend/metal/kernels/random.metal": 2,
       "mlx/backend/metal/kernels/rms_norm.metal": 12,
       "mlx/backend/metal/kernels/rope.metal": 18,
       "mlx/backend/metal/kernels/ternary.metal": 212
     },
-    "expected_entry_point_count": 482,
+    "expected_entry_point_count": 484,
     "dxc_validated_sources": [
       "mlx/backend/metal/kernels/arange.metal",
       "mlx/backend/metal/kernels/binary_two.metal",
       "mlx/backend/metal/kernels/layer_norm.metal",
+      "mlx/backend/metal/kernels/logsumexp.metal",
       "mlx/backend/metal/kernels/random.metal",
       "mlx/backend/metal/kernels/rms_norm.metal",
       "mlx/backend/metal/kernels/rope.metal",
@@ -2235,17 +2311,15 @@
     },
     "workgroup_blocked_sources": [
       "mlx/backend/metal/kernels/arg_reduce.metal",
-      "mlx/backend/metal/kernels/logsumexp.metal",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal",
       "mlx/backend/metal/kernels/softmax.metal"
     ],
     "workgroup_blocked_entry_point_counts": {
       "mlx/backend/metal/kernels/arg_reduce.metal": 24,
-      "mlx/backend/metal/kernels/logsumexp.metal": 6,
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": 42,
       "mlx/backend/metal/kernels/softmax.metal": 10
     },
-    "workgroup_blocked_entry_point_count": 82,
+    "workgroup_blocked_entry_point_count": 76,
     "workgroup_blocked_diagnostic": "project.translate.workgroup-size-entry-ambiguous",
     "host_dispatch_import_resolved_by": "https://github.com/CrossGL/crosstl/issues/1793",
     "dispatch_evidence": {
@@ -2266,27 +2340,6 @@
         "materializationParameters": [
           "N_READS",
           "Op",
-          "T"
-        ]
-      },
-      "mlx/backend/metal/kernels/logsumexp.metal": {
-        "specializationCount": 7,
-        "hostSource": "mlx/backend/metal/logsumexp.cpp",
-        "hostLines": "58-91",
-        "dispatchFormulas": [
-          "block: [32 * ceil_div(ceil_div(axis_size, 4), 32), 1, 1]",
-          "looped: [maxTotalThreadsPerThreadgroup, 1, 1]"
-        ],
-        "dispatchSelection": [
-          "block when axis_size <= 4096; looped when axis_size > 4096"
-        ],
-        "runtimeOperands": [
-          "axis_size",
-          "maxTotalThreadsPerThreadgroup"
-        ],
-        "materializationParameters": [
-          "AccT",
-          "N_READS",
           "T"
         ]
       },
@@ -2343,7 +2396,6 @@
     },
     "directx_toolchain_gaps": {
       "mlx/backend/metal/kernels/arg_reduce.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
-      "mlx/backend/metal/kernels/logsumexp.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
       "mlx/backend/metal/kernels/scaled_dot_product_attention.metal": "no bounded host dispatch manifest is configured for the runtime-selected pass, shape, and device architecture; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
       "mlx/backend/metal/kernels/softmax.metal": "no bounded host dispatch manifest is configured for the runtime-selected axis and pipeline limit; aggregate translation fails with project.translate.workgroup-size-entry-ambiguous (host dispatch import support resolved in https://github.com/CrossGL/crosstl/issues/1793)",
       "mlx/backend/metal/kernels/fence.metal": "the requested mem_device, memory_order_seq_cst, thread_scope_system atomic-fence contract is not representable in HLSL and fails with project.translate.directx-atomic-fence-unsupported (https://github.com/CrossGL/crosstl/issues/1537)"

--- a/demos/integrations/mlx/run_mlx_porting.py
+++ b/demos/integrations/mlx/run_mlx_porting.py
@@ -88,6 +88,46 @@ MLX_LAYER_NORM_DISPATCH_VARIANTS = {
     },
 }
 MLX_LOGSUMEXP_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
+MLX_LOGSUMEXP_SHA256 = (
+    "f9bec5e1e5a23d20bedf9ff8d29a8c03bbb5144bc5d751bbfe906d32ee894817"
+)
+MLX_LOGSUMEXP_DISPATCH_CONTRACT_SOURCE = (
+    Path(__file__).resolve().parent / "contracts" / "logsumexp.dispatch.json"
+)
+MLX_LOGSUMEXP_DISPATCH_NORMALIZED_SHA256 = (
+    "b1153ba5a68cb9fdb1bdcb04f552f258c6adaf127e6bcbedd8ef8c152067b3d5"
+)
+MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY = (
+    "sha256:db762a188e05786e206d9aa5a340b6f9095a8a3e938b85a7c04836f300e97c95"
+)
+MLX_LOGSUMEXP_DISPATCH_VARIANTS = {
+    "block-float32-axis-32": {
+        "entryPoint": "block_logsumexp_float32",
+        "artifactId": (
+            "sha256:f51ab67b8a9ad3240e3fbb52f6de00cdf4a8532e58790758e59aa50fb95e2c52"
+        ),
+        "dispatchVariantId": (
+            "sha256:0a9cafa696d2fddd6284c44673b9120120a70630a0a18714e27284f8a6189c59"
+        ),
+        "inputs": {"axisSize": 32, "dtype": "float32", "nRows": 1},
+        "workgroupSize": [32, 1, 1],
+        "dispatchWorkgroupCount": [1, 1, 1],
+        "specializationConstants": {},
+    },
+    "block-float32-axis-1025": {
+        "entryPoint": "block_logsumexp_float32",
+        "artifactId": (
+            "sha256:ae512c102a88628c05a49f28a872c44ab582bacf74584e8ca7e6ae765263afe0"
+        ),
+        "dispatchVariantId": (
+            "sha256:35754405ceaa5e50614c3fef95a66390b99580c9bd2394c0ba5279322fde7446"
+        ),
+        "inputs": {"axisSize": 1025, "dtype": "float32", "nRows": 1},
+        "workgroupSize": [288, 1, 1],
+        "dispatchWorkgroupCount": [1, 1, 1],
+        "specializationConstants": {},
+    },
+}
 MLX_METAL_ROUNDTRIP_SOURCE = MLX_FENCE_SOURCE
 MLX_RANDOM_SOURCE = "mlx/backend/metal/kernels/random.metal"
 MLX_QUANTIZED_SOURCE = "mlx/backend/metal/kernels/quantized.metal"
@@ -373,7 +413,7 @@ MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES = (
 MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES = tuple(
     source
     for source in MLX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES
-    if source not in {MLX_LAYER_NORM_SOURCE, MLX_RMS_NORM_SOURCE}
+    if source not in {MLX_LAYER_NORM_SOURCE, MLX_LOGSUMEXP_SOURCE, MLX_RMS_NORM_SOURCE}
 )
 MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES = tuple(
     source
@@ -497,21 +537,25 @@ MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS = {
     MLX_TERNARY_SOURCE: 212,
 }
 # Aggregate artifacts retain every source entry when one workgroup contract applies.
-# LayerNorm and RMSNorm contribute bounded, entry-scoped host-dispatch artifacts.
+# LayerNorm, LogSumExp, and RMSNorm contribute bounded, entry-scoped artifacts.
 MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES = tuple(
     source
     for source in MLX_DIRECTX_VULKAN_FRONTIER_SOURCES
     if source in MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES
-    or source in {MLX_LAYER_NORM_SOURCE, MLX_RMS_NORM_SOURCE}
+    or source in {MLX_LAYER_NORM_SOURCE, MLX_LOGSUMEXP_SOURCE, MLX_RMS_NORM_SOURCE}
 )
 MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS = {
     source: (
         len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
         if source == MLX_LAYER_NORM_SOURCE
         else (
-            len(MLX_RMS_NORM_DISPATCH_VARIANTS)
-            if source == MLX_RMS_NORM_SOURCE
-            else MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS[source]
+            len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+            if source == MLX_LOGSUMEXP_SOURCE
+            else (
+                len(MLX_RMS_NORM_DISPATCH_VARIANTS)
+                if source == MLX_RMS_NORM_SOURCE
+                else MLX_DIRECTX_FRONTIER_ENTRY_POINT_COUNTS[source]
+            )
         )
     )
     for source in MLX_DIRECTX_TOOLCHAIN_FRONTIER_SOURCES
@@ -522,6 +566,7 @@ MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT = sum(
 MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT = (
     len(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES)
     + len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+    + len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
     + len(MLX_RMS_NORM_DISPATCH_VARIANTS)
 )
 MLX_DIRECTX_TOOLCHAIN_WARNING_CONTRACTS: tuple[dict[str, Any], ...] = ()
@@ -1695,6 +1740,77 @@ def _prepare_layer_norm_dispatch_contract(
         )
 
     destination = work_dir / "contracts" / "layer_norm.dispatch.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source_path, destination)
+    return {
+        "path": _relpath(destination, mlx_root),
+        "contentIdentity": content_identity,
+        "variantCount": len(variants),
+    }
+
+
+def _prepare_logsumexp_dispatch_contract(
+    mlx_root: Path,
+    work_dir: Path,
+) -> dict[str, Any]:
+    source_path = MLX_LOGSUMEXP_DISPATCH_CONTRACT_SOURCE
+    _require(
+        source_path.is_file(),
+        f"LogSumExp dispatch contract is missing: {source_path}",
+    )
+    _require(
+        _normalized_text_sha256(source_path)
+        == MLX_LOGSUMEXP_DISPATCH_NORMALIZED_SHA256,
+        "LogSumExp dispatch contract normalized content changed",
+    )
+    logsumexp_source = mlx_root / MLX_LOGSUMEXP_SOURCE
+    _require(
+        logsumexp_source.is_file()
+        and _sha256(logsumexp_source) == MLX_LOGSUMEXP_SHA256,
+        "pinned LogSumExp source identity changed",
+    )
+
+    manifest = load_dispatch_contract(source_path)
+    content_identity = manifest.content_identity.to_json()
+    expected_identity = {
+        "algorithm": "sha256",
+        "value": MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY.removeprefix("sha256:"),
+    }
+    _require(
+        content_identity == expected_identity,
+        "LogSumExp dispatch contract identity changed",
+    )
+    evaluation = manifest.evaluate().to_json()
+    variants = evaluation.get("variants")
+    variants_by_workload = {
+        variant.get("workload", {}).get("id"): variant
+        for variant in variants or []
+        if isinstance(variant, Mapping) and isinstance(variant.get("workload"), Mapping)
+    }
+    _require(
+        isinstance(variants, list)
+        and len(variants) == len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+        and set(variants_by_workload) == set(MLX_LOGSUMEXP_DISPATCH_VARIANTS),
+        "LogSumExp dispatch contract variant set changed",
+    )
+    for workload_id, expected in MLX_LOGSUMEXP_DISPATCH_VARIANTS.items():
+        variant = variants_by_workload[workload_id]
+        _require(
+            variant.get("artifactId") == expected["artifactId"]
+            and variant.get("variantId") == expected["dispatchVariantId"]
+            and variant.get("source") == MLX_LOGSUMEXP_SOURCE
+            and variant.get("entryPoint") == expected["entryPoint"]
+            and variant.get("workload", {}).get("inputs") == expected["inputs"]
+            and variant.get("workgroupSize") == expected["workgroupSize"]
+            and variant.get("subgroupWidth") == 32
+            and variant.get("specializationConstants")
+            == expected["specializationConstants"]
+            and variant.get("dispatch", {}).get("workgroupCount")
+            == expected["dispatchWorkgroupCount"],
+            f"LogSumExp dispatch contract changed for {workload_id}",
+        )
+
+    destination = work_dir / "contracts" / "logsumexp.dispatch.json"
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(source_path, destination)
     return {
@@ -4107,6 +4223,341 @@ def _require_layer_norm_dispatch_frontier_report(
     return artifacts_by_entry, evidence, toolchain_runs
 
 
+def _require_logsumexp_dispatch_frontier_report(
+    mlx_root: Path,
+    output_dir: Path,
+    payload: Mapping[str, Any],
+    *,
+    contract: Mapping[str, Any],
+    validated: bool,
+) -> tuple[dict[str, Mapping[str, Any]], dict[str, Any], list[Mapping[str, Any]]]:
+    project = payload.get("project")
+    contract_records = (
+        project.get("dispatchContracts") if isinstance(project, Mapping) else None
+    )
+    artifact_count = len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+    _require(
+        isinstance(project, Mapping)
+        and project.get("includePatterns") == [MLX_LOGSUMEXP_SOURCE]
+        and project.get("targets") == ["directx"]
+        and project.get("dispatchContractFiles") == [contract["path"]]
+        and project.get("dispatchContractCount") == 1
+        and project.get("dispatchVariantCount") == artifact_count
+        and isinstance(contract_records, list)
+        and len(contract_records) == 1,
+        "LogSumExp dispatch frontier project metadata changed",
+    )
+    contract_record = contract_records[0]
+    expected_manifest_path = str((mlx_root / str(contract["path"])).resolve())
+    evaluation = (
+        contract_record.get("evaluation")
+        if isinstance(contract_record, Mapping)
+        else None
+    )
+    evaluated_variants = (
+        evaluation.get("variants") if isinstance(evaluation, Mapping) else None
+    )
+    _require(
+        isinstance(contract_record, Mapping)
+        and contract_record.get("path") == contract["path"]
+        and contract_record.get("schemaVersion") == 1
+        and contract_record.get("contentIdentity") == contract["contentIdentity"]
+        and contract_record.get("manifest", {}).get("provenance", {}).get("commit")
+        == MLX_COMMIT
+        and isinstance(evaluation, Mapping)
+        and evaluation.get("manifestSource") == expected_manifest_path
+        and evaluation.get("variantCount") == artifact_count
+        and isinstance(evaluated_variants, list)
+        and len(evaluated_variants) == artifact_count,
+        "LogSumExp dispatch frontier did not retain replayable manifest provenance",
+    )
+    evaluation_by_workload = {
+        variant.get("workload", {}).get("id"): variant
+        for variant in evaluated_variants
+        if isinstance(variant, Mapping) and isinstance(variant.get("workload"), Mapping)
+    }
+    _require(
+        set(evaluation_by_workload) == set(MLX_LOGSUMEXP_DISPATCH_VARIANTS),
+        "LogSumExp dispatch evaluation workload set changed",
+    )
+
+    summary = payload.get("summary")
+    _require(
+        isinstance(summary, Mapping)
+        and summary.get("unitCount") == 1
+        and summary.get("artifactCount") == artifact_count
+        and summary.get("translatedCount") == artifact_count
+        and summary.get("failedCount") == 0
+        and summary.get("diagnosticCounts") == {"error": 0, "note": 0, "warning": 0}
+        and summary.get("artifactsByTarget", {}).get("directx")
+        == {
+            "artifactCount": artifact_count,
+            "translatedCount": artifact_count,
+            "failedCount": 0,
+        }
+        and payload.get("diagnostics") == [],
+        "LogSumExp dispatch frontier accounting changed",
+    )
+    units = payload.get("units")
+    _require(
+        isinstance(units, list)
+        and len(units) == 1
+        and units[0].get("path") == MLX_LOGSUMEXP_SOURCE
+        and units[0].get("sourceBackend") == "metal"
+        and units[0].get("sourceHash")
+        == {"algorithm": "sha256", "value": MLX_LOGSUMEXP_SHA256},
+        "LogSumExp dispatch frontier source identity changed",
+    )
+
+    dispatch_plan = project.get("dispatchArtifactPlan")
+    planned_artifacts = (
+        dispatch_plan.get("artifacts") if isinstance(dispatch_plan, Mapping) else None
+    )
+    expected_artifact_ids = {
+        expected["artifactId"] for expected in MLX_LOGSUMEXP_DISPATCH_VARIANTS.values()
+    }
+    _require(
+        isinstance(dispatch_plan, Mapping)
+        and dispatch_plan.get("kind") == "crosstl-dispatch-artifact-plan"
+        and dispatch_plan.get("schemaVersion") == 1
+        and dispatch_plan.get("sourceUnitCount") == 1
+        and dispatch_plan.get("artifactCount") == artifact_count
+        and dispatch_plan.get("dispatchVariantCount") == artifact_count
+        and isinstance(planned_artifacts, list)
+        and len(planned_artifacts) == artifact_count,
+        "LogSumExp dispatch artifact plan changed",
+    )
+    plan_by_artifact_id = {
+        record.get("artifactId"): record
+        for record in planned_artifacts
+        if isinstance(record, Mapping)
+    }
+    _require(
+        set(plan_by_artifact_id) == expected_artifact_ids,
+        "LogSumExp dispatch artifact plan identity set changed",
+    )
+
+    artifacts = payload.get("artifacts")
+    _require(
+        isinstance(artifacts, list) and len(artifacts) == artifact_count,
+        "LogSumExp dispatch artifact records are incomplete",
+    )
+    artifacts_by_id = {
+        artifact.get("dispatchArtifact", {}).get("artifactId"): artifact
+        for artifact in artifacts
+        if isinstance(artifact, Mapping)
+        and isinstance(artifact.get("dispatchArtifact"), Mapping)
+    }
+    _require(
+        set(artifacts_by_id) == expected_artifact_ids,
+        "LogSumExp dispatch artifact identity set changed",
+    )
+
+    output_root = output_dir.resolve()
+    artifacts_by_workload: dict[str, Mapping[str, Any]] = {}
+    generated_evidence: dict[str, Any] = {}
+    expected_template_parameters = {"AccT": "float", "N_READS": "4", "T": "float"}
+    for workload_id, expected in MLX_LOGSUMEXP_DISPATCH_VARIANTS.items():
+        artifact_id = expected["artifactId"]
+        artifact = artifacts_by_id[artifact_id]
+        plan = plan_by_artifact_id[artifact_id]
+        evaluated = evaluation_by_workload[workload_id]
+        entry = artifact.get("entryPoint")
+        entry_point = entry.get("source") if isinstance(entry, Mapping) else None
+        _require(
+            evaluated.get("artifactId") == artifact_id
+            and evaluated.get("variantId") == expected["dispatchVariantId"]
+            and evaluated.get("entryPoint") == expected["entryPoint"]
+            and evaluated.get("workload", {}).get("inputs") == expected["inputs"]
+            and evaluated.get("workgroupSize") == expected["workgroupSize"]
+            and evaluated.get("subgroupWidth") == 32
+            and evaluated.get("specializationConstants") == {}
+            and evaluated.get("dispatch", {}).get("workgroupCount")
+            == expected["dispatchWorkgroupCount"],
+            f"LogSumExp evaluated dispatch changed for {workload_id}",
+        )
+        variant_name = "dispatch-" + artifact_id.removeprefix("sha256:")
+        _require(
+            artifact.get("source") == MLX_LOGSUMEXP_SOURCE
+            and artifact.get("sourceBackend") == "metal"
+            and artifact.get("sourceHash")
+            == {"algorithm": "sha256", "value": MLX_LOGSUMEXP_SHA256}
+            and artifact.get("target") == "directx"
+            and artifact.get("status") == "translated"
+            and artifact.get("variant") == variant_name
+            and entry_point == expected["entryPoint"]
+            and entry.get("target") == "CSMain"
+            and entry.get("stage") == "compute"
+            and artifact.get("dispatchArtifact") == plan
+            and plan.get("artifactId") == artifact_id
+            and plan.get("dispatchVariantIds") == [expected["dispatchVariantId"]]
+            and plan.get("manifestContentIdentities")
+            == [MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY]
+            and plan.get("source") == MLX_LOGSUMEXP_SOURCE
+            and plan.get("entryPoint") == expected["entryPoint"]
+            and plan.get("workgroupSize") == expected["workgroupSize"]
+            and plan.get("subgroupWidth") == 32
+            and plan.get("specializationConstants") == {},
+            f"LogSumExp dispatch artifact contract changed for {workload_id}",
+        )
+
+        execution = artifact.get("execution")
+        execution_entries = (
+            execution.get("entryPoints") if isinstance(execution, Mapping) else None
+        )
+        _require(
+            isinstance(execution, Mapping)
+            and execution.get("sourceEntryPoints") == [expected["entryPoint"]]
+            and execution.get("provenance", {}).get("kind") == "host-dispatch-contract"
+            and execution.get("provenance", {}).get("artifactId") == artifact_id
+            and execution.get("subgroupWidthProvenance", {}).get("kind")
+            == "host-dispatch-contract"
+            and execution.get("subgroupWidthEnforcement")
+            == {
+                "mechanism": "hlsl-wave-size-attribute",
+                "minimumShaderModel": "6.6",
+                "entryProfiles": [{"entryPoint": "CSMain", "profile": "cs_6_6"}],
+            }
+            and isinstance(execution_entries, list)
+            and len(execution_entries) == 1
+            and execution_entries[0].get("sourceEntryPoint") == expected["entryPoint"]
+            and execution_entries[0].get("materializedEntryPoint")
+            == expected["entryPoint"]
+            and execution_entries[0].get("targetEntryPoint") == "CSMain"
+            and execution_entries[0].get("workgroupSize") == expected["workgroupSize"]
+            and execution_entries[0].get("subgroupWidth") == 32,
+            f"LogSumExp execution metadata changed for {workload_id}",
+        )
+        _require(
+            not artifact.get("specializationConstants"),
+            f"LogSumExp artifact gained specialization constants for {workload_id}",
+        )
+
+        materialization = artifact.get("templateMaterialization")
+        specializations = (
+            materialization.get("specializations")
+            if isinstance(materialization, Mapping)
+            else None
+        )
+        _require(
+            isinstance(materialization, Mapping)
+            and materialization.get("status") == "materialized"
+            and materialization.get("specializationCount") == 1
+            and isinstance(specializations, list)
+            and len(specializations) == 1
+            and specializations[0].get("hostName") == expected["entryPoint"]
+            and specializations[0].get("parameters") == expected_template_parameters
+            and materialization.get("unsupported") == [],
+            f"LogSumExp materialization changed for {workload_id}",
+        )
+
+        artifact_path_value = artifact.get("path")
+        _require(
+            isinstance(artifact_path_value, str) and artifact_path_value,
+            f"LogSumExp artifact path is missing for {workload_id}",
+        )
+        artifact_path = (mlx_root / artifact_path_value).resolve()
+        _require(
+            _is_relative_to(artifact_path, output_root) and artifact_path.is_file(),
+            f"LogSumExp artifact is missing or escaped output for {workload_id}",
+        )
+        generated = artifact_path.read_text(encoding="utf-8")
+        generated_hash = _sha256(artifact_path)
+        normalized_hash = _normalized_text_sha256(artifact_path)
+        _require(
+            artifact.get("generatedHash")
+            == {"algorithm": "sha256", "value": generated_hash}
+            and artifact.get("generatedSizeBytes") == artifact_path.stat().st_size
+            and len(re.findall(r"\bvoid\s+CSMain\s*\(", generated)) == 1
+            and re.search(r"\[\s*WaveSize\s*\(\s*32\s*\)\s*\]", generated) is not None
+            and re.search(
+                r"\[\s*numthreads\s*\(\s*{}\s*,\s*1\s*,\s*1\s*\)\s*\]".format(
+                    expected["workgroupSize"][0]
+                ),
+                generated,
+            )
+            is not None
+            and all(
+                fragment in generated
+                for fragment in (
+                    "WaveActiveMax",
+                    "WaveActiveSum",
+                    "GroupMemoryBarrierWithGroupSync",
+                    "exp(",
+                    "log(",
+                    "out_[gid]",
+                )
+            ),
+            f"LogSumExp generated HLSL contract changed for {workload_id}",
+        )
+        generated_evidence[workload_id] = {
+            "entryPoint": expected["entryPoint"],
+            "artifactId": artifact_id,
+            "dispatchVariantId": expected["dispatchVariantId"],
+            "inputs": dict(expected["inputs"]),
+            "workgroupSize": list(expected["workgroupSize"]),
+            "dispatchWorkgroupCount": list(expected["dispatchWorkgroupCount"]),
+            "subgroupWidth": 32,
+            "generatedHlsl": {
+                "normalizedSha256": normalized_hash,
+                "contentSha256": generated_hash,
+                "sizeBytes": artifact_path.stat().st_size,
+            },
+        }
+        artifacts_by_workload[workload_id] = artifact
+
+    toolchain_runs: list[Mapping[str, Any]] = []
+    if validated:
+        validation = payload.get("validation")
+        runs = (
+            validation.get("toolchainRuns") if isinstance(validation, Mapping) else None
+        )
+        _require(
+            isinstance(validation, Mapping)
+            and isinstance(validation.get("summary"), Mapping)
+            and validation["summary"].get("failedCount") == 0
+            and isinstance(runs, list),
+            "LogSumExp dispatch DXC validation changed",
+        )
+        toolchain_runs = [
+            run
+            for run in runs
+            if isinstance(run, Mapping) and run.get("target") == "directx"
+        ]
+        artifact_paths = {
+            artifact["path"] for artifact in artifacts_by_workload.values()
+        }
+        _require(
+            len(toolchain_runs) == artifact_count
+            and all(run.get("status") == "ok" for run in toolchain_runs)
+            and {run.get("path") for run in toolchain_runs} == artifact_paths,
+            "LogSumExp dispatch DXC did not validate every artifact",
+        )
+
+    evidence = {
+        "status": "translated-dxc-validated" if validated else "translated",
+        "source": MLX_LOGSUMEXP_SOURCE,
+        "sourceSha256": MLX_LOGSUMEXP_SHA256,
+        "target": "directx",
+        "testSources": [
+            "python/tests/test_ops.py::test_logsumexp",
+            "python/tests/test_autograd.py::test_logsumexp_grad",
+        ],
+        "dispatchContract": {
+            "path": contract["path"],
+            "contentIdentity": MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY,
+            "variantCount": artifact_count,
+            "resolvedIssue": MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
+        },
+        "artifactCount": artifact_count,
+        "variants": generated_evidence,
+        "dxcValidatedArtifactCount": len(toolchain_runs),
+        "runtimeExecutionAttempted": False,
+        "numericalParityClaimed": False,
+    }
+    return artifacts_by_workload, evidence, toolchain_runs
+
+
 def _require_rms_norm_dispatch_frontier_report(
     mlx_root: Path,
     output_dir: Path,
@@ -4851,6 +5302,37 @@ def _translate_directx_frontier(
         validated=False,
     )
 
+    logsumexp_contract = _prepare_logsumexp_dispatch_contract(mlx_root, work_dir)
+    logsumexp_output_dir = work_dir / "out-directx-logsumexp-dispatch-frontier"
+    (
+        _logsumexp_result,
+        logsumexp_payload,
+        _logsumexp_config,
+        logsumexp_report_path,
+    ) = _run_frontier_project(
+        mlx_root=mlx_root,
+        config_dir=config_dir,
+        report_dir=report_dir,
+        log_dir=log_dir,
+        python=python,
+        command_name="directx-logsumexp-dispatch-frontier",
+        target="directx",
+        sources=(MLX_LOGSUMEXP_SOURCE,),
+        output_dir=logsumexp_output_dir,
+        dispatch_contracts=(str(logsumexp_contract["path"]),),
+    )
+    (
+        logsumexp_artifacts,
+        logsumexp_evidence,
+        _logsumexp_runs,
+    ) = _require_logsumexp_dispatch_frontier_report(
+        mlx_root,
+        logsumexp_output_dir,
+        logsumexp_payload,
+        contract=logsumexp_contract,
+        validated=False,
+    )
+
     rms_norm_contract = _prepare_rms_norm_dispatch_contract(mlx_root, work_dir)
     rms_norm_output_dir = work_dir / "out-directx-rms-norm-dispatch-frontier"
     (
@@ -4982,6 +5464,38 @@ def _translate_directx_frontier(
             contract=layer_norm_contract,
             validated=True,
         )
+        logsumexp_toolchain_output = (
+            work_dir / "out-directx-logsumexp-dispatch-toolchain"
+        )
+        (
+            _logsumexp_toolchain_result,
+            logsumexp_toolchain_payload,
+            _logsumexp_toolchain_config,
+            _logsumexp_toolchain_report,
+        ) = _run_frontier_project(
+            mlx_root=mlx_root,
+            config_dir=config_dir,
+            report_dir=report_dir,
+            log_dir=log_dir,
+            python=python,
+            command_name="validate-directx-logsumexp-dispatch-toolchain",
+            target="directx",
+            sources=(MLX_LOGSUMEXP_SOURCE,),
+            output_dir=logsumexp_toolchain_output,
+            run_toolchains=True,
+            dispatch_contracts=(str(logsumexp_contract["path"]),),
+        )
+        (
+            logsumexp_artifacts,
+            logsumexp_evidence,
+            logsumexp_runs,
+        ) = _require_logsumexp_dispatch_frontier_report(
+            mlx_root,
+            logsumexp_toolchain_output,
+            logsumexp_toolchain_payload,
+            contract=logsumexp_contract,
+            validated=True,
+        )
         rms_norm_toolchain_output = work_dir / "out-directx-rms-norm-dispatch-toolchain"
         (
             _rms_norm_toolchain_result,
@@ -5012,10 +5526,16 @@ def _translate_directx_frontier(
             contract=rms_norm_contract,
             validated=True,
         )
-        directx_runs = [*aggregate_runs, *layer_norm_runs, *rms_norm_runs]
+        directx_runs = [
+            *aggregate_runs,
+            *layer_norm_runs,
+            *logsumexp_runs,
+            *rms_norm_runs,
+        ]
         artifact_paths = {
             *(artifact["path"] for artifact in artifacts.values()),
             *(artifact["path"] for artifact in layer_norm_artifacts.values()),
+            *(artifact["path"] for artifact in logsumexp_artifacts.values()),
             *(artifact["path"] for artifact in rms_norm_artifacts.values()),
         }
         validated_paths = {
@@ -5033,6 +5553,10 @@ def _translate_directx_frontier(
         artifact["path"]: entry_point
         for entry_point, artifact in layer_norm_artifacts.items()
     }
+    logsumexp_workload_by_path = {
+        artifact["path"]: workload_id
+        for workload_id, artifact in logsumexp_artifacts.items()
+    }
     rms_norm_workload_by_path = {
         artifact["path"]: workload_id
         for workload_id, artifact in rms_norm_artifacts.items()
@@ -5047,6 +5571,8 @@ def _translate_directx_frontier(
         )
         if source == MLX_LAYER_NORM_SOURCE:
             entry_point = layer_norm_entry_by_path.get(run.get("path"))
+        elif source == MLX_LOGSUMEXP_SOURCE:
+            entry_point = logsumexp_workload_by_path.get(run.get("path"))
         elif source == MLX_RMS_NORM_SOURCE:
             entry_point = rms_norm_workload_by_path.get(run.get("path"))
         else:
@@ -5090,6 +5616,7 @@ def _translate_directx_frontier(
         "scope": "target-split-frontier",
         "report": _relpath(report_path, mlx_root),
         "layerNormDispatchReport": _relpath(layer_norm_report_path, mlx_root),
+        "logsumexpDispatchReport": _relpath(logsumexp_report_path, mlx_root),
         "rmsNormDispatchReport": _relpath(rms_norm_report_path, mlx_root),
         "workgroupBlockedReport": _relpath(blocked_report_path, mlx_root),
         "sources": list(MLX_DIRECTX_VULKAN_FRONTIER_SOURCES),
@@ -5097,6 +5624,7 @@ def _translate_directx_frontier(
         "artifactCount": (
             len(MLX_DIRECTX_TRANSLATED_FRONTIER_SOURCES)
             + len(MLX_LAYER_NORM_DISPATCH_VARIANTS)
+            + len(MLX_LOGSUMEXP_DISPATCH_VARIANTS)
             + len(MLX_RMS_NORM_DISPATCH_VARIANTS)
             + len(MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES)
         ),
@@ -5135,6 +5663,7 @@ def _translate_directx_frontier(
         "native16BitArithmeticEvidence": MLX_DIRECTX_NATIVE_16_BIT_ARITHMETIC_EVIDENCE,
         "bfloat16LoweringEvidence": bfloat16_lowering_evidence,
         "layerNormDispatchEvidence": layer_norm_evidence,
+        "logsumexpDispatchEvidence": logsumexp_evidence,
         "rmsNormDispatchEvidence": rms_norm_evidence,
         "dynamicWorkgroupDispatchEvidence": dispatch_evidence,
         "semanticReadinessStatus": "not-established",

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2423,6 +2423,11 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "translate_project_reports_unrepresentable_atomic_fence_contract" in (
         mlx_porting
     )
+    assert (
+        "python -m pytest -q -n auto "
+        "tests/test_mlx_dispatch_contract_fixture.py "
+        "tests/test_mlx_logsumexp_dispatch_contract_fixture.py" in mlx_porting
+    )
     assert '"tests/test_mlx_porting_harness.py"' in mlx_porting
     assert '"tests/test_mlx_logsumexp_dispatch_contract_fixture.py"' in mlx_porting
     assert '"tests/test_mlx_rms_norm_dispatch_contract_fixture.py"' in mlx_porting

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -2424,6 +2424,7 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
         mlx_porting
     )
     assert '"tests/test_mlx_porting_harness.py"' in mlx_porting
+    assert '"tests/test_mlx_logsumexp_dispatch_contract_fixture.py"' in mlx_porting
     assert '"tests/test_mlx_rms_norm_dispatch_contract_fixture.py"' in mlx_porting
     assert '"tests/test_mlx_quantized_directx_proof.py"' in mlx_porting
     assert '"tests/test_mlx_quantized_opengl_proof.py"' in mlx_porting
@@ -2451,6 +2452,7 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert "MLX_DIRECTX_DYNAMIC_WORKGROUP_FRONTIER_SOURCES" in mlx_porting
     assert "MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE" in mlx_porting
     assert "MLX_LAYER_NORM_DISPATCH_VARIANTS" in mlx_porting
+    assert "MLX_LOGSUMEXP_DISPATCH_VARIANTS" in mlx_porting
     assert "MLX_RMS_NORM_DISPATCH_VARIANTS" in mlx_porting
     assert 'checks["directx-frontier"]' in mlx_porting
     assert 'checks["vulkan-frontier"]' in mlx_porting
@@ -2463,8 +2465,9 @@ def test_mlx_project_porting_workflow_runs_tracked_porting_harness():
     assert 'directx["bfloat16LoweringEvidence"]' in mlx_porting
     assert "DirectX bfloat16 lowering evidence is incomplete" in mlx_porting
     assert "DirectX workgroup blocker evidence changed" in mlx_porting
-    assert "expected 82 fail-closed DirectX compute entries" in mlx_porting
+    assert "expected 76 fail-closed DirectX compute entries" in mlx_porting
     assert "LayerNorm dispatch frontier evidence is incomplete" in mlx_porting
+    assert "LogSumExp dispatch frontier evidence is incomplete" in mlx_porting
     assert "RMSNorm dispatch frontier evidence is incomplete" in mlx_porting
     assert "matched-materialized-host-names" in mlx_porting
     assert "DirectX frontier toolchain must validate every configured" in mlx_porting
@@ -3071,6 +3074,27 @@ def test_mlx_project_porting_workflow_runs_pinned_binary_native_loader_proof():
     )
     assert "-n auto" in directx_step
     assert "-k" not in directx_step
+
+
+def test_mlx_project_porting_workflow_runs_pinned_logsumexp_native_loader_proof():
+    mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
+    ci_coverage = _load_ci_coverage_module()
+    test_path = "tests/test_translator/test_mlx_logsumexp_native_loader.py"
+
+    assert mlx_porting.count(f'"{test_path}"') == 2
+    step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Prove pinned MLX LogSumExp Direct3D native-loader execution",
+    )
+    assert "if: runner.os == 'Windows'" in step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in step
+    assert 'CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER: "1"' in step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_logsumexp_executes_through_directx_native_loader" in step
+    )
+    assert "-n auto" in step
+    assert "-k" not in step
 
 
 def test_support_matrix_workflow_runs_daily_checks_and_docs_probe():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -3100,6 +3100,34 @@ def test_mlx_project_porting_workflow_runs_pinned_logsumexp_native_loader_proof(
     )
     assert "-n auto" in step
     assert "-k" not in step
+    assert ci_coverage.workflow_step_after(
+        mlx_porting,
+        "Prove pinned MLX LogSumExp Direct3D native-loader execution",
+        "Checkout pinned MLX",
+    )
+    assert mlx_porting.index(
+        "- name: Prove pinned MLX LogSumExp Direct3D native-loader execution"
+    ) < mlx_porting.index("- name: Run MLX project-porting checks")
+
+
+def test_mlx_project_porting_workflow_installs_pinned_warp_runtime():
+    mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
+    ci_coverage = _load_ci_coverage_module()
+    step_name = "Install pinned Windows WARP runtime"
+    step = ci_coverage.workflow_step_section(mlx_porting, step_name)
+
+    assert ci_coverage.workflow_step_after(
+        mlx_porting,
+        step_name,
+        "Install Windows Direct3D runtime dependencies",
+    )
+    assert "if: runner.os == 'Windows'" in step
+    assert 'warpVersion = "1.0.20"' in step
+    assert "e5fe5de661ce98b58ef9cfb736e73c0a7a2623d3bbf5f14839b2d55566d87e40" in step
+    assert "api.nuget.org/v3-flatcontainer/microsoft.direct3d.warp" in step
+    assert "Get-FileHash -Path $archive -Algorithm SHA256" in step
+    assert '"build\\native\\bin\\x64\\d3d10warp.dll"' in step
+    assert 'Join-Path $env:pythonLocation "d3d10warp.dll"' in step
 
 
 def test_support_matrix_workflow_runs_daily_checks_and_docs_probe():

--- a/tests/test_mlx_logsumexp_dispatch_contract_fixture.py
+++ b/tests/test_mlx_logsumexp_dispatch_contract_fixture.py
@@ -1,0 +1,158 @@
+import hashlib
+import json
+from pathlib import Path
+
+import crosstl.project as project_api
+
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_REPOSITORY = "https://github.com/ml-explore/mlx"
+MLX_HOST_SOURCE = "mlx/backend/metal/logsumexp.cpp"
+MLX_KERNEL_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "demos"
+    / "integrations"
+    / "mlx"
+    / "contracts"
+    / "logsumexp.dispatch.json"
+)
+EXPECTED_MANIFEST_DIGEST = (
+    "db762a188e05786e206d9aa5a340b6f9095a8a3e938b85a7c04836f300e97c95"
+)
+EXPECTED_VARIANTS = {
+    "block-float32-axis-32": {
+        "axisSize": 32,
+        "workgroupSize": (32, 1, 1),
+        "variant": (
+            "sha256:0a9cafa696d2fddd6284c44673b9120120a70630a0a18714e27284f8a6189c59"
+        ),
+        "artifact": (
+            "sha256:f51ab67b8a9ad3240e3fbb52f6de00cdf4a8532e58790758e59aa50fb95e2c52"
+        ),
+    },
+    "block-float32-axis-1025": {
+        "axisSize": 1025,
+        "workgroupSize": (288, 1, 1),
+        "variant": (
+            "sha256:35754405ceaa5e50614c3fef95a66390b99580c9bd2394c0ba5279322fde7446"
+        ),
+        "artifact": (
+            "sha256:ae512c102a88628c05a49f28a872c44ab582bacf74584e8ca7e6ae765263afe0"
+        ),
+    },
+}
+
+
+def _workgroup_formula():
+    return {
+        "op": "multiply",
+        "args": [
+            32,
+            {
+                "op": "ceilDiv",
+                "args": [
+                    {
+                        "op": "ceilDiv",
+                        "args": [{"input": "axisSize"}, 4],
+                    },
+                    32,
+                ],
+            },
+        ],
+    }
+
+
+def test_logsumexp_dispatch_fixture_pins_schema_identity_and_provenance():
+    manifest = project_api.load_dispatch_contract(FIXTURE)
+    canonical = json.dumps(
+        manifest.to_json(),
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    assert manifest.schema_version == project_api.DISPATCH_CONTRACT_SCHEMA_VERSION == 1
+    assert manifest.content_identity.to_json() == {
+        "algorithm": "sha256",
+        "value": EXPECTED_MANIFEST_DIGEST,
+    }
+    assert hashlib.sha256(canonical.encode("utf-8")).hexdigest() == (
+        EXPECTED_MANIFEST_DIGEST
+    )
+    assert manifest.provenance["repository"] == MLX_REPOSITORY
+    assert manifest.provenance["commit"] == MLX_COMMIT
+    assert manifest.provenance["sourceReferences"] == {
+        "hostDispatch": MLX_HOST_SOURCE,
+        "kernel": MLX_KERNEL_SOURCE,
+    }
+    assert manifest.contracts[0].provenance["hostSource"] == MLX_HOST_SOURCE
+    assert manifest.contracts[0].provenance["kernelSource"] == MLX_KERNEL_SOURCE
+
+
+def test_logsumexp_dispatch_fixture_evaluates_unit_test_variants_exactly():
+    variants = {
+        variant.workload_id: variant
+        for variant in project_api.load_dispatch_contract(FIXTURE).evaluate()
+    }
+
+    assert set(variants) == set(EXPECTED_VARIANTS)
+    for workload_id, expected in EXPECTED_VARIANTS.items():
+        variant = variants[workload_id]
+        assert variant.inputs == {
+            "axisSize": expected["axisSize"],
+            "dtype": "float32",
+            "nRows": 1,
+        }
+        assert variant.entry_point == "block_logsumexp_float32"
+        assert variant.branch_id == "block-float32"
+        assert variant.contract_id == "mlx-logsumexp-unit-tests"
+        assert variant.device_id == "wave32-max1024"
+        assert variant.source == MLX_KERNEL_SOURCE
+        assert variant.workgroup_size == expected["workgroupSize"]
+        assert variant.subgroup_width == 32
+        assert variant.capabilities == {
+            "maxThreadsPerWorkgroup": 1024,
+            "simdWidth": 32,
+        }
+        assert variant.specialization_constants == {}
+        assert variant.dispatch_field == "workgroupCount"
+        assert variant.dispatch_size == (1, 1, 1)
+        assert variant.variant_id == expected["variant"]
+        assert variant.artifact_id == expected["artifact"]
+
+
+def test_logsumexp_dispatch_fixture_is_test_backed_and_explicitly_bounded():
+    manifest = project_api.load_dispatch_contract(FIXTURE)
+    normalized = manifest.to_json()
+    workloads = {workload["id"]: workload for workload in normalized["workloads"]}
+    contract = normalized["contracts"][0]
+
+    assert len(manifest.workloads) == 2
+    assert len(manifest.contracts) == 1
+    assert len(manifest.contracts[0].branches) == 1
+    assert workloads["block-float32-axis-32"]["provenance"] == {
+        "hostFunction": "LogSumExp::eval_gpu",
+        "branch": "block",
+        "testSource": "python/tests/test_ops.py::test_logsumexp",
+        "shape": [2, 2, 8],
+        "coveredAxisSizes": [3, 4, 6, 32],
+        "additionalTestSource": "python/tests/test_autograd.py::test_logsumexp_grad",
+    }
+    assert workloads["block-float32-axis-1025"]["provenance"] == {
+        "hostFunction": "LogSumExp::eval_gpu",
+        "branch": "block",
+        "testSource": "python/tests/test_ops.py::test_logsumexp",
+        "shape": [1025],
+    }
+    assert contract["provenance"]["hostFormula"] == (
+        "32 * ceilDiv(ceilDiv(axisSize, 4), 32)"
+    )
+    assert contract["branches"][0]["workgroupSize"][0] == _workgroup_formula()
+    assert manifest.provenance["scope"] == {
+        "description": "Pinned float32 LogSumExp unit-test dispatch records.",
+        "blockEntriesIncluded": True,
+        "loopedEntriesIncluded": False,
+        "runtimeExecutionVerified": False,
+        "numericalParityVerified": False,
+    }

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -2094,15 +2094,15 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
 
     frontier = expected_gaps["frontier_status"]
     assert frontier["sources"] == len(module.MLX_DIRECTX_VULKAN_FRONTIER_SOURCES)
-    assert frontier["artifacts"] == 34
+    assert frontier["artifacts"] == 35
     assert frontier["status"] == (
         "target-split-with-bounded-dispatch-and-pending-contracts"
     )
     assert frontier["scope"] == "target-split-frontier"
-    assert frontier["translated_artifacts"] == 30
-    assert frontier["failed_artifacts"] == 4
+    assert frontier["translated_artifacts"] == 32
+    assert frontier["failed_artifacts"] == 3
     assert frontier["target_artifacts"] == {
-        "directx": {"translated": 19, "failed": 4},
+        "directx": {"translated": 21, "failed": 3},
         "vulkan": {"translated": 11, "failed": 0},
     }
     assert frontier["semantic_readiness_status"] == "not-established"
@@ -2308,6 +2308,40 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert layer_norm["dxc_validated_artifact_count"] == 2
     assert layer_norm["runtime_execution_attempted"] is False
     assert layer_norm["numerical_parity_claimed"] is False
+    logsumexp = directx["logsumexp_dispatch_frontier"]
+    assert logsumexp["status"] == "translated-dxc-validated"
+    assert logsumexp["source"] == module.MLX_LOGSUMEXP_SOURCE
+    assert logsumexp["source_sha256"] == module.MLX_LOGSUMEXP_SHA256
+    assert logsumexp["test_sources"] == [
+        "python/tests/test_ops.py::test_logsumexp",
+        "python/tests/test_autograd.py::test_logsumexp_grad",
+    ]
+    assert logsumexp["dispatch_contract"] == {
+        "path": "demos/integrations/mlx/contracts/logsumexp.dispatch.json",
+        "normalized_sha256": module.MLX_LOGSUMEXP_DISPATCH_NORMALIZED_SHA256,
+        "content_identity": module.MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY,
+        "variant_count": len(module.MLX_LOGSUMEXP_DISPATCH_VARIANTS),
+        "resolved_issue": module.MLX_HOST_DISPATCH_IMPORT_RESOLVED_ISSUE,
+    }
+    assert logsumexp["artifact_count"] == len(module.MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+    assert set(logsumexp["variants"]) == set(module.MLX_LOGSUMEXP_DISPATCH_VARIANTS)
+    assert logsumexp["dxc_validated_artifact_count"] == 2
+    for workload_id, expected in module.MLX_LOGSUMEXP_DISPATCH_VARIANTS.items():
+        variant = logsumexp["variants"][workload_id]
+        assert variant["entry_point"] == expected["entryPoint"]
+        assert variant["artifact_id"] == expected["artifactId"]
+        assert variant["dispatch_variant_id"] == expected["dispatchVariantId"]
+        assert variant["inputs"] == expected["inputs"]
+        assert variant["workgroup_size"] == expected["workgroupSize"]
+        assert variant["dispatch_workgroup_count"] == (
+            expected["dispatchWorkgroupCount"]
+        )
+        assert variant["subgroup_width"] == 32
+        assert variant["subgroup_width_enforcement"] == "WaveSize(32)"
+        assert len(variant["generated_hlsl"]["sha256"]) == 64
+        assert variant["generated_hlsl"]["size_bytes"] > 0
+    assert logsumexp["runtime_execution_attempted"] is False
+    assert logsumexp["numerical_parity_claimed"] is False
     rms_norm = directx["rms_norm_dispatch_frontier"]
     assert rms_norm["status"] == "translated-dxc-validated"
     assert rms_norm["source"] == module.MLX_RMS_NORM_SOURCE
@@ -4551,6 +4585,211 @@ def _write_layer_norm_dispatch_report(
                     "evaluation": {
                         "manifestSource": str((mlx_root / contract["path"]).resolve()),
                         "variantCount": artifact_count,
+                    },
+                }
+            ],
+            "dispatchArtifactPlan": {
+                "kind": "crosstl-dispatch-artifact-plan",
+                "schemaVersion": 1,
+                "sourceUnitCount": 1,
+                "artifactCount": artifact_count,
+                "dispatchVariantCount": artifact_count,
+                "artifacts": planned_artifacts,
+            },
+        },
+        "summary": {
+            "unitCount": 1,
+            "artifactCount": artifact_count,
+            "translatedCount": artifact_count,
+            "failedCount": 0,
+            "diagnosticCounts": {"error": 0, "note": 0, "warning": 0},
+            "artifactsByTarget": {
+                "directx": {
+                    "artifactCount": artifact_count,
+                    "translatedCount": artifact_count,
+                    "failedCount": 0,
+                }
+            },
+        },
+        "units": [unit],
+        "artifacts": artifacts,
+        "diagnostics": [],
+        "validation": {
+            "summary": {"failedCount": 0},
+            "toolchainRuns": list(toolchain_runs),
+        },
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+    return report
+
+
+def _write_logsumexp_dispatch_report(
+    module,
+    mlx_root,
+    output_dir,
+    report_path,
+    *,
+    contract,
+    toolchain_runs=(),
+):
+    unit = {
+        "id": module.MLX_LOGSUMEXP_SOURCE,
+        "path": module.MLX_LOGSUMEXP_SOURCE,
+        "sourceBackend": "metal",
+        "sourceHash": {
+            "algorithm": "sha256",
+            "value": module.MLX_LOGSUMEXP_SHA256,
+        },
+        "sourceSizeBytes": 593,
+    }
+    artifacts = []
+    planned_artifacts = []
+    evaluated_variants = []
+    for workload_id, expected in module.MLX_LOGSUMEXP_DISPATCH_VARIANTS.items():
+        entry_point = expected["entryPoint"]
+        variant = "dispatch-" + expected["artifactId"].removeprefix("sha256:")
+        generated_path = (
+            output_dir
+            / "directx"
+            / variant
+            / "mlx/backend/metal/kernels/logsumexp"
+            / f"{entry_point}.hlsl"
+        )
+        generated_path.parent.mkdir(parents=True, exist_ok=True)
+        generated_path.write_text(
+            "\n".join(
+                (
+                    f"[numthreads({expected['workgroupSize'][0]}, 1, 1)]",
+                    "[WaveSize(32)]",
+                    "void CSMain() {",
+                    "  float maxval = WaveActiveMax(0.0);",
+                    "  GroupMemoryBarrierWithGroupSync();",
+                    "  float normalizer = WaveActiveSum(exp(maxval));",
+                    "  out_[gid] = log(normalizer);",
+                    "}",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        generated_hash = hashlib.sha256(generated_path.read_bytes()).hexdigest()
+        plan = {
+            "artifactId": expected["artifactId"],
+            "dispatchVariantIds": [expected["dispatchVariantId"]],
+            "entryPoint": entry_point,
+            "manifestContentIdentities": [
+                module.MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY
+            ],
+            "source": module.MLX_LOGSUMEXP_SOURCE,
+            "specializationConstants": {},
+            "subgroupWidth": 32,
+            "variant": variant,
+            "workgroupSize": list(expected["workgroupSize"]),
+        }
+        planned_artifacts.append(plan)
+        evaluated_variants.append(
+            {
+                "artifactId": expected["artifactId"],
+                "variantId": expected["dispatchVariantId"],
+                "source": module.MLX_LOGSUMEXP_SOURCE,
+                "entryPoint": entry_point,
+                "workload": {
+                    "id": workload_id,
+                    "inputs": dict(expected["inputs"]),
+                },
+                "workgroupSize": list(expected["workgroupSize"]),
+                "subgroupWidth": 32,
+                "specializationConstants": {},
+                "dispatch": {
+                    "workgroupCount": list(expected["dispatchWorkgroupCount"])
+                },
+            }
+        )
+        artifacts.append(
+            {
+                "source": module.MLX_LOGSUMEXP_SOURCE,
+                "sourceBackend": "metal",
+                "sourceHash": unit["sourceHash"],
+                "sourceSizeBytes": unit["sourceSizeBytes"],
+                "target": "directx",
+                "status": "translated",
+                "variant": variant,
+                "path": generated_path.relative_to(mlx_root).as_posix(),
+                "generatedHash": {
+                    "algorithm": "sha256",
+                    "value": generated_hash,
+                },
+                "generatedSizeBytes": generated_path.stat().st_size,
+                "entryPoint": {
+                    "source": entry_point,
+                    "target": "CSMain",
+                    "stage": "compute",
+                },
+                "dispatchArtifact": plan,
+                "execution": {
+                    "sourceEntryPoints": [entry_point],
+                    "provenance": {
+                        "kind": "host-dispatch-contract",
+                        "artifactId": expected["artifactId"],
+                    },
+                    "subgroupWidthProvenance": {
+                        "kind": "host-dispatch-contract",
+                    },
+                    "subgroupWidthEnforcement": {
+                        "mechanism": "hlsl-wave-size-attribute",
+                        "minimumShaderModel": "6.6",
+                        "entryProfiles": [
+                            {"entryPoint": "CSMain", "profile": "cs_6_6"}
+                        ],
+                    },
+                    "entryPoints": [
+                        {
+                            "sourceEntryPoint": entry_point,
+                            "materializedEntryPoint": entry_point,
+                            "targetEntryPoint": "CSMain",
+                            "workgroupSize": list(expected["workgroupSize"]),
+                            "subgroupWidth": 32,
+                        }
+                    ],
+                },
+                "specializationConstants": None,
+                "templateMaterialization": {
+                    "status": "materialized",
+                    "specializationCount": 1,
+                    "specializations": [
+                        {
+                            "hostName": entry_point,
+                            "parameters": {
+                                "AccT": "float",
+                                "N_READS": "4",
+                                "T": "float",
+                            },
+                        }
+                    ],
+                    "unsupported": [],
+                },
+            }
+        )
+
+    artifact_count = len(artifacts)
+    report = {
+        "project": {
+            "includePatterns": [module.MLX_LOGSUMEXP_SOURCE],
+            "targets": ["directx"],
+            "dispatchContractFiles": [contract["path"]],
+            "dispatchContractCount": 1,
+            "dispatchVariantCount": artifact_count,
+            "dispatchContracts": [
+                {
+                    "path": contract["path"],
+                    "schemaVersion": 1,
+                    "contentIdentity": contract["contentIdentity"],
+                    "manifest": {"provenance": {"commit": module.MLX_COMMIT}},
+                    "evaluation": {
+                        "manifestSource": str((mlx_root / contract["path"]).resolve()),
+                        "variantCount": artifact_count,
+                        "variants": evaluated_variants,
                     },
                 }
             ],
@@ -7935,6 +8174,21 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
         "_prepare_layer_norm_dispatch_contract",
         lambda *_args: layer_norm_contract,
     )
+    logsumexp_contract = {
+        "path": ".crosstl-mlx-porting/contracts/logsumexp.dispatch.json",
+        "contentIdentity": {
+            "algorithm": "sha256",
+            "value": module.MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY.removeprefix(
+                "sha256:"
+            ),
+        },
+        "variantCount": len(module.MLX_LOGSUMEXP_DISPATCH_VARIANTS),
+    }
+    monkeypatch.setattr(
+        module,
+        "_prepare_logsumexp_dispatch_contract",
+        lambda *_args: logsumexp_contract,
+    )
     rms_norm_contract = {
         "path": ".crosstl-mlx-porting/contracts/rms_norm.dispatch.json",
         "contentIdentity": {
@@ -8024,6 +8278,47 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
                     output_dir,
                     report_dir / f"{name}.json",
                     contract=layer_norm_contract,
+                    toolchain_runs=toolchain_runs,
+                )
+        elif "logsumexp-dispatch" in name:
+            is_toolchain = name.startswith("validate-")
+            output_dir = work_dir / (
+                "out-directx-logsumexp-dispatch-toolchain"
+                if is_toolchain
+                else "out-directx-logsumexp-dispatch-frontier"
+            )
+            report = _write_logsumexp_dispatch_report(
+                module,
+                mlx_root,
+                output_dir,
+                report_dir / f"{name}.json",
+                contract=logsumexp_contract,
+            )
+            if is_toolchain:
+                toolchain_runs = [
+                    {
+                        "source": module.MLX_LOGSUMEXP_SOURCE,
+                        "target": "directx",
+                        "path": artifact["path"],
+                        "command": [
+                            "dxc",
+                            "-T",
+                            "cs_6_6",
+                            "-E",
+                            "CSMain",
+                            artifact["path"],
+                        ],
+                        "status": "ok",
+                        "stderr": "",
+                    }
+                    for artifact in report["artifacts"]
+                ]
+                _write_logsumexp_dispatch_report(
+                    module,
+                    mlx_root,
+                    output_dir,
+                    report_dir / f"{name}.json",
+                    contract=logsumexp_contract,
                     toolchain_runs=toolchain_runs,
                 )
         elif "rms-norm-dispatch" in name:
@@ -8174,6 +8469,12 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert set(result["layerNormDispatchEvidence"]["variants"]) == set(
         module.MLX_LAYER_NORM_DISPATCH_VARIANTS
     )
+    assert result["logsumexpDispatchEvidence"]["status"] == ("translated-dxc-validated")
+    assert result["logsumexpDispatchEvidence"]["artifactCount"] == 2
+    assert result["logsumexpDispatchEvidence"]["dxcValidatedArtifactCount"] == 2
+    assert set(result["logsumexpDispatchEvidence"]["variants"]) == set(
+        module.MLX_LOGSUMEXP_DISPATCH_VARIANTS
+    )
     assert result["rmsNormDispatchEvidence"]["status"] == ("translated-dxc-validated")
     assert result["rmsNormDispatchEvidence"]["artifactCount"] == 12
     assert result["rmsNormDispatchEvidence"]["dxcValidatedArtifactCount"] == 12
@@ -8190,15 +8491,18 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     assert [name for name, _command in commands] == [
         "directx-frontier",
         "directx-layer-norm-dispatch-frontier",
+        "directx-logsumexp-dispatch-frontier",
         "directx-rms-norm-dispatch-frontier",
         "directx-workgroup-frontier",
         "validate-directx-frontier-toolchain",
         "validate-directx-layer-norm-dispatch-toolchain",
+        "validate-directx-logsumexp-dispatch-toolchain",
         "validate-directx-rms-norm-dispatch-toolchain",
     ]
-    assert "--run-toolchains" in commands[4][1]
     assert "--run-toolchains" in commands[5][1]
     assert "--run-toolchains" in commands[6][1]
+    assert "--run-toolchains" in commands[7][1]
+    assert "--run-toolchains" in commands[8][1]
     toolchain_config = (
         config_dir / "validate-directx-frontier-toolchain.toml"
     ).read_text(encoding="utf-8")
@@ -8214,6 +8518,11 @@ def test_reduced_frontier_requires_all_directx_entries_per_artifact(
     ).read_text(encoding="utf-8")
     assert module.MLX_LAYER_NORM_SOURCE in layer_norm_config
     assert layer_norm_contract["path"] in layer_norm_config
+    logsumexp_config = (
+        config_dir / "validate-directx-logsumexp-dispatch-toolchain.toml"
+    ).read_text(encoding="utf-8")
+    assert module.MLX_LOGSUMEXP_SOURCE in logsumexp_config
+    assert logsumexp_contract["path"] in logsumexp_config
     rms_norm_config = (
         config_dir / "validate-directx-rms-norm-dispatch-toolchain.toml"
     ).read_text(encoding="utf-8")
@@ -8347,6 +8656,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_ARANGE_SOURCE,
         module.MLX_BINARY_TWO_SOURCE,
         module.MLX_LAYER_NORM_SOURCE,
+        module.MLX_LOGSUMEXP_SOURCE,
         module.MLX_RANDOM_SOURCE,
         module.MLX_RMS_NORM_SOURCE,
         module.MLX_ROPE_SOURCE,
@@ -8362,6 +8672,7 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_ARANGE_SOURCE: 11,
         module.MLX_BINARY_TWO_SOURCE: 225,
         module.MLX_LAYER_NORM_SOURCE: 2,
+        module.MLX_LOGSUMEXP_SOURCE: 2,
         module.MLX_RANDOM_SOURCE: 2,
         module.MLX_RMS_NORM_SOURCE: 12,
         module.MLX_ROPE_SOURCE: 18,
@@ -8375,12 +8686,12 @@ def test_directx_toolchain_frontier_matches_pinned_dxc_inventory():
         module.MLX_SCALED_DOT_PRODUCT_ATTENTION_SOURCE: 42,
         module.MLX_SOFTMAX_SOURCE: 10,
     }
-    assert len(expected_sources) == 7
+    assert len(expected_sources) == 8
     assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == sum(
         module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNTS.values()
     )
-    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 482
-    assert module.MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT == 19
+    assert module.MLX_DIRECTX_TOOLCHAIN_ENTRY_POINT_COUNT == 484
+    assert module.MLX_DIRECTX_TOOLCHAIN_ARTIFACT_COUNT == 21
     assert sum(module.MLX_DYNAMIC_WORKGROUP_ENTRY_POINT_COUNTS.values()) == 106
     assert {
         source: evidence["specializationCount"]
@@ -8456,12 +8767,14 @@ def test_directx_frontier_readme_records_compile_only_scope_and_current_gaps():
     normalized_readme = " ".join(readme.split())
 
     assert "official DXC v1.9.2602.24 on Windows CI" in readme
-    assert "19-artifact frontier representing seven pinned sources" in (
+    assert "21-artifact frontier representing eight pinned sources" in (
         normalized_readme
     )
-    assert "11, 225, 2, 2, 12, 18, and 212 entries respectively" in (normalized_readme)
-    assert "482 generated compute entries" in normalized_readme
-    assert "four pending aggregate sources cover 82 compute entries" in (
+    assert "11, 225, 2, 2, 2, 12, 18, and 212 entries respectively" in (
+        normalized_readme
+    )
+    assert "484 generated compute entries" in normalized_readme
+    assert "three pending aggregate sources cover 76 compute entries" in (
         normalized_readme
     )
     assert "no placeholder workgroup size is restored" in normalized_readme
@@ -8505,7 +8818,11 @@ def test_selected_quantized_frontiers_record_current_target_boundaries():
     assert "profile `cs_6_0`, no `-enable-16bit-types`, and `-WX` passes" in (
         normalized_readme
     )
-    assert "zero warnings across all 482 entry-point runs" in normalized_readme
+    assert "zero warnings across all 484 entry-point runs" in normalized_readme
+    assert "two float32 block-reduction workloads" in normalized_readme
+    assert "axis sizes 32 and 1025" in normalized_readme
+    assert "numerical runtime evidence for one finite workload" in normalized_readme
+    assert "does not redirect the MLX runtime" in normalized_readme
     assert "records this as a warning-clean contract" in normalized_readme
     assert "rejects any newly observed warning" in normalized_readme
     assert "two selected `random.metal` entries compile without" in normalized_readme

--- a/tests/test_translator/test_codegen/test_directx_codegen.py
+++ b/tests/test_translator/test_codegen/test_directx_codegen.py
@@ -7988,7 +7988,7 @@ def test_hlsl_metal_narrow_storage_helper_preserves_byte_view_offset(tmp_path):
     assert "/ 4" in generated
     assert "% 4) * 8" in generated
     assert "& 255u" in generated
-    assert "bytes_offset += int64_t(4);" in generated
+    assert "bytes_offset += int(4);" in generated
     assert "read_byte(input, int64_t((bytes_offset + 2)), 1)" in generated
     HLSLParser(HLSLLexer(generated).tokenize()).parse()
     assert_directx_compute_validates_if_available(generated, tmp_path)
@@ -8143,7 +8143,7 @@ def test_hlsl_metal_resource_pointer_offsets_apply_to_buffer_helpers(tmp_path):
     assert "out_ +=" not in generated_code
     assert "buffer_store" not in generated_code
     assert "int64_t out__offset = int64_t(0);" in generated_code
-    assert "out__offset += int64_t((uint64_t(index) * 4));" in generated_code
+    assert "out__offset += uint((uint64_t(index) * 4));" in generated_code
     assert "out_[uint((out__offset + 1))] = 7u;" in generated_code
     assert "out_[uint(out__offset)] = 9u;" in generated_code
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
@@ -8185,8 +8185,8 @@ def test_hlsl_metal_resource_pointer_reference_offsets_write_back(tmp_path):
         "inout int64_t source_offset, RWStructuredBuffer<float> destination, "
         "inout int64_t destination_offset, int amount)" in generated
     )
-    assert "source_offset += int64_t(amount);" in generated
-    assert "destination_offset += int64_t(amount);" in generated
+    assert "source_offset += int(amount);" in generated
+    assert "destination_offset += int(amount);" in generated
     assert "int64_t source_offset = int64_t(0);" in generated
     assert "int64_t destination_offset = int64_t(0);" in generated
     assert (
@@ -8297,10 +8297,10 @@ def test_hlsl_metal_resource_pointer_dereferences_lower_to_buffer_indices(tmp_pa
 
     assert "int64_t cursor_offset = int64_t(1);" in generated_code
     assert "float first = sourceValues[uint(cursor_offset)];" in generated_code
-    assert "cursor_offset += int64_t(2);" in generated_code
+    assert "cursor_offset += int(2);" in generated_code
     assert "float second = sourceValues[uint(cursor_offset)];" in generated_code
     assert "int64_t writer_offset = int64_t(2);" in generated_code
-    assert "writer_offset += int64_t(3);" in generated_code
+    assert "writer_offset += int(3);" in generated_code
     assert "resultValues[uint(writer_offset)] = (first + second);" in generated_code
     assert "float* cursor" not in generated_code
     assert "*writer" not in generated_code
@@ -8672,7 +8672,7 @@ def test_hlsl_readonly_resource_pointer_root_can_advance(tmp_path):
     )
 
     assert "int64_t sourceValues_offset = int64_t(0);" in generated_code
-    assert "sourceValues_offset += int64_t(index);" in generated_code
+    assert "sourceValues_offset += uint(index);" in generated_code
     assert "float value = sourceValues[uint(sourceValues_offset)];" in generated_code
     assert "sourceValues +=" not in generated_code
     HLSLParser(HLSLLexer(generated_code).tokenize()).parse()
@@ -43224,7 +43224,7 @@ def test_hlsl_metal_storage_struct_view_preserves_typed_alias_offset(tmp_path):
         source_backend="metal",
     )
 
-    assert "words_offset += int64_t((gid * 2));" in generated
+    assert "words_offset += uint((gid * 2));" in generated
     assert "local.words[0] = packed[uint(((words_offset * 4)) / 4)];" in generated
     assert "local.words[1] = packed[uint((((words_offset + 1) * 4)) / 4)];" in generated
     assert "local.words[0] = packed[uint(0)]" not in generated

--- a/tests/test_translator/test_mlx_logsumexp_native_loader.py
+++ b/tests/test_translator/test_mlx_logsumexp_native_loader.py
@@ -151,8 +151,7 @@ def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
     axis_32_artifact = next(
         artifact
         for artifact in report_payload["artifacts"]
-        if artifact["dispatchArtifact"]["artifactId"]
-        == MLX_LOGSUMEXP_AXIS_32_ARTIFACT
+        if artifact["dispatchArtifact"]["artifactId"] == MLX_LOGSUMEXP_AXIS_32_ARTIFACT
     )
     expected_variant = "dispatch-" + MLX_LOGSUMEXP_AXIS_32_ARTIFACT.removeprefix(
         "sha256:"
@@ -230,8 +229,7 @@ def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
     }
     assert descriptor["specializationConstants"] == []
     descriptor_layouts = {
-        binding["name"]: binding["scalarLayout"]
-        for binding in descriptor["bindings"]
+        binding["name"]: binding["scalarLayout"] for binding in descriptor["bindings"]
     }
     assert descriptor_layouts == _expected_scalar_layouts()
     return descriptor, package_dir
@@ -291,7 +289,9 @@ def test_pinned_mlx_logsumexp_executes_through_directx_native_loader():
                 executor="directx",
                 adapter_kind="directx-native-runtime",
             ),
-            runtime_adapter=DirectXRuntimeParityAdapter(runtime=DirectXComputeRuntime()),
+            runtime_adapter=DirectXRuntimeParityAdapter(
+                runtime=DirectXComputeRuntime()
+            ),
         )
         availability = executor.is_available(request)
         if not availability.available:

--- a/tests/test_translator/test_mlx_logsumexp_native_loader.py
+++ b/tests/test_translator/test_mlx_logsumexp_native_loader.py
@@ -70,6 +70,39 @@ def _skip_or_fail(message: str) -> None:
     pytest.skip(message)
 
 
+def _assert_directx_runtime_requirements(source_path: Path, work_dir: Path) -> None:
+    dxc = shutil.which("dxc")
+    if dxc is None:
+        return
+
+    dxil_path = work_dir / "block-logsumexp-float32.dxil"
+    compile_result = subprocess.run(
+        [
+            dxc,
+            "-WX",
+            "-T",
+            "cs_6_6",
+            "-E",
+            "CSMain",
+            "-Fo",
+            str(dxil_path),
+            str(source_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    dump_result = subprocess.run(
+        [dxc, "-dumpbin", str(dxil_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert dump_result.returncode == 0, dump_result.stderr
+    requirements = dump_result.stdout + dump_result.stderr
+    assert "Wave level operations" in requirements
+    assert "64-Bit integer" not in requirements
+
+
 def _pinned_mlx_root() -> Path:
     root_value = os.environ.get("CROSTL_MLX_ROOT")
     if not root_value:
@@ -170,6 +203,10 @@ def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
     assert axis_32_artifact["dispatchArtifact"]["workgroupSize"] == [32, 1, 1]
     assert axis_32_artifact["dispatchArtifact"]["subgroupWidth"] == 32
     assert not axis_32_artifact.get("specializationConstants")
+    generated_path = mlx_root / axis_32_artifact["path"]
+    generated_source = generated_path.read_text(encoding="utf-8")
+    assert "in__offset += uint(" in generated_source
+    _assert_directx_runtime_requirements(generated_path, work_dir)
 
     report_path = work_dir / "portability-report.json"
     report.write_json(report_path)

--- a/tests/test_translator/test_mlx_logsumexp_native_loader.py
+++ b/tests/test_translator/test_mlx_logsumexp_native_loader.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from crosstl.project import (
+    DirectXComputeRuntime,
+    DirectXRuntimeParityAdapter,
+    RuntimeParityExecutor,
+    RuntimeTestAdapterSpec,
+    build_native_loader_abi_descriptor,
+    build_native_loader_dispatch_request,
+    build_runtime_artifact_manifest,
+    build_runtime_loader_manifest,
+    build_runtime_package,
+    load_project_config,
+    translate_project,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_LOGSUMEXP_SOURCE = "mlx/backend/metal/kernels/logsumexp.metal"
+MLX_LOGSUMEXP_SHA256 = (
+    "f9bec5e1e5a23d20bedf9ff8d29a8c03bbb5144bc5d751bbfe906d32ee894817"
+)
+MLX_LOGSUMEXP_ENTRY = "block_logsumexp_float32"
+MLX_LOGSUMEXP_AXIS_32_ARTIFACT = (
+    "sha256:f51ab67b8a9ad3240e3fbb52f6de00cdf4a8532e58790758e59aa50fb95e2c52"
+)
+MLX_LOGSUMEXP_DISPATCH_CONTRACT = (
+    ROOT / "demos" / "integrations" / "mlx" / "contracts" / "logsumexp.dispatch.json"
+)
+REQUIRE_PROOF_ENV = "CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER"
+
+
+def _project_config(*, output_dir: str, dispatch_contract: str) -> str:
+    return textwrap.dedent(f"""
+        [project]
+        source_roots = ["mlx/backend/metal/kernels"]
+        include = ["{MLX_LOGSUMEXP_SOURCE}"]
+        include_dirs = ["."]
+        targets = ["directx"]
+        output_dir = "{output_dir}"
+        dispatch_contracts = ["{dispatch_contract}"]
+
+        [project.sources]
+        "**/*.metal" = "metal"
+        """).strip()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _skip_or_fail(message: str) -> None:
+    if os.environ.get(REQUIRE_PROOF_ENV) == "1":
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+def _pinned_mlx_root() -> Path:
+    root_value = os.environ.get("CROSTL_MLX_ROOT")
+    if not root_value:
+        if os.environ.get(REQUIRE_PROOF_ENV) == "1":
+            pytest.fail("CROSTL_MLX_ROOT is not configured")
+        pytest.skip("CROSTL_MLX_ROOT is not configured")
+
+    mlx_root = Path(root_value).resolve()
+    source_path = mlx_root / MLX_LOGSUMEXP_SOURCE
+    if not source_path.is_file():
+        pytest.fail(f"Pinned MLX LogSumExp source is missing: {source_path}")
+
+    checkout_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=mlx_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert checkout_commit == MLX_COMMIT
+    assert hashlib.sha256(source_path.read_bytes()).hexdigest() == MLX_LOGSUMEXP_SHA256
+    return mlx_root
+
+
+def _expected_scalar_layouts() -> dict[str, dict]:
+    runtime_array = {
+        "physicalType": "float",
+        "elementType": "float32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer",
+        "runtimeSized": True,
+    }
+    return {
+        "block_logsumexp_float32_axis_size_Constants": {
+            "physicalType": "int",
+            "elementType": "int32",
+            "elementSizeBytes": 4,
+            "elementStrideBytes": 4,
+            "alignmentBytes": 16,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-constant-buffer",
+            "runtimeSized": False,
+            "memberName": "block_logsumexp_float32_axis_size",
+            "blockSizeBytes": 16,
+        },
+        "in_": dict(runtime_array),
+        "out_": dict(runtime_array),
+    }
+
+
+def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
+    contract_path = work_dir / "logsumexp.dispatch.json"
+    shutil.copyfile(MLX_LOGSUMEXP_DISPATCH_CONTRACT, contract_path)
+    output_dir = work_dir / "out"
+    config_path = work_dir / "crosstl.toml"
+    config_path.write_text(
+        _project_config(
+            output_dir=output_dir.relative_to(mlx_root).as_posix(),
+            dispatch_contract=contract_path.relative_to(mlx_root).as_posix(),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = translate_project(
+        load_project_config(mlx_root, config_path),
+        targets=("directx",),
+        output_dir=output_dir.relative_to(mlx_root).as_posix(),
+        format_output=False,
+        validate=True,
+    )
+    report_payload = report.to_json()
+
+    assert report_payload["summary"]["unitCount"] == 1
+    assert report_payload["summary"]["translatedCount"] == 2
+    assert report_payload["summary"]["failedCount"] == 0
+    axis_32_artifact = next(
+        artifact
+        for artifact in report_payload["artifacts"]
+        if artifact["dispatchArtifact"]["artifactId"]
+        == MLX_LOGSUMEXP_AXIS_32_ARTIFACT
+    )
+    expected_variant = "dispatch-" + MLX_LOGSUMEXP_AXIS_32_ARTIFACT.removeprefix(
+        "sha256:"
+    )
+    assert axis_32_artifact["source"] == MLX_LOGSUMEXP_SOURCE
+    assert axis_32_artifact["sourceHash"] == {
+        "algorithm": "sha256",
+        "value": MLX_LOGSUMEXP_SHA256,
+    }
+    assert axis_32_artifact["variant"] == expected_variant
+    assert axis_32_artifact["entryPoint"] == {
+        "source": MLX_LOGSUMEXP_ENTRY,
+        "target": "CSMain",
+        "stage": "compute",
+    }
+    assert axis_32_artifact["dispatchArtifact"]["workgroupSize"] == [32, 1, 1]
+    assert axis_32_artifact["dispatchArtifact"]["subgroupWidth"] == 32
+    assert not axis_32_artifact.get("specializationConstants")
+
+    report_path = work_dir / "portability-report.json"
+    report.write_json(report_path)
+    runtime_artifacts = build_runtime_artifact_manifest(report_path)
+    assert runtime_artifacts["success"] is True, json.dumps(runtime_artifacts, indent=2)
+    assert runtime_artifacts["summary"]["artifactCount"] == 2
+    assert runtime_artifacts["summary"]["specializationConstantCount"] == 0
+
+    reflected_artifact = next(
+        artifact
+        for artifact in runtime_artifacts["artifacts"]
+        if artifact["variant"] == expected_variant
+    )
+    assert reflected_artifact["hostInterface"]["status"] == "ready"
+    resources = reflected_artifact["hostInterface"]["resources"]
+    assert {resource["name"]: resource["binding"] for resource in resources} == {
+        "block_logsumexp_float32_axis_size_Constants": 2,
+        "in_": 0,
+        "out_": 1,
+    }
+    assert {resource["name"]: resource["access"] for resource in resources} == {
+        "block_logsumexp_float32_axis_size_Constants": "read",
+        "in_": "read",
+        "out_": "read_write",
+    }
+    reflected_layouts = {
+        resource["name"]: resource["scalarLayout"] for resource in resources
+    }
+    assert reflected_layouts == _expected_scalar_layouts()
+
+    runtime_artifacts_path = work_dir / "runtime-artifacts.json"
+    _write_json(runtime_artifacts_path, runtime_artifacts)
+    package_dir = work_dir / "runtime-package"
+    package = build_runtime_package(runtime_artifacts_path, package_dir)
+    assert package["success"] is True, json.dumps(package, indent=2)
+
+    loader_manifest = build_runtime_loader_manifest(
+        package_dir / "runtime-package.json"
+    )
+    assert loader_manifest["success"] is True, json.dumps(loader_manifest, indent=2)
+    assert loader_manifest["summary"]["readyLoadUnitCount"] == 2
+    assert loader_manifest["summary"]["blockedLoadUnitCount"] == 0
+    load_unit = next(
+        unit
+        for unit in loader_manifest["loadUnits"]
+        if unit["variant"] == expected_variant
+    )
+    descriptor = build_native_loader_abi_descriptor(
+        loader_manifest,
+        load_unit_id=load_unit["id"],
+    )
+    assert descriptor["target"] == "directx"
+    assert descriptor["entryPoint"]["name"] == "CSMain"
+    assert descriptor["entryPoint"]["executionConfig"] == {
+        "numthreads": [32, 1, 1],
+        "subgroupWidth": 32,
+    }
+    assert descriptor["specializationConstants"] == []
+    descriptor_layouts = {
+        binding["name"]: binding["scalarLayout"]
+        for binding in descriptor["bindings"]
+    }
+    assert descriptor_layouts == _expected_scalar_layouts()
+    return descriptor, package_dir
+
+
+def test_pinned_mlx_logsumexp_executes_through_directx_native_loader():
+    mlx_root = _pinned_mlx_root()
+    with tempfile.TemporaryDirectory(
+        prefix=".crosstl-logsumexp-directx-native-loader-",
+        dir=mlx_root,
+    ) as temporary_directory:
+        descriptor, package_dir = _build_runtime_package(
+            mlx_root,
+            Path(temporary_directory),
+        )
+        input_values = [(index - 16) / 8.0 for index in range(32)]
+        maximum = max(input_values)
+        expected_value = maximum + math.log(
+            math.fsum(math.exp(value - maximum) for value in input_values)
+        )
+        request = build_native_loader_dispatch_request(
+            descriptor,
+            package_dir,
+            {
+                "block_logsumexp_float32_axis_size_Constants": {
+                    "dtype": "int32",
+                    "shape": [1],
+                    "values": [32],
+                },
+                "in_": {
+                    "dtype": "float32",
+                    "shape": [32],
+                    "values": input_values,
+                },
+            },
+            {
+                "out_": {
+                    "dtype": "float32",
+                    "shape": [1],
+                    "values": [expected_value],
+                    "tolerance": {"absolute": 5e-5, "relative": 5e-5},
+                }
+            },
+            (1, 1, 1),
+            expected_target="directx",
+        )
+        assert request.execution_plan is not None
+        assert request.execution_plan.diagnostics == ()
+        assert request.execution_plan.dispatch.workgroup_size == (32, 1, 1)
+        assert request.execution_plan.dispatch.workgroup_count == (1, 1, 1)
+        assert request.execution_plan.dispatch.global_size == (32, 1, 1)
+
+        executor = RuntimeParityExecutor(
+            RuntimeTestAdapterSpec(
+                adapter_id="mlx-logsumexp-directx-native-loader",
+                target="directx",
+                executor="directx",
+                adapter_kind="directx-native-runtime",
+            ),
+            runtime_adapter=DirectXRuntimeParityAdapter(runtime=DirectXComputeRuntime()),
+        )
+        availability = executor.is_available(request)
+        if not availability.available:
+            _skip_or_fail(
+                availability.reason or "The native DirectX runtime is unavailable"
+            )
+
+        result = executor.run(request)
+
+    assert result.status == "ok"
+    assert result.outputs["out_"]["dtype"] == "float32"
+    assert result.outputs["out_"]["shape"] == [1]
+    assert result.outputs["out_"]["values"] == pytest.approx(
+        [expected_value],
+        abs=5e-5,
+        rel=5e-5,
+    )


### PR DESCRIPTION
## Summary

- add a pinned MLX LogSumExp host-dispatch contract for axis sizes 32 and 1025
- integrate both entry-scoped artifacts into the DirectX project frontier with strict source, dispatch, materialization, subgroup, and DXC evidence
- execute the axis-size-32 artifact through the packaged native-loader ABI in Windows Direct3D CI and compare readback with a stable CPU reference
- provision a checksum-pinned Microsoft WARP runtime so fixed `WaveSize(32)` artifacts execute on hosted Windows runners
- update frontier accounting and documentation without claiming full MLX runtime integration or coverage of the looped reduction path

## Validation

- full reduced MLX project-porting harness against commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`
- DXC `cs_6_6` with warnings as errors for both generated LogSumExp artifacts
- Windows Direct3D native-loader execution with numerical readback for the axis-size-32 artifact
- `python -m pytest -q -n auto`: 17,311 passed, 226 skipped
- `python -m pre_commit run --all-files`
- support matrix update/check and support issue sync dry run

Support issue traceability: no issue closed
This bounded corpus proof does not change a support-matrix status.
