### PR TITLE
Add exact subgroup-width contracts for OpenGL compute

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -533,6 +533,55 @@ jobs:
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_binary_native_loader.py::test_pinned_mlx_binary_add_executes_through_opengl_native_loader
 
+      - name: Validate pinned MLX LogSumExp OpenGL dispatch artifacts
+        if: runner.os == 'Linux'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_LOGSUMEXP_OPENGL_TOOLCHAIN: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_logsumexp_native_loader.py::test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts
+
+      - name: Prove exact OpenGL subgroup-width execution
+        if: runner.os == 'Linux'
+        env:
+          CROSTL_RUN_OPENGL_EXACT_SUBGROUP_DEVICE_TEST: "1"
+          EGL_PLATFORM: surfaceless
+          GALLIUM_DRIVER: zink
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          LIBGL_KOPPER_DRI2: "true"
+          MESA_LOADER_DRIVER_OVERRIDE: zink
+          PYOPENGL_PLATFORM: egl
+        run: |
+          set -euo pipefail
+
+          lavapipe_icd=""
+          for icd_dir in /usr/share/vulkan/icd.d /etc/vulkan/icd.d; do
+            if [ ! -d "$icd_dir" ]; then
+              continue
+            fi
+            lavapipe_icd="$(
+              find "$icd_dir" \
+                -maxdepth 1 \
+                -type f \
+                -name 'lvp_icd*.json' \
+                -print \
+                -quit
+            )"
+            if [ -n "$lavapipe_icd" ]; then
+              break
+            fi
+          done
+          if [ -z "$lavapipe_icd" ]; then
+            echo "::error::Lavapipe Vulkan ICD manifest was not found." >&2
+            exit 1
+          fi
+          export VK_DRIVER_FILES="$lavapipe_icd"
+          export VK_ICD_FILENAMES="$lavapipe_icd"
+
+          python -m pytest -q -n auto \
+            tests/test_translator/test_native_runtime_drivers.py::test_opengl_compute_runtime_executes_exact_subgroup_width_on_device
+
       - name: Validate generated OpenGL subgroup contract through Vulkan
         if: runner.os == 'Linux'
         env:

--- a/crosstl/project/native_opengl_adapter.py
+++ b/crosstl/project/native_opengl_adapter.py
@@ -107,7 +107,8 @@ def generate_opengl_native_loader_adapter() -> str:
             CROSSTL_OPENGL43_UNIFORM_BARRIER_BIT = 0x00000004u,
             CROSSTL_OPENGL43_BUFFER_UPDATE_BARRIER_BIT = 0x00000200u,
             CROSSTL_OPENGL43_SHADER_STORAGE_BARRIER_BIT = 0x00002000u,
-            CROSSTL_OPENGL43_MAX_COMPUTE_WORK_GROUP_COUNT = 0x91BEu
+            CROSSTL_OPENGL43_MAX_COMPUTE_WORK_GROUP_COUNT = 0x91BEu,
+            CROSSTL_OPENGL43_SUBGROUP_SIZE_KHR = 0x9532u
         };
 
         typedef enum CrossTLOpenGL43Status {
@@ -158,7 +159,10 @@ def generate_opengl_native_loader_adapter() -> str:
             CROSSTL_OPENGL43_STATUS_SPECIALIZATION_PAYLOAD_INVALID = 44,
             CROSSTL_OPENGL43_STATUS_SPECIALIZATION_ID_DUPLICATE = 45,
             CROSSTL_OPENGL43_STATUS_SPIRV_BINARY_LOAD_FAILED = 46,
-            CROSSTL_OPENGL43_STATUS_SPIRV_SPECIALIZATION_FAILED = 47
+            CROSSTL_OPENGL43_STATUS_SPIRV_SPECIALIZATION_FAILED = 47,
+            CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID = 48,
+            CROSSTL_OPENGL43_STATUS_SUBGROUP_CAPABILITY_UNSUPPORTED = 49,
+            CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_MISMATCH = 50
         } CrossTLOpenGL43Status;
 
         typedef CrossTLOpenGL43Enum(CROSSTL_OPENGL43_APIENTRY
@@ -332,6 +336,7 @@ def generate_opengl_native_loader_adapter() -> str:
             CrossTLOpenGL43ArtifactKind kind;
             std::vector<uint8_t> bytes;
             std::vector<CrossTLOpenGL43Specialization> specializations;
+            uint32_t required_subgroup_width = 0u;
         } CrossTLOpenGL43Artifact;
 
         typedef struct CrossTLOpenGL43Pipeline {
@@ -355,7 +360,8 @@ def generate_opengl_native_loader_adapter() -> str:
             return "caller-owned current desktop OpenGL 4.3+ context; "
                    "context-compatible loaded core entry points; serialized "
                    "execution on the context-owning thread; OpenGL 4.6 or "
-                   "GL_ARB_gl_spirv for SPIR-V specialization";
+                   "GL_ARB_gl_spirv for SPIR-V specialization; "
+                   "GL_KHR_shader_subgroup for exact subgroup-width artifacts";
         }
 
         static inline const char *crosstl_opengl43_status_name(int32_t status) {
@@ -456,6 +462,12 @@ def generate_opengl_native_loader_adapter() -> str:
                     return "spirv-binary-load-failed";
                 case CROSSTL_OPENGL43_STATUS_SPIRV_SPECIALIZATION_FAILED:
                     return "spirv-specialization-failed";
+                case CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID:
+                    return "subgroup-width-contract-invalid";
+                case CROSSTL_OPENGL43_STATUS_SUBGROUP_CAPABILITY_UNSUPPORTED:
+                    return "subgroup-capability-unsupported";
+                case CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_MISMATCH:
+                    return "subgroup-width-mismatch";
                 default:
                     return "unknown";
             }
@@ -970,6 +982,95 @@ def generate_opengl_native_loader_adapter() -> str:
             return CROSSTL_OPENGL43_STATUS_OK;
         }
 
+        static inline int32_t crosstl_opengl43_parse_subgroup_width(
+            CrossTLOpenGL43Context *context,
+            CrossTLOpenGL43Artifact *artifact) {
+            if (artifact == NULL ||
+                artifact->kind != CROSSTL_OPENGL43_ARTIFACT_GLSL_SOURCE) {
+                return CROSSTL_OPENGL43_STATUS_OK;
+            }
+            const std::string source(
+                reinterpret_cast<const char *>(artifact->bytes.data()),
+                artifact->bytes.size());
+            const std::string marker =
+                "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH";
+            const size_t position = source.find(marker);
+            if (position == std::string::npos) {
+                return CROSSTL_OPENGL43_STATUS_OK;
+            }
+            if (source.find(marker, position + marker.size()) !=
+                std::string::npos) {
+                return crosstl_opengl43_report(
+                    context,
+                    CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID,
+                    "load-artifact",
+                    "The GLSL artifact declares multiple subgroup-width markers.");
+            }
+            const size_t line_start = source.rfind('\n', position);
+            const size_t prefix_start =
+                line_start == std::string::npos ? 0u : line_start + 1u;
+            for (size_t index = prefix_start; index < position; ++index) {
+                if (source[index] != ' ' && source[index] != '\t') {
+                    return crosstl_opengl43_report(
+                        context,
+                        CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID,
+                        "load-artifact",
+                        "The GLSL subgroup-width marker must start a directive line.");
+                }
+            }
+            size_t cursor = position + marker.size();
+            if (cursor >= source.size() ||
+                (source[cursor] != ' ' && source[cursor] != '\t')) {
+                return crosstl_opengl43_report(
+                    context,
+                    CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID,
+                    "load-artifact",
+                    "The GLSL subgroup-width marker is malformed.");
+            }
+            while (cursor < source.size() &&
+                   (source[cursor] == ' ' || source[cursor] == '\t')) {
+                ++cursor;
+            }
+            uint32_t width = 0u;
+            size_t digit_count = 0u;
+            while (cursor < source.size() &&
+                   source[cursor] >= '0' && source[cursor] <= '9') {
+                const uint32_t digit =
+                    static_cast<uint32_t>(source[cursor] - '0');
+                if (width > (128u - digit) / 10u) {
+                    return crosstl_opengl43_report(
+                        context,
+                        CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID,
+                        "load-artifact",
+                        "The GLSL subgroup-width marker is out of range.");
+                }
+                width = width * 10u + digit;
+                ++cursor;
+                ++digit_count;
+            }
+            if (cursor < source.size() &&
+                (source[cursor] == 'u' || source[cursor] == 'U')) {
+                ++cursor;
+            }
+            while (cursor < source.size() &&
+                   (source[cursor] == ' ' || source[cursor] == '\t' ||
+                    source[cursor] == '\r')) {
+                ++cursor;
+            }
+            if (digit_count == 0u ||
+                (cursor < source.size() && source[cursor] != '\n') ||
+                width == 0u || width > 128u ||
+                (width & (width - 1u)) != 0u) {
+                return crosstl_opengl43_report(
+                    context,
+                    CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID,
+                    "load-artifact",
+                    "The GLSL subgroup width must be a power of two from 1 through 128.");
+            }
+            artifact->required_subgroup_width = width;
+            return CROSSTL_OPENGL43_STATUS_OK;
+        }
+
         static inline int32_t crosstl_opengl43_load_artifact(
             void *opaque,
             const CrossTLNativeLoaderUnitDescriptor *unit,
@@ -1110,7 +1211,14 @@ def generate_opengl_native_loader_adapter() -> str:
                     delete artifact;
                     return status;
                 }
-                if (kind == CROSSTL_OPENGL43_ARTIFACT_SPIRV_BINARY) {
+                if (kind == CROSSTL_OPENGL43_ARTIFACT_GLSL_SOURCE) {
+                    status = crosstl_opengl43_parse_subgroup_width(
+                        context, artifact);
+                    if (status != CROSSTL_OPENGL43_STATUS_OK) {
+                        delete artifact;
+                        return status;
+                    }
+                } else {
                     if (artifact->bytes.size() < 20u ||
                         artifact->bytes.size() % sizeof(uint32_t) != 0u) {
                         delete artifact;
@@ -1274,6 +1382,44 @@ def generate_opengl_native_loader_adapter() -> str:
                     : "GL_ARB_gl_spirv requires glSpecializeShaderARB.");
         }
 
+        static inline int32_t crosstl_opengl43_validate_subgroup_width(
+            CrossTLOpenGL43Context *context,
+            const CrossTLOpenGL43Artifact *artifact) {
+            if (artifact == NULL || artifact->required_subgroup_width == 0u) {
+                return CROSSTL_OPENGL43_STATUS_OK;
+            }
+            CrossTLOpenGL43Int subgroup_width = 0;
+            crosstl_opengl43_clear_errors(context);
+            context->functions.get_integerv(
+                CROSSTL_OPENGL43_SUBGROUP_SIZE_KHR, &subgroup_width);
+            int32_t status = crosstl_opengl43_check_error_status(
+                context,
+                CROSSTL_OPENGL43_STATUS_SUBGROUP_CAPABILITY_UNSUPPORTED,
+                "create-pipeline",
+                "glGetIntegerv(GL_SUBGROUP_SIZE_KHR)");
+            if (status != CROSSTL_OPENGL43_STATUS_OK) {
+                return status;
+            }
+            if (subgroup_width <= 0 || subgroup_width > 128 ||
+                (static_cast<uint32_t>(subgroup_width) &
+                 (static_cast<uint32_t>(subgroup_width) - 1u)) != 0u) {
+                return crosstl_opengl43_report(
+                    context,
+                    CROSSTL_OPENGL43_STATUS_SUBGROUP_CAPABILITY_UNSUPPORTED,
+                    "create-pipeline",
+                    "GL_SUBGROUP_SIZE_KHR did not report a valid subgroup width.");
+            }
+            if (static_cast<uint32_t>(subgroup_width) !=
+                artifact->required_subgroup_width) {
+                return crosstl_opengl43_report(
+                    context,
+                    CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_MISMATCH,
+                    "create-pipeline",
+                    "The OpenGL device subgroup width does not match the artifact requirement.");
+            }
+            return CROSSTL_OPENGL43_STATUS_OK;
+        }
+
         static inline int32_t crosstl_opengl43_create_pipeline(
             void *opaque,
             void *artifact_opaque,
@@ -1305,6 +1451,11 @@ def generate_opengl_native_loader_adapter() -> str:
             }
             CrossTLOpenGL43Artifact *artifact =
                 static_cast<CrossTLOpenGL43Artifact *>(artifact_opaque);
+            status = crosstl_opengl43_validate_subgroup_width(
+                context, artifact);
+            if (status != CROSSTL_OPENGL43_STATUS_OK) {
+                return status;
+            }
             if (artifact->kind ==
                     CROSSTL_OPENGL43_ARTIFACT_GLSL_SOURCE &&
                 !crosstl_native_loader_strings_equal(

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -178,6 +178,12 @@ class _OpenGLSPIRVUnavailable(RuntimeError):
 
 
 _OPENGL_SPIRV_HEADER_BYTE_LENGTH = 5 * 4
+_OPENGL_SUBGROUP_SIZE_KHR = 0x9532
+_OPENGL_SUBGROUP_EXTENSION = "GL_KHR_shader_subgroup"
+_OPENGL_REQUIRED_SUBGROUP_WIDTH_RE = re.compile(
+    r"^\s*#define\s+CROSSTL_REQUIRED_SUBGROUP_WIDTH\s+" r"(?P<width>[^\s]+)\s*$",
+    re.MULTILINE,
+)
 _DIRECTX_MAX_PADDED_DESCRIPTOR_COUNT = 4096
 
 
@@ -813,6 +819,16 @@ class OpenGLComputeRuntime:
                     "missingPythonModules": ["moderngl"],
                 },
             )
+        try:
+            required_subgroup_width = _opengl_runtime_request_required_subgroup_width(
+                request
+            )
+        except RuntimeAdapterSetupError as exc:
+            return RuntimeExecutorAvailability(
+                False,
+                reason=str(exc),
+                details=dict(exc.details),
+            )
 
         context = None
         try:
@@ -835,6 +851,16 @@ class OpenGLComputeRuntime:
                     },
                 )
             specialization_details: dict[str, Any] = {}
+            subgroup_details: dict[str, Any] = {}
+            if required_subgroup_width is not None:
+                actual_subgroup_width = self._validate_context_subgroup_width(
+                    context, required_subgroup_width
+                )
+                subgroup_details = {
+                    "requiredSubgroupWidth": required_subgroup_width,
+                    "subgroupWidth": actual_subgroup_width,
+                    "subgroupWidthQuery": "GL_SUBGROUP_SIZE_KHR",
+                }
             if requires_spirv:
                 api = self._load_opengl_spirv_api(context)
                 specialization_details = {
@@ -842,6 +868,12 @@ class OpenGLComputeRuntime:
                     "specializationEntryPoint": api.specialize_entry_point,
                     "requiredExtension": "GL_ARB_gl_spirv",
                 }
+        except RuntimeAdapterSetupError as exc:
+            return RuntimeExecutorAvailability(
+                False,
+                reason=str(exc),
+                details=dict(exc.details),
+            )
         except _OpenGLSPIRVUnavailable as exc:
             return RuntimeExecutorAvailability(
                 False,
@@ -874,6 +906,7 @@ class OpenGLComputeRuntime:
                 "contextBackend": backend or "default",
                 "versionCode": version_code,
                 **specialization_details,
+                **subgroup_details,
             },
         )
 
@@ -972,6 +1005,24 @@ class OpenGLComputeRuntime:
                     workgroup_count=_workgroup_count(request, target="OpenGL"),
                 )
             )
+        required_subgroup_widths = sorted(
+            {
+                width
+                for prepared in prepared_dispatches
+                for width in (
+                    _opengl_dispatch_required_subgroup_width(
+                        prepared.request, prepared.shader_artifact
+                    ),
+                )
+                if width is not None
+            }
+        )
+        if len(required_subgroup_widths) > 1:
+            raise _opengl_setup_error(
+                "One OpenGL dispatch sequence cannot require multiple subgroup widths.",
+                "subgroup-width-sequence-conflict",
+                subgroupWidths=required_subgroup_widths,
+            )
         allocation_plan, view_keys = _prepare_sequence_allocations(
             [item.buffers for item in prepared_dispatches],
             target="opengl",
@@ -1002,6 +1053,16 @@ class OpenGLComputeRuntime:
                     contextBackend=backend or "default",
                     requiredVersionCode=self.require_version,
                     versionCode=version_code,
+                )
+            if required_subgroup_widths:
+                actual_subgroup_width = self._validate_context_subgroup_width(
+                    context, required_subgroup_widths[0]
+                )
+                self._record_subgroup_width_validation(
+                    state,
+                    required=required_subgroup_widths[0],
+                    actual=actual_subgroup_width,
+                    backend=backend,
                 )
 
             try:
@@ -1209,6 +1270,104 @@ class OpenGLComputeRuntime:
                     f"OpenGL resource binding failed for {prepared.name!r}: {exc}",
                     details=details,
                 ) from exc
+
+    def _query_context_subgroup_width(self, context: Any) -> int:
+        extensions = {
+            str(extension) for extension in getattr(context, "extensions", ()) or ()
+        }
+        if _OPENGL_SUBGROUP_EXTENSION not in extensions:
+            raise _opengl_setup_error(
+                "OpenGL exact subgroup-width execution requires "
+                f"{_OPENGL_SUBGROUP_EXTENSION}.",
+                "subgroup-extension-unavailable",
+                requiredExtension=_OPENGL_SUBGROUP_EXTENSION,
+                extensionAvailable=False,
+            )
+        try:
+            gl = self._module_loader("OpenGL.GL")
+        except Exception as exc:
+            raise _opengl_setup_error(
+                "PyOpenGL is required to query the OpenGL subgroup width.",
+                "dependency-unavailable",
+                missingPythonModules=["PyOpenGL"],
+                hostQuery="GL_SUBGROUP_SIZE_KHR",
+            ) from exc
+        get_integer = getattr(gl, "glGetIntegerv", None)
+        if not _opengl_entry_point_available(get_integer):
+            raise _opengl_setup_error(
+                "OpenGL subgroup-width query entry point is unavailable.",
+                "subgroup-query-unavailable",
+                hostQuery="GL_SUBGROUP_SIZE_KHR",
+                missingEntryPoints=["glGetIntegerv"],
+            )
+        token = int(getattr(gl, "GL_SUBGROUP_SIZE_KHR", _OPENGL_SUBGROUP_SIZE_KHR))
+        try:
+            value = get_integer(token)
+            item = getattr(value, "item", None)
+            if callable(item):
+                value = item()
+            elif isinstance(value, Sequence) and not isinstance(
+                value, (str, bytes, bytearray)
+            ):
+                value = value[0] if value else 0
+            width = int(value)
+        except Exception as exc:
+            raise _opengl_setup_error(
+                "OpenGL subgroup-width query failed.",
+                "subgroup-query-failed",
+                hostQuery="GL_SUBGROUP_SIZE_KHR",
+                queryToken=token,
+                error=str(exc),
+            ) from exc
+        if width <= 0 or width > 128 or width & (width - 1):
+            raise _opengl_setup_error(
+                "OpenGL reported an invalid subgroup width.",
+                "subgroup-query-invalid",
+                hostQuery="GL_SUBGROUP_SIZE_KHR",
+                subgroupWidth=width,
+            )
+        return width
+
+    def _validate_context_subgroup_width(self, context: Any, required: int) -> int:
+        actual = self._query_context_subgroup_width(context)
+        if actual != required:
+            raise _opengl_setup_error(
+                f"OpenGL artifact requires subgroup width {required}, but the "
+                f"current device reports {actual}.",
+                "subgroup-width-mismatch",
+                requiredSubgroupWidth=required,
+                subgroupWidth=actual,
+                hostQuery="GL_SUBGROUP_SIZE_KHR",
+                mismatchBehavior="reject-before-dispatch",
+            )
+        return actual
+
+    def _record_subgroup_width_validation(
+        self,
+        state: Any,
+        *,
+        required: int,
+        actual: int,
+        backend: str | None,
+    ) -> None:
+        details = {
+            "target": "opengl",
+            "runtime": self.name,
+            "contextBackend": backend or "default",
+            "requiredSubgroupWidth": required,
+            "subgroupWidth": actual,
+            "hostQuery": "GL_SUBGROUP_SIZE_KHR",
+        }
+        state_details = getattr(state, "details", None)
+        if isinstance(state_details, dict):
+            state_details["openglSubgroupWidth"] = details
+        record_step = getattr(state, "record_step", None)
+        if callable(record_step):
+            record_step(
+                "validate",
+                "validate-opengl-subgroup-width",
+                details=details,
+            )
 
     def _load_moderngl(self) -> Any:
         try:
@@ -3537,6 +3696,125 @@ def _opengl_context_version_code(context: Any) -> int:
         return int(getattr(context, "version_code", 0) or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _opengl_subgroup_width_value(value: Any, *, source: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise _opengl_setup_error(
+            "OpenGL exact subgroup width must be a positive integer.",
+            "subgroup-width-contract-invalid",
+            contractSource=source,
+            subgroupWidth=value,
+        )
+    if value > 128 or value & (value - 1):
+        raise _opengl_setup_error(
+            "OpenGL exact subgroup width must be a power of two no greater than 128.",
+            "subgroup-width-contract-invalid",
+            contractSource=source,
+            subgroupWidth=value,
+        )
+    return value
+
+
+def _opengl_execution_config_subgroup_width(
+    execution_config: Mapping[str, Any],
+    *,
+    source: str,
+) -> int | None:
+    values = []
+    for field_name in ("subgroupWidth", "subgroup_width", "waveSize", "wave_size"):
+        if field_name not in execution_config:
+            continue
+        value = _opengl_subgroup_width_value(
+            execution_config[field_name],
+            source=f"{source}.{field_name}",
+        )
+        if value is not None:
+            values.append(value)
+    if len(set(values)) > 1:
+        raise _opengl_setup_error(
+            "OpenGL execution metadata declares conflicting subgroup widths.",
+            "subgroup-width-contract-conflict",
+            contractSource=source,
+            subgroupWidths=sorted(set(values)),
+        )
+    return values[0] if values else None
+
+
+def _opengl_shader_subgroup_width(shader_artifact: str | bytes) -> int | None:
+    if not isinstance(shader_artifact, str):
+        return None
+    matches = list(_OPENGL_REQUIRED_SUBGROUP_WIDTH_RE.finditer(shader_artifact))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise _opengl_setup_error(
+            "OpenGL artifact declares multiple exact subgroup-width markers.",
+            "subgroup-width-marker-ambiguous",
+            marker="CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+            markerCount=len(matches),
+        )
+    token = matches[0].group("width")
+    match = re.fullmatch(r"(?P<value>(?:0[xX][0-9A-Fa-f]+)|(?:[0-9]+))[uU]?", token)
+    if match is None:
+        raise _opengl_setup_error(
+            "OpenGL artifact subgroup-width marker is not an integer literal.",
+            "subgroup-width-marker-invalid",
+            marker="CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+            markerValue=token,
+        )
+    return _opengl_subgroup_width_value(
+        int(match.group("value"), 0),
+        source="artifact.CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+    )
+
+
+def _opengl_dispatch_required_subgroup_width(
+    request: NativeRuntimeDispatchRequest,
+    shader_artifact: str | bytes,
+) -> int | None:
+    metadata_width = _opengl_execution_config_subgroup_width(
+        request.execution_config,
+        source="dispatch.executionConfig",
+    )
+    marker_width = _opengl_shader_subgroup_width(shader_artifact)
+    if (
+        metadata_width is not None
+        and marker_width is not None
+        and metadata_width != marker_width
+    ):
+        raise _opengl_setup_error(
+            "OpenGL artifact and execution metadata require different subgroup widths.",
+            "subgroup-width-contract-conflict",
+            executionSubgroupWidth=metadata_width,
+            artifactSubgroupWidth=marker_width,
+        )
+    return metadata_width if metadata_width is not None else marker_width
+
+
+def _opengl_runtime_request_required_subgroup_width(
+    request: RuntimeExecutionRequest,
+) -> int | None:
+    selected_entry = request.fixture.entry_point
+    widths = []
+    for entry_point in request.adapter_contract.entry_points:
+        if selected_entry is not None and entry_point.name != selected_entry:
+            continue
+        width = _opengl_execution_config_subgroup_width(
+            entry_point.execution_config,
+            source=f"runtimeAdapter.entryPoints.{entry_point.name}.executionConfig",
+        )
+        if width is not None:
+            widths.append(width)
+    if len(set(widths)) > 1:
+        raise _opengl_setup_error(
+            "OpenGL runtime request selects conflicting subgroup widths.",
+            "subgroup-width-contract-conflict",
+            subgroupWidths=sorted(set(widths)),
+        )
+    return widths[0] if widths else None
 
 
 def _opengl_status(value: Any) -> bool:

--- a/crosstl/project/pipeline.py
+++ b/crosstl/project/pipeline.py
@@ -1527,6 +1527,8 @@ WORKGROUP_SIZE_SPECIALIZATION_TARGETS = frozenset(("directx", "opengl"))
 SUBGROUP_WIDTH_RULES_CONFIG_KEY = "subgroup_width_rules"
 SUBGROUP_WIDTH_SPECIALIZATION_CAPABILITY = "execution.subgroup-width-specialization"
 DIRECTX_EXACT_SUBGROUP_WIDTHS = frozenset((4, 8, 16, 32, 64, 128))
+OPENGL_EXACT_SUBGROUP_WIDTHS = frozenset((1, 2, 4, 8, 16, 32, 64, 128))
+SUBGROUP_WIDTH_SPECIALIZATION_TARGETS = frozenset(("directx", "opengl"))
 DEFERRED_SPECIALIZATION_TARGETS = frozenset(
     ("cgl", "crossgl", "metal", "opengl", "vulkan")
 )
@@ -1821,7 +1823,16 @@ REPORT_ARTIFACT_EXECUTION_SUBGROUP_WIDTH_RULE_FIELDS = frozenset(
     ("expression", "sourcePattern", "path")
 )
 REPORT_ARTIFACT_EXECUTION_SUBGROUP_WIDTH_ENFORCEMENT_FIELDS = frozenset(
-    ("mechanism", "minimumShaderModel", "entryProfiles")
+    (
+        "mechanism",
+        "minimumShaderModel",
+        "entryProfiles",
+        "shaderExtension",
+        "hostExtension",
+        "hostQuery",
+        "artifactMarker",
+        "mismatchBehavior",
+    )
 )
 REPORT_ARTIFACT_EXECUTION_SUBGROUP_WIDTH_PROFILE_FIELDS = frozenset(
     ("entryPoint", "profile")
@@ -3004,6 +3015,17 @@ DIRECTX_HLSL_EXACT_WAVE_SIZE_RE = re.compile(
 DIRECTX_HLSL_WAVE_SIZE_RE = re.compile(
     r"\[\s*WaveSize\s*\((?P<arguments>[^\]]*)\)\s*\]",
     re.IGNORECASE,
+)
+OPENGL_REQUIRED_SUBGROUP_WIDTH_MACRO = "CROSSTL_REQUIRED_SUBGROUP_WIDTH"
+OPENGL_REQUIRED_SUBGROUP_WIDTH_RE = re.compile(
+    rf"^\s*#define\s+{OPENGL_REQUIRED_SUBGROUP_WIDTH_MACRO}\s+"
+    r"(?P<width>[^\s]+)\s*$",
+    re.MULTILINE,
+)
+OPENGL_SUBGROUP_WIDTH_GUARD_RE = re.compile(
+    rf"\bif\s*\(\s*gl_SubgroupSize\s*!=\s*"
+    rf"{OPENGL_REQUIRED_SUBGROUP_WIDTH_MACRO}\s*\)\s*\{{\s*return\s*;\s*\}}",
+    re.MULTILINE,
 )
 DIRECTX_HLSL_SEMANTIC_RE = re.compile(
     r":\s*(?P<semantic>[A-Za-z_]\w*)\b", re.IGNORECASE
@@ -11429,30 +11451,58 @@ def _configured_subgroup_width_rule(
     )
 
 
+def _exact_subgroup_widths_for_target(target: str) -> frozenset[int]:
+    if target == "directx":
+        return DIRECTX_EXACT_SUBGROUP_WIDTHS
+    if target == "opengl":
+        return OPENGL_EXACT_SUBGROUP_WIDTHS
+    return frozenset()
+
+
+def _subgroup_width_enforcement_metadata(
+    target: str,
+    target_entry_points: Sequence[str],
+) -> dict[str, Any]:
+    entries = list(dict.fromkeys(str(entry) for entry in target_entry_points))
+    if target == "directx":
+        return {
+            "mechanism": "hlsl-wave-size-attribute",
+            "minimumShaderModel": "6.6",
+            "entryProfiles": [
+                {"entryPoint": entry, "profile": "cs_6_6"} for entry in entries
+            ],
+        }
+    if target == "opengl":
+        return {
+            "mechanism": "glsl-subgroup-size-guard",
+            "shaderExtension": "GL_KHR_shader_subgroup_basic",
+            "hostExtension": "GL_KHR_shader_subgroup",
+            "hostQuery": "GL_SUBGROUP_SIZE_KHR",
+            "artifactMarker": OPENGL_REQUIRED_SUBGROUP_WIDTH_MACRO,
+            "mismatchBehavior": "reject-before-dispatch",
+        }
+    raise ValueError(f"Target '{target}' has no exact subgroup-width contract")
+
+
 def _unsupported_subgroup_width_rule_target_error(
     config: ProjectConfig,
     unit: ProjectTranslationUnit,
     target: str,
 ) -> ProjectSubgroupWidthError | None:
     configured = _configured_subgroup_width_rule(config, unit.relative_path)
-    if configured is None or target == "directx":
+    if configured is None or target in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS:
         return None
     pattern, expression, provenance = configured
-    reason = (
-        "opengl-enforcement-unavailable"
-        if target == "opengl"
-        else "target-not-supported"
-    )
     return ProjectSubgroupWidthError(
         f"Target '{target}' cannot enforce an exact subgroup width.",
         code="project.translate.subgroup-width-enforcement-unsupported",
-        reason=reason,
+        reason="target-not-supported",
         rule_details={
             "path": provenance["path"],
             "sourcePattern": pattern,
             "expression": expression,
             "target": target,
-            "supportedTargets": ["directx"],
+            "supportedTargets": sorted(SUBGROUP_WIDTH_SPECIALIZATION_TARGETS),
         },
     )
 
@@ -12287,9 +12337,10 @@ def _project_subgroup_width_rule_execution_metadata(
                 source_entry_points=(host_name,),
                 subgroup_width=subgroup_width,
             )
-        if subgroup_width not in DIRECTX_EXACT_SUBGROUP_WIDTHS:
+        supported_widths = _exact_subgroup_widths_for_target(target)
+        if subgroup_width not in supported_widths:
             raise ProjectSubgroupWidthError(
-                f"DirectX cannot enforce subgroup width {subgroup_width} for "
+                f"Target '{target}' cannot enforce subgroup width {subgroup_width} for "
                 f"'{host_name}'.",
                 code="project.translate.subgroup-width-invalid",
                 reason="target-width-unsupported",
@@ -12299,7 +12350,7 @@ def _project_subgroup_width_rule_execution_metadata(
                     "path": provenance["path"],
                     "sourcePattern": source_pattern,
                     "expression": expression,
-                    "supportedWidths": sorted(DIRECTX_EXACT_SUBGROUP_WIDTHS),
+                    "supportedWidths": sorted(supported_widths),
                 },
             )
         _set_crossgl_stage_subgroup_width(stage, subgroup_width)
@@ -12342,14 +12393,10 @@ def _project_subgroup_width_rule_execution_metadata(
         "sourceEntryPoints": [entry["sourceEntryPoint"] for entry in entries],
         "entryPoints": entries,
         "subgroupWidthProvenance": provenance,
-        "subgroupWidthEnforcement": {
-            "mechanism": "hlsl-wave-size-attribute",
-            "minimumShaderModel": "6.6",
-            "entryProfiles": [
-                {"entryPoint": entry["targetEntryPoint"], "profile": "cs_6_6"}
-                for entry in entries
-            ],
-        },
+        "subgroupWidthEnforcement": _subgroup_width_enforcement_metadata(
+            target,
+            [str(entry["targetEntryPoint"]) for entry in entries],
+        ),
     }
     execution["identity"] = _subgroup_rule_execution_identity(
         source=unit.relative_path,
@@ -12372,7 +12419,7 @@ def _dispatch_subgroup_width_execution_metadata(
     configured_subgroup: tuple[int, Mapping[str, Any]],
 ) -> dict[str, Any]:
     subgroup_width, provenance = configured_subgroup
-    if target != "directx":
+    if target not in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS:
         raise ProjectSubgroupWidthError(
             "The target cannot enforce an exact host dispatch subgroup width.",
             code="project.translate.subgroup-width-invalid",
@@ -12380,15 +12427,16 @@ def _dispatch_subgroup_width_execution_metadata(
             source_entry_points=(selected_entry_point or "main",),
             subgroup_width=subgroup_width,
         )
-    if subgroup_width not in DIRECTX_EXACT_SUBGROUP_WIDTHS:
+    supported_widths = _exact_subgroup_widths_for_target(target)
+    if subgroup_width not in supported_widths:
         raise ProjectSubgroupWidthError(
-            f"DirectX cannot enforce subgroup width {subgroup_width}.",
+            f"Target '{target}' cannot enforce subgroup width {subgroup_width}.",
             code="project.translate.subgroup-width-invalid",
             reason="target-width-unsupported",
             source_entry_points=(selected_entry_point or "main",),
             subgroup_width=subgroup_width,
             rule_details={
-                "supportedWidths": sorted(DIRECTX_EXACT_SUBGROUP_WIDTHS),
+                "supportedWidths": sorted(supported_widths),
                 "path": provenance.get("path"),
             },
         )
@@ -12435,11 +12483,9 @@ def _dispatch_subgroup_width_execution_metadata(
         "entryPoints": [entry],
         "provenance": normalized_provenance,
         "subgroupWidthProvenance": normalized_provenance,
-        "subgroupWidthEnforcement": {
-            "mechanism": "hlsl-wave-size-attribute",
-            "minimumShaderModel": "6.6",
-            "entryProfiles": [{"entryPoint": target_entry, "profile": "cs_6_6"}],
-        },
+        "subgroupWidthEnforcement": _subgroup_width_enforcement_metadata(
+            target, [target_entry]
+        ),
     }
     execution["identity"] = _subgroup_rule_execution_identity(
         source=unit.relative_path,
@@ -25671,9 +25717,66 @@ def _validate_project_workgroup_target_output(
         )
 
 
+def _validate_project_opengl_subgroup_width_target_output(
+    output_path: Path,
+    *,
+    execution: Mapping[str, Any],
+    expected: Mapping[str, int],
+) -> None:
+    if set(expected) != {"main"}:
+        raise ProjectSubgroupWidthError(
+            "Generated OpenGL artifact must expose one guarded main entry point.",
+            code="project.translate.subgroup-width-invalid",
+            reason="target-entry-identity-mismatch",
+            source_entry_points=execution.get("sourceEntryPoints", ()),
+        )
+    enforcement = execution.get("subgroupWidthEnforcement")
+    expected_enforcement = _subgroup_width_enforcement_metadata("opengl", ["main"])
+    if enforcement != expected_enforcement:
+        raise ProjectSubgroupWidthError(
+            "OpenGL subgroup-width enforcement metadata is incomplete.",
+            code="project.translate.subgroup-width-invalid",
+            reason="target-profile-contract-invalid",
+            source_entry_points=execution.get("sourceEntryPoints", ()),
+        )
+
+    source = output_path.read_text(encoding="utf-8", errors="replace")
+    markers = list(OPENGL_REQUIRED_SUBGROUP_WIDTH_RE.finditer(source))
+    reflected_width = None
+    if len(markers) == 1:
+        try:
+            reflected_width = parse_c_family_integral_literal(markers[0].group("width"))
+        except CFamilyIntegralLiteralError:
+            reflected_width = None
+    expected_width = expected["main"]
+    has_required_extension = bool(
+        re.search(
+            r"^\s*#extension\s+GL_KHR_shader_subgroup_basic\s*:\s*require\s*$",
+            source,
+            flags=re.MULTILINE,
+        )
+    )
+    guards = list(OPENGL_SUBGROUP_WIDTH_GUARD_RE.finditer(source))
+    if (
+        len(markers) != 1
+        or reflected_width != expected_width
+        or not has_required_extension
+        or len(guards) != 1
+    ):
+        raise ProjectSubgroupWidthError(
+            "Generated OpenGL entry does not preserve its exact subgroup-width guard.",
+            code="project.translate.subgroup-width-conflict",
+            reason="target-output-mismatch",
+            source_entry_points=execution.get("sourceEntryPoints", ()),
+            subgroup_width=expected_width,
+            source_subgroup_width=reflected_width,
+        )
+
+
 def _validate_project_subgroup_width_target_output(
     output_path: Path,
     *,
+    target: str,
     execution: Mapping[str, Any],
 ) -> None:
     entries = [
@@ -25686,6 +25789,20 @@ def _validate_project_subgroup_width_target_output(
     expected = {
         str(entry["targetEntryPoint"]): int(entry["subgroupWidth"]) for entry in entries
     }
+    if target == "opengl":
+        _validate_project_opengl_subgroup_width_target_output(
+            output_path,
+            execution=execution,
+            expected=expected,
+        )
+        return
+    if target != "directx":
+        raise ProjectSubgroupWidthError(
+            f"Target '{target}' has no exact subgroup-width output validator.",
+            code="project.translate.subgroup-width-invalid",
+            reason="target-not-enforceable",
+            source_entry_points=execution.get("sourceEntryPoints", ()),
+        )
     enforcement = execution.get("subgroupWidthEnforcement")
     profiles = (
         enforcement.get("entryProfiles") if isinstance(enforcement, Mapping) else None
@@ -25792,17 +25909,33 @@ def _opengl_workgroup_split_specs(
             split_execution = {
                 "sourceEntryPoints": [source_entry],
                 "entryPoints": [split_entry],
-                "provenance": dict(execution["provenance"]),
             }
-            split_execution["identity"] = _workgroup_rule_execution_identity(
-                source=unit.relative_path,
-                source_hash=unit.source_hash,
-                target="opengl",
-                variant=variant,
-                source_entry_points=[source_entry],
-                entry_points=[split_entry],
-                provenance=split_execution["provenance"],
-            )
+            for field_name in (
+                "provenance",
+                "subgroupWidthProvenance",
+                "subgroupWidthEnforcement",
+            ):
+                value = execution.get(field_name)
+                if isinstance(value, Mapping):
+                    split_execution[field_name] = copy.deepcopy(value)
+            if "subgroupWidth" in split_entry:
+                split_execution["identity"] = _subgroup_rule_execution_identity(
+                    source=unit.relative_path,
+                    source_hash=unit.source_hash,
+                    target="opengl",
+                    variant=variant,
+                    execution=split_execution,
+                )
+            else:
+                split_execution["identity"] = _workgroup_rule_execution_identity(
+                    source=unit.relative_path,
+                    source_hash=unit.source_hash,
+                    target="opengl",
+                    variant=variant,
+                    source_entry_points=[source_entry],
+                    entry_points=[split_entry],
+                    provenance=split_execution["provenance"],
+                )
             specs.append((source_entry, materialized_entry, split_execution))
         return specs
 
@@ -26630,7 +26763,7 @@ def _translate_project_impl(
                     requires_subgroup_specialization = (
                         configured_subgroup is not None
                         or (
-                            target == "directx"
+                            target in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS
                             and _configured_subgroup_width_rule(
                                 config, unit.relative_path
                             )
@@ -26815,6 +26948,7 @@ def _translate_project_impl(
                                     )
                                     _validate_project_subgroup_width_target_output(
                                         split_output_path,
+                                        target=target,
                                         execution=split_execution,
                                     )
                                     records, split_diagnostics = (
@@ -26880,6 +27014,7 @@ def _translate_project_impl(
                                 )
                                 _validate_project_subgroup_width_target_output(
                                     output_path,
+                                    target=target,
                                     execution=execution,
                                 )
                     if generated_source is None and index_range_assertions:
@@ -28272,7 +28407,11 @@ def _subgroup_width_target_validation_diagnostics(
     artifact_path: Path,
 ) -> list[ProjectDiagnostic]:
     execution = artifact.get("execution")
-    if artifact.get("target") != "directx" or not isinstance(execution, Mapping):
+    if artifact.get(
+        "target"
+    ) not in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS or not isinstance(
+        execution, Mapping
+    ):
         return []
     entries = [
         entry
@@ -28285,6 +28424,7 @@ def _subgroup_width_target_validation_diagnostics(
     try:
         _validate_project_subgroup_width_target_output(
             artifact_path,
+            target=str(artifact["target"]),
             execution=execution,
         )
     except ProjectSubgroupWidthError as exc:
@@ -30063,7 +30203,10 @@ def _runtime_manifest_execution_host_interface(
     artifact: Mapping[str, Any],
     host_interface: Mapping[str, Any] | None,
 ) -> Mapping[str, Any] | None:
-    if artifact.get("target") != "directx" or not isinstance(host_interface, Mapping):
+    target = artifact.get("target")
+    if target not in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS or not isinstance(
+        host_interface, Mapping
+    ):
         return host_interface
     execution = artifact.get("execution")
     execution_entries = (
@@ -30098,7 +30241,9 @@ def _runtime_manifest_execution_host_interface(
             else {}
         )
         if isinstance(size, list):
-            execution_config["numthreads"] = list(size)
+            execution_config["numthreads" if target == "directx" else "local_size"] = (
+                list(size)
+            )
         if subgroup_width is not None:
             execution_config["subgroupWidth"] = subgroup_width
         entry_point.update(
@@ -45489,8 +45634,13 @@ def _artifact_subgroup_rule_execution_contract_reasons(
         record.get("variant") if _is_non_empty_string(record.get("variant")) else None
     )
     source_hash = record.get("sourceHash")
-    if target != "directx":
-        reasons.append(f"{execution_prefix} subgroup width requires target directx")
+    supported_widths = (
+        _exact_subgroup_widths_for_target(str(target))
+        if _is_non_empty_string(target)
+        else frozenset()
+    )
+    if target not in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS:
+        reasons.append(f"{execution_prefix} subgroup width requires a supported target")
     project_rules = (
         project.get("subgroupWidthRules") if isinstance(project, Mapping) else None
     )
@@ -45537,9 +45687,9 @@ def _artifact_subgroup_rule_execution_contract_reasons(
             or subgroup_width <= 0
         ):
             reasons.append(f"{entry_prefix}.subgroupWidth must be a positive integer")
-        elif subgroup_width not in DIRECTX_EXACT_SUBGROUP_WIDTHS:
+        elif subgroup_width not in supported_widths:
             reasons.append(
-                f"{entry_prefix}.subgroupWidth is not enforceable by DirectX WaveSize"
+                f"{entry_prefix}.subgroupWidth is not enforceable by target {target}"
             )
         rule = entry.get("subgroupWidthRule")
         expression = None
@@ -45741,12 +45891,13 @@ def _artifact_subgroup_rule_execution_contract_reasons(
                 REPORT_ARTIFACT_EXECUTION_SUBGROUP_WIDTH_ENFORCEMENT_FIELDS,
             )
         )
-    profile_records = []
-    if not isinstance(profiles, list):
-        reasons.append(
-            f"{execution_prefix}.subgroupWidthEnforcement.entryProfiles must be a list"
-        )
-    else:
+    if profiles is not None:
+        if not isinstance(profiles, list):
+            reasons.append(
+                f"{execution_prefix}.subgroupWidthEnforcement.entryProfiles must "
+                "be a list"
+            )
+            profiles = []
         for index, item in enumerate(profiles):
             profile_prefix = (
                 f"{execution_prefix}.subgroupWidthEnforcement.entryProfiles[{index}]"
@@ -45761,22 +45912,15 @@ def _artifact_subgroup_rule_execution_contract_reasons(
                     REPORT_ARTIFACT_EXECUTION_SUBGROUP_WIDTH_PROFILE_FIELDS,
                 )
             )
-            profile_records.append(item)
-    profile_entries = [str(item.get("entryPoint", "")) for item in profile_records]
-    if (
-        not isinstance(enforcement, Mapping)
-        or enforcement.get("mechanism") != "hlsl-wave-size-attribute"
-        or enforcement.get("minimumShaderModel") != "6.6"
-        or profile_entries != sorted(set(target_entries))
-        or any(
-            not _is_non_empty_string(item.get("profile"))
-            or item.get("profile") != "cs_6_6"
-            for item in profile_records
-        )
-    ):
+    expected_enforcement = (
+        _subgroup_width_enforcement_metadata(str(target), target_entries)
+        if target in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS
+        else None
+    )
+    if enforcement != expected_enforcement:
         reasons.append(
-            f"{execution_prefix}.subgroupWidthEnforcement must require WaveSize "
-            "and cs_6_6 for every target entry"
+            f"{execution_prefix}.subgroupWidthEnforcement must match the "
+            f"{target} exact-width contract"
         )
     identity_reasons = _hash_contract_reasons(
         f"{execution_prefix}.identity",
@@ -45858,9 +46002,11 @@ def _artifact_dispatch_execution_contract_reasons(
         "artifactId": dispatch_artifact.get("artifactId"),
     }
     reasons = []
-    if record.get("target") != "directx":
+    target = record.get("target")
+    if target not in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS:
         reasons.append(
-            f"{execution_prefix} exact subgroup enforcement requires target directx"
+            f"{execution_prefix} exact subgroup enforcement requires a supported "
+            "target"
         )
     if execution.get("provenance") != expected_provenance:
         reasons.append(
@@ -45925,7 +46071,7 @@ def _artifact_dispatch_execution_contract_reasons(
             expected_identity = _workgroup_rule_entry_identity(
                 source=str(record["source"]),
                 source_hash=record["sourceHash"],
-                target="directx",
+                target=str(target),
                 variant=str(record["variant"]),
                 entry=entry,
             )
@@ -45935,15 +46081,16 @@ def _artifact_dispatch_execution_contract_reasons(
                 )
 
         target_entry = entry.get("targetEntryPoint")
-        expected_enforcement = {
-            "mechanism": "hlsl-wave-size-attribute",
-            "minimumShaderModel": "6.6",
-            "entryProfiles": [{"entryPoint": target_entry, "profile": "cs_6_6"}],
-        }
+        expected_enforcement = (
+            _subgroup_width_enforcement_metadata(str(target), [str(target_entry)])
+            if target in SUBGROUP_WIDTH_SPECIALIZATION_TARGETS
+            and _is_non_empty_string(target_entry)
+            else None
+        )
         if execution.get("subgroupWidthEnforcement") != expected_enforcement:
             reasons.append(
-                f"{execution_prefix}.subgroupWidthEnforcement must require "
-                "WaveSize and cs_6_6 for the target entry"
+                f"{execution_prefix}.subgroupWidthEnforcement must match the "
+                f"{target} exact-width contract"
             )
 
     identity_reasons = _hash_contract_reasons(
@@ -45960,7 +46107,7 @@ def _artifact_dispatch_execution_contract_reasons(
         expected_identity = _subgroup_rule_execution_identity(
             source=str(record["source"]),
             source_hash=record["sourceHash"],
-            target="directx",
+            target=str(target),
             variant=str(record["variant"]),
             execution=execution,
         )

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -665,6 +665,7 @@ class NativeRuntimeDispatchRequest:
     constants: Mapping[str, NativeRuntimeConstantBinding]
     dispatch: RuntimeDispatchGeometry | None = None
     entry_point: str | None = None
+    execution_config: Mapping[str, Any] = field(default_factory=dict)
 
     def to_json(self) -> dict[str, Any]:
         payload = {
@@ -681,6 +682,8 @@ class NativeRuntimeDispatchRequest:
         }
         if self.entry_point is not None:
             payload["entryPoint"] = self.entry_point
+        if self.execution_config:
+            payload["executionConfig"] = dict(self.execution_config)
         if self.dispatch is not None:
             payload["dispatch"] = self.dispatch.to_json()
         return payload
@@ -1510,6 +1513,15 @@ class NativeRuntimeParityAdapter(RuntimeParityAdapter):
         constants = self._native_constant_bindings(state)
         dispatch = state.plan.dispatch
         entry_point = dispatch.entry_point if dispatch is not None else None
+        execution_config: dict[str, Any] = {}
+        if dispatch is not None and isinstance(
+            dispatch.metadata.get("executionConfig"), Mapping
+        ):
+            execution_config.update(dispatch.metadata["executionConfig"])
+        for candidate in state.request.adapter_contract.entry_points:
+            if entry_point is None or candidate.name == entry_point:
+                execution_config.update(candidate.execution_config)
+                break
         runtime_artifact = dict(state.request.artifact)
         if state.request.artifact_identity is not None:
             runtime_artifact.update(state.request.artifact_identity.to_json())
@@ -1523,6 +1535,7 @@ class NativeRuntimeParityAdapter(RuntimeParityAdapter):
             constants=constants,
             dispatch=dispatch,
             entry_point=entry_point,
+            execution_config=execution_config,
         )
         state.record_step(
             "bind",
@@ -1531,6 +1544,7 @@ class NativeRuntimeParityAdapter(RuntimeParityAdapter):
                 "target": self.target,
                 "bufferCount": len(buffers),
                 "constantCount": len(constants),
+                "executionConfig": execution_config,
                 "outputBufferCount": sum(
                     1
                     for binding in buffers.values()

--- a/crosstl/translator/codegen/GLSL_codegen.py
+++ b/crosstl/translator/codegen/GLSL_codegen.py
@@ -370,6 +370,19 @@ class OpenGLWorkgroupSizeError(ValueError):
         self.reason = reason
 
 
+class OpenGLSubgroupWidthError(ValueError):
+    """Raised when an exact OpenGL subgroup-width guard is not representable."""
+
+    project_diagnostic_code = "project.translate.subgroup-width-invalid"
+    missing_capabilities = ("execution.subgroup-width-specialization",)
+    check_kind = "execution-specialization"
+
+    def __init__(self, message, *, subgroup_width=None, reason=None):
+        super().__init__(message)
+        self.subgroup_width = subgroup_width
+        self.reason = reason
+
+
 class OpenGLEntryPointSelectionError(ValueError):
     """Raised when a requested standalone OpenGL entry cannot be selected."""
 
@@ -1621,6 +1634,11 @@ class GLSLCodeGen:
     GLSL_INT64_EXTENSION = "GL_ARB_gpu_shader_int64"
     GLSL_INT64_EXTENSION_LINE = "#extension GL_ARB_gpu_shader_int64 : require"
     GLSL_INT64_SCALAR_TYPES = {"int64_t", "uint64_t"}
+    GLSL_SUBGROUP_BASIC_EXTENSION_LINE = (
+        "#extension GL_KHR_shader_subgroup_basic : require"
+    )
+    GLSL_EXACT_SUBGROUP_WIDTHS = frozenset({1, 2, 4, 8, 16, 32, 64, 128})
+    GLSL_REQUIRED_SUBGROUP_WIDTH_MACRO = "CROSSTL_REQUIRED_SUBGROUP_WIDTH"
     GLSL_CLANG_TRAILING_ZERO_BUILTINS = frozenset(
         {"__builtin_ctz", "__builtin_ctzl", "__builtin_ctzll"}
     )
@@ -3444,11 +3462,15 @@ class GLSLCodeGen:
     def glsl_wave_extension_lines(self, ast, target_stage=None):
         operations = self.glsl_wave_operations(ast, target_stage)
         lines = []
-        if self.uses_glsl_subgroup_basic_builtin(ast, target_stage) or any(
-            operation in self.GLSL_WAVE_EXTENSION_REQUIREMENTS
-            for operation in operations
+        if (
+            self.glsl_stage_requires_exact_subgroup_width(ast, target_stage)
+            or (self.uses_glsl_subgroup_basic_builtin(ast, target_stage))
+            or any(
+                operation in self.GLSL_WAVE_EXTENSION_REQUIREMENTS
+                for operation in operations
+            )
         ):
-            lines.append("#extension GL_KHR_shader_subgroup_basic : require")
+            lines.append(self.GLSL_SUBGROUP_BASIC_EXTENSION_LINE)
         for operation in self.GLSL_WAVE_INTRINSIC_ARITIES:
             if operation not in operations:
                 continue
@@ -3460,6 +3482,74 @@ class GLSLCodeGen:
                 if shuffle_line not in lines:
                     lines.append(shuffle_line)
         return lines
+
+    def glsl_wave_size_attribute(self, attribute):
+        name = str(getattr(attribute, "name", "")).strip().lower()
+        if name.startswith("hlsl_"):
+            name = name[len("hlsl_") :]
+        return name == "wavesize"
+
+    def glsl_exact_subgroup_width(self, function, shader_type=None):
+        attributes = [
+            attribute
+            for attribute in getattr(function, "attributes", []) or []
+            if self.glsl_wave_size_attribute(attribute)
+        ]
+        if not attributes:
+            return None
+        if len(attributes) != 1:
+            raise OpenGLSubgroupWidthError(
+                "OpenGL compute entry points require exactly one WaveSize attribute.",
+                reason="source-metadata-ambiguous",
+            )
+        if shader_type is not None and shader_type != "compute":
+            raise OpenGLSubgroupWidthError(
+                "OpenGL WaveSize is only valid on compute shader entry points.",
+                reason="stage-unsupported",
+            )
+        arguments = list(getattr(attributes[0], "arguments", []) or [])
+        if len(arguments) != 1:
+            raise OpenGLSubgroupWidthError(
+                "OpenGL WaveSize requires exactly one integer argument.",
+                reason="source-metadata-not-exact",
+            )
+        width = self.literal_int_value(arguments[0])
+        if width not in self.GLSL_EXACT_SUBGROUP_WIDTHS:
+            raise OpenGLSubgroupWidthError(
+                "OpenGL WaveSize must be a power of two from 1 through 128.",
+                subgroup_width=width,
+                reason="target-width-unsupported",
+            )
+        return width
+
+    def glsl_stage_exact_subgroup_width(self, ast, target_stage=None):
+        widths = set()
+        for stage_name, stage in getattr(ast, "stages", {}).items():
+            normalized_stage = normalize_stage_name(stage_name)
+            if target_stage is not None and normalized_stage != target_stage:
+                continue
+            function = getattr(stage, "entry_point", None)
+            if function is None:
+                continue
+            width = self.glsl_exact_subgroup_width(function, normalized_stage)
+            if width is not None:
+                widths.add(width)
+        if len(widths) > 1:
+            raise OpenGLSubgroupWidthError(
+                "One OpenGL artifact cannot require multiple exact subgroup widths.",
+                reason="entry-width-conflict",
+            )
+        return next(iter(widths), None)
+
+    def glsl_stage_requires_exact_subgroup_width(self, ast, target_stage=None):
+        return self.glsl_stage_exact_subgroup_width(ast, target_stage) is not None
+
+    def generate_glsl_exact_subgroup_width_guard(self, function, shader_type):
+        width = self.glsl_exact_subgroup_width(function, shader_type)
+        if width is None:
+            return ""
+        macro = self.GLSL_REQUIRED_SUBGROUP_WIDTH_MACRO
+        return f"    if (gl_SubgroupSize != {macro}) {{\n" "        return;\n" "    }\n"
 
     def generate_glsl_wave_helpers(self, ast, target_stage=None):
         operations = self.glsl_wave_operations(ast, target_stage)
@@ -4598,12 +4688,18 @@ class GLSLCodeGen:
         self.current_glsl_resource_binding_layouts_supported = (
             self.glsl_resource_binding_layouts_supported(version_line)
         )
+        exact_subgroup_width = self.glsl_stage_exact_subgroup_width(ast, target_stage)
         code += f"{version_line}\n"
         for line in self.glsl_stage_extension_lines(ast, target_stage):
             if line not in extra_lines:
                 code += f"{line}\n"
         if extra_lines:
             code += "\n".join(extra_lines) + "\n"
+        if exact_subgroup_width is not None:
+            code += (
+                f"#define {self.GLSL_REQUIRED_SUBGROUP_WIDTH_MACRO} "
+                f"{exact_subgroup_width}u\n"
+            )
         cooperative_matrix_support_insertion_index = len(code)
         code += self.generate_glsl_enum_constants(
             self.plain_enums + self.struct_payload_enums,
@@ -11250,6 +11346,8 @@ class GLSLCodeGen:
         if shader_type in stage_entry_types:
             code += f"void {entry_name or 'main'}() {{\n"
             self.current_function_return_type = "void"
+            if shader_type == "compute" and is_native_stage_entry:
+                code += self.generate_glsl_exact_subgroup_width_guard(func, shader_type)
         else:
             raw_return_type = self.type_name_string(getattr(func, "return_type", None))
             self.current_function_return_type = raw_return_type or "void"
@@ -35877,6 +35975,7 @@ complex64_t crossgl_complex64_mod_assign(
             "fragment",
             "fractional_even_spacing",
             "fractional_odd_spacing",
+            "hlsl_wavesize",
             "invocations",
             "inputtopology",
             "isolines",
@@ -35909,6 +36008,7 @@ complex64_t crossgl_complex64_mod_assign(
             "vertex",
             "vertices",
             "workgroup_size",
+            "wavesize",
         } | self.GLSL_BLEND_SUPPORT_LAYOUT_NAMES
         if normalized in valid_names:
             return normalized

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -899,12 +899,13 @@ artifacts. The built-in Python runtime and generated C++ adapter reject a
 reported width other than 32 before compiling the shader or allocating its
 resources.
 
-The Linux software-device proof separately executes an exact-width reduced
-compute artifact on a device reporting subgroup width 4. That verifies the
-query, compatibility gate, dispatch, and readback path, but it cannot execute
-the width-32 LogSumExp artifacts. OpenGL LogSumExp numerical parity therefore
-remains dependent on compatible hardware or a semantics-preserving subgroup
-emulation strategy tracked by
+The Linux software-device proof separately queries the device subgroup width,
+specializes a reduced exact-width compute artifact to that reported value, and
+verifies dispatch and readback. This validates the query and compatibility path
+without assuming a fixed Mesa subgroup width, but it cannot execute the
+width-32 LogSumExp artifacts unless the device reports 32. OpenGL LogSumExp
+numerical parity therefore remains dependent on compatible hardware or a
+semantics-preserving subgroup emulation strategy tracked by
 [#1894](https://github.com/CrossGL/crosstl/issues/1894).
 
 A separate Windows native-loader test packages the axis-size-32 artifact,

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -174,6 +174,13 @@ The current harness verifies:
   exact fail-closed workgroup-size diagnostic and no target file. This is native
   artifact validation only; the gate does not run the kernels or establish
   runtime parity;
+- a separate bounded OpenGL dispatch-contract proof for the actual pinned
+  `logsumexp.metal` source. The two float32 workloads emit standalone GLSL
+  artifacts with workgroup sizes `[32, 1, 1]` and `[288, 1, 1]`, an exact
+  subgroup width of 32, and preserved subgroup max and sum reductions. Linux CI
+  compiles both artifacts to OpenGL SPIR-V 1.3 and validates both binaries. The
+  runtime contract requires `GL_KHR_shader_subgroup` and rejects a device whose
+  `GL_SUBGROUP_SIZE_KHR` value is not 32 before shader compilation or dispatch;
 - full project materialization of pinned `gemv.metal` for DirectX. The gate
   requires 225 materialized specializations, no unsupported materializations or
   unresolved residue, no bare pure value-discard statements, one aggregate HLSL
@@ -550,8 +557,10 @@ view work tracked by [#1546](https://github.com/CrossGL/crosstl/issues/1546),
 the resource pointer-offset contract tracked by
 [#1518](https://github.com/CrossGL/crosstl/issues/1518),
 with the broader subgroup contract tracked by
-[#1786](https://github.com/CrossGL/crosstl/issues/1786). Those issues remain
-open for their broader cross-target, writable-view, alignment, subgroup, and
+[#1894](https://github.com/CrossGL/crosstl/issues/1894). Issue
+[#1786](https://github.com/CrossGL/crosstl/issues/1786) established the exact
+subgroup-width metadata and DirectX enforcement model. The remaining issues
+cover broader cross-target, writable-view, alignment, subgroup fallback, and
 runtime acceptance criteria. This proof does not dispatch the kernel through
 Direct3D, run MLX tests, or claim numerical parity.
 
@@ -661,11 +670,11 @@ shader attribute` warnings caused by using a library profile. The gate derives
 the expected warning source-line counts from the seven generated `numthreads`
 forms and requires exact severity, message, source expression, and count
 matches. Any unused-value warning, error, or other diagnostic fails the gate.
-[#1786](https://github.com/CrossGL/crosstl/issues/1786) tracks the required
-32-lane wave-size specialization. Library compilation proves that DXC accepts
-and code-generates every exported function. It does not establish wave
-semantics, runtime execution, numerical parity, or whole-kernel semantic
-validity.
+[#1786](https://github.com/CrossGL/crosstl/issues/1786) established the exact
+wave-size specialization contract. This existing GEMV library frontier does not
+apply that contract, so library compilation proves that DXC accepts and
+code-generates every exported function but does not establish wave semantics,
+runtime execution, numerical parity, or whole-kernel semantic validity.
 
 The separate pinned `gemv.metal` OpenGL frontier uses the same 4,096
 specialization limit and 2,097,152-item materialization work budget. It requires
@@ -685,15 +694,17 @@ subgroup width and the configured `[32, 8, 1]` workgroup, `simd_gid` is in
 `[0, 7]`, the base offset is in `[0, 14]`, and the guarded reduction reaches at
 most element `14` of the 16-element backing. Translation remains fail-closed
 because the target-independent backing-view analysis does not yet carry this
-range proof, while the target subgroup-width contract is also not established.
+range proof. The existing frontier also does not configure the exact subgroup
+width on the blocked artifact.
 [#1671](https://github.com/CrossGL/crosstl/issues/1671) tracks backing and range
 propagation and remains the translation blocker.
-[#1786](https://github.com/CrossGL/crosstl/issues/1786) remains the execution
-blocker for required subgroup-width specialization. Because translation emits
-no GLSL artifact, this frontier does not claim an emitted or runnable GEMV
-artifact, attempts no native compiler or runtime validation, and makes no
-runtime or numerical-parity claim. Configuring the workgroup-size rule alone
-does not prove the unavailable generated-artifact execution contract.
+The exact subgroup-width contract can now gate execution on a device reporting
+width 32; [#1894](https://github.com/CrossGL/crosstl/issues/1894) tracks a
+semantics-preserving fallback for devices without that native width. Because
+translation emits no GLSL artifact, this frontier does not claim an emitted or
+runnable GEMV artifact, attempts no native compiler or runtime validation, and
+makes no runtime or numerical-parity claim. Configuring the workgroup-size rule
+alone does not prove the unavailable generated-artifact execution contract.
 
 Owner-dependent `constexpr` helper calls in quantized struct static members now
 resolve for the selected pinned replay, completing CrossGL/crosstl#1672.
@@ -877,6 +888,25 @@ requires official DXC `cs_6_6` compilation with warnings as errors on Windows.
 This establishes translation and native compiler acceptance for the two listed
 test-derived dispatches.
 
+The same checked-in contract also produces two standalone OpenGL artifacts.
+Each generated GLSL file requires `GL_KHR_shader_subgroup_basic`, declares
+`CROSSTL_REQUIRED_SUBGROUP_WIDTH` as 32, and checks `gl_SubgroupSize` before any
+translated kernel work. The portability report records the matching
+`GL_KHR_shader_subgroup` host requirement and `GL_SUBGROUP_SIZE_KHR` query, and
+the runtime artifact manifest retains both the local size and exact subgroup
+width. Linux CI requires `glslangValidator` and `spirv-val` to accept both
+artifacts. The built-in Python runtime and generated C++ adapter reject a
+reported width other than 32 before compiling the shader or allocating its
+resources.
+
+The Linux software-device proof separately executes an exact-width reduced
+compute artifact on a device reporting subgroup width 4. That verifies the
+query, compatibility gate, dispatch, and readback path, but it cannot execute
+the width-32 LogSumExp artifacts. OpenGL LogSumExp numerical parity therefore
+remains dependent on compatible hardware or a semantics-preserving subgroup
+emulation strategy tracked by
+[#1894](https://github.com/CrossGL/crosstl/issues/1894).
+
 A separate Windows native-loader test packages the axis-size-32 artifact,
 builds its reflected DirectX ABI, binds 32 nonuniform float32 inputs and the
 axis-size constant, dispatches one 32-thread workgroup, and compares the
@@ -956,12 +986,13 @@ each HLSL library with `cs_6_6`; native 16-bit artifacts additionally pass
 
 For OpenGL, the `workgroup_32` and `workgroup_64` variants leave `has_w`
 deferred, retain `layout(constant_id = 20)`, and split each host-named entry
-into a standalone `main` artifact. The proof deliberately does not configure a
-subgroup-width rule for OpenGL because this project contract cannot enforce an
-exact subgroup width there. It requires subgroup provenance and enforcement
-metadata to remain absent. Linux CI compiles all 24 GLSL artifacts to OpenGL
-SPIR-V 1.3 and validates all 24 binaries with `spirv-val`; that result does not
-establish the source's 32-lane simdgroup or `simd_sum` semantics.
+into a standalone `main` artifact. This existing RMSNorm proof deliberately
+does not configure an OpenGL subgroup-width rule, so subgroup provenance and
+enforcement metadata remain absent. Linux CI compiles all 24 GLSL artifacts to
+OpenGL SPIR-V 1.3 and validates all 24 binaries with `spirv-val`; that result
+does not establish the source's 32-lane simdgroup or `simd_sum` semantics. The
+bounded LogSumExp proof above exercises the exact-width OpenGL contract without
+inflating the RMSNorm claim.
 
 This is translation and native compilation evidence only. It does not execute
 RMSNorm, establish numerical or runtime parity, claim complete runtime

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -285,7 +285,10 @@
     },
     "runtime_compatibility": {
       "adapter_preflight_included": true,
-      "compatible_width_device_test": 4,
+      "compatible_width_device_test": {
+        "artifact_specialized_to_reported_width": true,
+        "width_source": "GL_SUBGROUP_SIZE_KHR"
+      },
       "logsumexp_required_width": 32,
       "logsumexp_runtime_execution_attempted": false,
       "blocked_by": "https://github.com/CrossGL/crosstl/issues/1894"

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -233,6 +233,67 @@
     "runtime_integration_included": false,
     "runtime_parity_claimed": false
   },
+  "opengl_logsumexp_dispatch_status": {
+    "status": "translated-glslang-spirv-val-validated-with-runtime-width-preflight",
+    "commit": "4367c73b60541ddd5a266ce4644fd93d20223b6e",
+    "source": "mlx/backend/metal/kernels/logsumexp.metal",
+    "source_sha256": "f9bec5e1e5a23d20bedf9ff8d29a8c03bbb5144bc5d751bbfe906d32ee894817",
+    "target": "opengl",
+    "dispatch_contract": {
+      "path": "demos/integrations/mlx/contracts/logsumexp.dispatch.json",
+      "content_identity": "sha256:db762a188e05786e206d9aa5a340b6f9095a8a3e938b85a7c04836f300e97c95",
+      "workload_count": 2,
+      "workgroup_sizes": [
+        [
+          32,
+          1,
+          1
+        ],
+        [
+          288,
+          1,
+          1
+        ]
+      ],
+      "subgroup_width": 32
+    },
+    "project_translation": {
+      "unit_count": 1,
+      "artifact_count": 2,
+      "translated_count": 2,
+      "failed_count": 0,
+      "project_diagnostic_count": 0,
+      "entry_point": "block_logsumexp_float32",
+      "target_entry_point": "main"
+    },
+    "subgroup_width_contract": {
+      "shader_extension": "GL_KHR_shader_subgroup_basic",
+      "artifact_marker": "CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+      "entry_guard": "gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+      "host_extension": "GL_KHR_shader_subgroup",
+      "host_query": "GL_SUBGROUP_SIZE_KHR",
+      "mismatch_behavior": "reject-before-shader-compilation-or-dispatch"
+    },
+    "toolchain_validation": {
+      "compiler": "glslangValidator",
+      "compiler_target": "OpenGL/SPIR-V 1.3",
+      "validator": "spirv-val",
+      "validator_target": "SPIR-V 1.3",
+      "compiled_artifact_count": 2,
+      "validated_artifact_count": 2,
+      "status": "passed"
+    },
+    "runtime_compatibility": {
+      "adapter_preflight_included": true,
+      "compatible_width_device_test": 4,
+      "logsumexp_required_width": 32,
+      "logsumexp_runtime_execution_attempted": false,
+      "blocked_by": "https://github.com/CrossGL/crosstl/issues/1894"
+    },
+    "runtime_integration_included": false,
+    "numerical_parity_claimed": false,
+    "runtime_parity_claimed": false
+  },
   "opengl_fft_workgroup_pointer_status": {
     "status": "blocked-after-provenance",
     "source": "mlx/backend/metal/kernels/fft.metal",
@@ -2618,6 +2679,7 @@
     "https://github.com/CrossGL/crosstl/issues/1696",
     "https://github.com/CrossGL/crosstl/issues/1735",
     "https://github.com/CrossGL/crosstl/issues/1786",
+    "https://github.com/CrossGL/crosstl/issues/1894",
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1462",
     "https://github.com/CrossGL/crosstl/issues/1676",

--- a/docs/source/project-porting.rst
+++ b/docs/source/project-porting.rst
@@ -2290,14 +2290,24 @@ execution identities, and checks the generated ``WaveSize`` and shader-profile
 contract. A subgroup-width rule can accompany a per-entry workgroup-size rule;
 both must resolve to the same materialized entry identities.
 
-OpenGL cannot enforce an exact subgroup width through this project contract, so
-a matching rule fails before GLSL generation with
+OpenGL accepts exact widths ``1``, ``2``, ``4``, ``8``, ``16``, ``32``, ``64``,
+and ``128`` through a device-compatibility contract. Generated GLSL requires
+``GL_KHR_shader_subgroup_basic``, declares
+``CROSSTL_REQUIRED_SUBGROUP_WIDTH``, and guards the compute entry before any
+translated work. Execution metadata requires the host extension
+``GL_KHR_shader_subgroup`` and the ``GL_SUBGROUP_SIZE_KHR`` query. The built-in
+Python and generated C++ OpenGL adapters compare that query with the artifact
+contract before shader compilation, resource allocation, or dispatch, and
+report a structured mismatch instead of running on an incompatible device.
+Report validation verifies the extension, marker, guard, execution metadata,
+and deterministic identities. The shader guard is a defensive fallback; hosts
+must honor the recorded pre-dispatch check.
+
+Every other target currently fails closed before generation with
 ``project.translate.subgroup-width-enforcement-unsupported`` and reason
-``opengl-enforcement-unavailable``. Every other target currently fails closed
-with the same diagnostic and reason ``target-not-supported``. These failures
-record the missing ``execution.subgroup-width-specialization`` capability, rule
-provenance, and the supported target set without emitting a misleading target
-artifact.
+``target-not-supported``. These failures record the missing
+``execution.subgroup-width-specialization`` capability, rule provenance, and
+the supported target set without emitting a misleading target artifact.
 
 Subgroup-width specialization establishes a compiler-facing shader contract
 only. It does not dispatch device work, verify hardware support, integrate a
@@ -2317,12 +2327,13 @@ The pinned MLX project-porting gate applies this contract to
 named variants, selecting ``has_w=false`` by declaration name and ``"20"=true``
 by numeric ID. The gate checks report provenance and concrete materialization,
 then compiles a reflected compute entry from each generated HLSL artifact with
-DXC on Windows. Its unconfigured OpenGL project checks deferred
-``layout(constant_id = 20)`` emission and validates generated OpenGL SPIR-V on
-Linux. This proves translation and native compilation only; it does not claim
-RMSNorm numerical runtime parity or full MLX test-suite support. Numerical
-execution also requires host dispatch values to match each compiled artifact's
-workgroup-size contract.
+DXC on Windows. Its current OpenGL proof leaves the subgroup rule unconfigured,
+checks deferred ``layout(constant_id = 20)`` emission, and validates generated
+OpenGL SPIR-V on Linux. The separate bounded LogSumExp proof exercises the
+OpenGL exact-width contract. These checks prove translation and native
+compilation only; they do not claim RMSNorm numerical runtime parity or full MLX
+test-suite support. Numerical execution also requires host dispatch values to
+match each compiled artifact's workgroup-size and subgroup-width contracts.
 
 ``source_roots`` limits discovery to selected directories. ``include`` and
 ``exclude`` use shell-style patterns against repository-relative paths. Project

--- a/docs/source/support-matrix.rst
+++ b/docs/source/support-matrix.rst
@@ -23,7 +23,7 @@ implicitly supported.
    :header: "Backend", "Target aliases", "Target profiles", "Ext", "Target generator", "Source kind", "Native frontend", "Tests", "Test count", "Unsupported markers", "Docs source"
 
    "DirectX / HLSL", "dx11, dx12, d3d11, d3d12", "directx-11, directx-12", ".hlsl", "crosstl/translator/codegen/directx_codegen.py", "native", "crosstl/backend/DirectX", "tests/test_translator/test_codegen/test_directx_codegen.py, tests/test_backend/test_directx", "1387", "451", "Microsoft Learn HLSL reference; HLSL specification project"
-   "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_arithmetic_conversions.py, tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_translator/test_codegen/test_GLSL_storage_pointer_codegen.py, tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py, tests/test_backend/test_GLSL", "1523", "287", "GLSL 4.60 specification; OpenGL registry"
+   "OpenGL / GLSL", "", "", ".glsl", "crosstl/translator/codegen/GLSL_codegen.py", "native", "crosstl/backend/GLSL", "tests/test_translator/test_arithmetic_conversions.py, tests/test_translator/test_codegen/test_GLSL_codegen.py, tests/test_translator/test_codegen/test_GLSL_storage_pointer_codegen.py, tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py, tests/test_backend/test_GLSL", "1525", "289", "GLSL 4.60 specification; OpenGL registry"
    "WebGL / GLSL ES", "webgl2, essl, glsl-es", "", ".webgl.glsl", "crosstl/translator/codegen/webgl_codegen.py", "target-only", "", "tests/test_translator/test_arithmetic_conversions.py, tests/test_translator/test_codegen/test_webgl_codegen.py", "59", "40", "WebGL 2.0 specification; OpenGL ES Shading Language 3.00 specification"
    "WebGPU / WGSL", "webgpu", "", ".wgsl", "crosstl/translator/codegen/wgsl_codegen.py", "target-only", "", "tests/test_translator/test_codegen/test_wgsl_codegen.py", "104", "70", "WGSL specification; WebGPU specification"
    "Metal", "", "", ".metal", "crosstl/translator/codegen/metal_codegen.py", "native", "crosstl/backend/Metal", "tests/test_translator/test_codegen/test_metal_codegen.py, tests/test_backend/test_metal", "1645", "564", "Apple Metal resources; Metal Shading Language specification"
@@ -38,7 +38,7 @@ implicitly supported.
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
    "DirectX / HLSL", "84", "1", "2", "0", "0", "0"
-   "OpenGL / GLSL", "83", "1", "2", "1", "0", "0"
+   "OpenGL / GLSL", "84", "1", "2", "0", "0", "0"
    "WebGL / GLSL ES", "43", "1", "23", "17", "3", "0"
    "WebGPU / WGSL", "47", "1", "21", "15", "3", "0"
    "Metal", "71", "1", "4", "8", "3", "0"
@@ -59,7 +59,7 @@ scope for graphics backend completion work.
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
    "DirectX / HLSL", "84", "1", "2", "0", "0", "0"
-   "OpenGL / GLSL", "83", "1", "2", "1", "0", "0"
+   "OpenGL / GLSL", "84", "1", "2", "0", "0", "0"
    "Metal", "71", "1", "4", "8", "3", "0"
 
 .. csv-table:: DirectX/OpenGL/Metal actionable backlog
@@ -82,7 +82,7 @@ inspection, diagnostics, validation, and corpus-coverage rows.
    :header: "Backend", "supported", "partial", "diagnostic", "validated_rejection", "unsupported", "unknown"
 
    "DirectX / HLSL", "41", "1", "1", "0", "0", "0"
-   "OpenGL / GLSL", "40", "1", "1", "1", "0", "0"
+   "OpenGL / GLSL", "41", "1", "1", "0", "0", "0"
    "WebGL / GLSL ES", "30", "1", "1", "8", "3", "0"
    "WebGPU / WGSL", "30", "1", "1", "8", "3", "0"
    "Metal", "30", "1", "1", "8", "3", "0"
@@ -232,7 +232,7 @@ Each category below uses the status codes from the legend.
    "Source entry-point discovery", "P", "P", "P", "P", "P", "P", "P", "P", "P", "P", "P"
    "Entry-scoped project artifacts", "Y", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
    "Per-entry workgroup size specialization", "Y", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
-   "Per-entry subgroup width specialization", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R"
+   "Per-entry subgroup width specialization", "Y", "Y", "R", "R", "R", "R", "R", "R", "R", "R", "R"
    "Optional validation hooks", "D", "D", "D", "D", "D", "D", "D", "D", "D", "D", "D"
    "Migration action report", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"
    "Runtime integration planning", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"

--- a/support/features.json
+++ b/support/features.json
@@ -7964,10 +7964,15 @@
           ]
         },
         "opengl": {
-          "status": "validated_rejection",
-          "notes": "A matching [project.subgroup_width_rules] entry fails closed before OpenGL code generation because the target cannot enforce the requested exact subgroup width. The project.translate.subgroup-width-enforcement-unsupported diagnostic reports reason opengl-enforcement-unavailable, the execution.subgroup-width-specialization capability, rule provenance, and the supported target set, and no GLSL artifact is emitted. This support covers structured shader/kernel artifact rejection only; runtime execution and numerical parity are not established.",
+          "status": "supported",
+          "notes": "Per-source [project.subgroup_width_rules] integral expressions and dispatch-derived subgroup widths are evaluated for entry-scoped OpenGL compute artifacts. OpenGL accepts exact widths 1, 2, 4, 8, 16, 32, 64, and 128, requires GL_KHR_shader_subgroup_basic in GLSL, emits a CROSSTL_REQUIRED_SUBGROUP_WIDTH marker and entry guard, and records the GL_KHR_shader_subgroup host capability plus GL_SUBGROUP_SIZE_KHR pre-dispatch query. The built-in Python and generated C++ runtime adapters reject an incompatible device before shader compilation or resource setup. Report validation verifies the generated extension, marker, guard, execution metadata, and deterministic identities. This support covers generated shader/kernel artifacts and compatibility-gated execution contracts; runtime execution and numerical parity are not established in general.",
           "evidence": [
-            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_fail_closed_without_target_enforcement"
+            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_emit_guarded_opengl_contracts",
+            "tests/test_translator/test_project_dispatch_artifact_generation.py::def test_opengl_enforces_exact_dispatch_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_probes_exact_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device",
+            "tests/test_translator/test_native_opengl_adapter.py::def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle",
+            "tests/test_translator/test_mlx_logsumexp_native_loader.py::def test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
           ]
         },
         "metal": {

--- a/support/generated/graphics-backend-roadmap.json
+++ b/support/generated/graphics-backend-roadmap.json
@@ -2671,10 +2671,15 @@
         },
         "opengl": {
           "evidence": [
-            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_fail_closed_without_target_enforcement"
+            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_emit_guarded_opengl_contracts",
+            "tests/test_translator/test_project_dispatch_artifact_generation.py::def test_opengl_enforces_exact_dispatch_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_probes_exact_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device",
+            "tests/test_translator/test_native_opengl_adapter.py::def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle",
+            "tests/test_translator/test_mlx_logsumexp_native_loader.py::def test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
           ],
-          "notes": "A matching [project.subgroup_width_rules] entry fails closed before OpenGL code generation because the target cannot enforce the requested exact subgroup width. The project.translate.subgroup-width-enforcement-unsupported diagnostic reports reason opengl-enforcement-unavailable, the execution.subgroup-width-specialization capability, rule provenance, and the supported target set, and no GLSL artifact is emitted. This support covers structured shader/kernel artifact rejection only; runtime execution and numerical parity are not established.",
-          "status": "validated_rejection"
+          "notes": "Per-source [project.subgroup_width_rules] integral expressions and dispatch-derived subgroup widths are evaluated for entry-scoped OpenGL compute artifacts. OpenGL accepts exact widths 1, 2, 4, 8, 16, 32, 64, and 128, requires GL_KHR_shader_subgroup_basic in GLSL, emits a CROSSTL_REQUIRED_SUBGROUP_WIDTH marker and entry guard, and records the GL_KHR_shader_subgroup host capability plus GL_SUBGROUP_SIZE_KHR pre-dispatch query. The built-in Python and generated C++ runtime adapters reject an incompatible device before shader compilation or resource setup. Report validation verifies the generated extension, marker, guard, execution metadata, and deterministic identities. This support covers generated shader/kernel artifacts and compatibility-gated execution contracts; runtime execution and numerical parity are not established in general.",
+          "status": "supported"
         }
       }
     },
@@ -5414,10 +5419,10 @@
       "opengl": {
         "diagnostic": 2,
         "partial": 1,
-        "supported": 83,
+        "supported": 84,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 1
+        "validated_rejection": 0
       }
     }
   },

--- a/support/generated/project-porting-roadmap.json
+++ b/support/generated/project-porting-roadmap.json
@@ -3339,10 +3339,15 @@
         },
         "opengl": {
           "evidence": [
-            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_fail_closed_without_target_enforcement"
+            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_emit_guarded_opengl_contracts",
+            "tests/test_translator/test_project_dispatch_artifact_generation.py::def test_opengl_enforces_exact_dispatch_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_probes_exact_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device",
+            "tests/test_translator/test_native_opengl_adapter.py::def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle",
+            "tests/test_translator/test_mlx_logsumexp_native_loader.py::def test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
           ],
-          "notes": "A matching [project.subgroup_width_rules] entry fails closed before OpenGL code generation because the target cannot enforce the requested exact subgroup width. The project.translate.subgroup-width-enforcement-unsupported diagnostic reports reason opengl-enforcement-unavailable, the execution.subgroup-width-specialization capability, rule provenance, and the supported target set, and no GLSL artifact is emitted. This support covers structured shader/kernel artifact rejection only; runtime execution and numerical parity are not established.",
-          "status": "validated_rejection"
+          "notes": "Per-source [project.subgroup_width_rules] integral expressions and dispatch-derived subgroup widths are evaluated for entry-scoped OpenGL compute artifacts. OpenGL accepts exact widths 1, 2, 4, 8, 16, 32, 64, and 128, requires GL_KHR_shader_subgroup_basic in GLSL, emits a CROSSTL_REQUIRED_SUBGROUP_WIDTH marker and entry guard, and records the GL_KHR_shader_subgroup host capability plus GL_SUBGROUP_SIZE_KHR pre-dispatch query. The built-in Python and generated C++ runtime adapters reject an incompatible device before shader compilation or resource setup. Report validation verifies the generated extension, marker, guard, execution metadata, and deterministic identities. This support covers generated shader/kernel artifacts and compatibility-gated execution contracts; runtime execution and numerical parity are not established in general.",
+          "status": "supported"
         },
         "rust": {
           "evidence": [
@@ -12069,10 +12074,10 @@
       "opengl": {
         "diagnostic": 1,
         "partial": 1,
-        "supported": 40,
+        "supported": 41,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 1
+        "validated_rejection": 0
       },
       "rust": {
         "diagnostic": 1,

--- a/support/generated/support-matrix.json
+++ b/support/generated/support-matrix.json
@@ -152,7 +152,7 @@
         "path": "crosstl/backend/GLSL"
       },
       "signals": {
-        "unsupported_marker_count": 287,
+        "unsupported_marker_count": 289,
         "unsupported_marker_samples": [
           {
             "path": "crosstl/translator/codegen/GLSL_codegen.py",
@@ -248,7 +248,7 @@
           "tests/test_translator/test_codegen/test_GLSL_workgroup_pointer_codegen.py",
           "tests/test_backend/test_GLSL"
         ],
-        "test_count": 1523
+        "test_count": 1525
       },
       "translator_codegen": {
         "exists": true,
@@ -9763,10 +9763,15 @@
         },
         "opengl": {
           "evidence": [
-            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_fail_closed_without_target_enforcement"
+            "tests/test_translator/test_project_subgroup_width_rules.py::def test_subgroup_width_rules_emit_guarded_opengl_contracts",
+            "tests/test_translator/test_project_dispatch_artifact_generation.py::def test_opengl_enforces_exact_dispatch_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_probes_exact_subgroup_width",
+            "tests/test_translator/test_native_runtime_drivers.py::def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device",
+            "tests/test_translator/test_native_opengl_adapter.py::def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle",
+            "tests/test_translator/test_mlx_logsumexp_native_loader.py::def test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
           ],
-          "notes": "A matching [project.subgroup_width_rules] entry fails closed before OpenGL code generation because the target cannot enforce the requested exact subgroup width. The project.translate.subgroup-width-enforcement-unsupported diagnostic reports reason opengl-enforcement-unavailable, the execution.subgroup-width-specialization capability, rule provenance, and the supported target set, and no GLSL artifact is emitted. This support covers structured shader/kernel artifact rejection only; runtime execution and numerical parity are not established.",
-          "status": "validated_rejection"
+          "notes": "Per-source [project.subgroup_width_rules] integral expressions and dispatch-derived subgroup widths are evaluated for entry-scoped OpenGL compute artifacts. OpenGL accepts exact widths 1, 2, 4, 8, 16, 32, 64, and 128, requires GL_KHR_shader_subgroup_basic in GLSL, emits a CROSSTL_REQUIRED_SUBGROUP_WIDTH marker and entry guard, and records the GL_KHR_shader_subgroup host capability plus GL_SUBGROUP_SIZE_KHR pre-dispatch query. The built-in Python and generated C++ runtime adapters reject an incompatible device before shader compilation or resource setup. Report validation verifies the generated extension, marker, guard, execution metadata, and deterministic identities. This support covers generated shader/kernel artifacts and compatibility-gated execution contracts; runtime execution and numerical parity are not established in general.",
+          "status": "supported"
         },
         "rust": {
           "evidence": [
@@ -18483,10 +18488,10 @@
       "opengl": {
         "diagnostic": 2,
         "partial": 1,
-        "supported": 83,
+        "supported": 84,
         "unknown": 0,
         "unsupported": 0,
-        "validated_rejection": 1
+        "validated_rejection": 0
       },
       "rust": {
         "diagnostic": 5,

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -3109,6 +3109,26 @@ def test_mlx_project_porting_workflow_runs_pinned_logsumexp_native_loader_proof(
         "- name: Prove pinned MLX LogSumExp Direct3D native-loader execution"
     ) < mlx_porting.index("- name: Run MLX project-porting checks")
 
+    opengl_step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Validate pinned MLX LogSumExp OpenGL dispatch artifacts",
+    )
+    assert "if: runner.os == 'Linux'" in opengl_step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in opengl_step
+    assert 'CROSTL_REQUIRE_MLX_LOGSUMEXP_OPENGL_TOOLCHAIN: "1"' in opengl_step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
+        in opengl_step
+    )
+    assert "-n auto" in opengl_step
+    assert "-k" not in opengl_step
+    assert ci_coverage.workflow_step_after(
+        mlx_porting,
+        "Validate pinned MLX LogSumExp OpenGL dispatch artifacts",
+        "Checkout pinned MLX",
+    )
+
 
 def test_mlx_project_porting_workflow_installs_pinned_warp_runtime():
     mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -2211,6 +2211,44 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert opengl_frontier["runtime_integration_included"] is False
     assert opengl_frontier["runtime_parity_claimed"] is False
 
+    opengl_logsumexp = expected_gaps["opengl_logsumexp_dispatch_status"]
+    assert opengl_logsumexp["commit"] == module.MLX_COMMIT
+    assert opengl_logsumexp["source"] == module.MLX_LOGSUMEXP_SOURCE
+    assert opengl_logsumexp["source_sha256"] == module.MLX_LOGSUMEXP_SHA256
+    assert opengl_logsumexp["target"] == "opengl"
+    assert opengl_logsumexp["dispatch_contract"] == {
+        "path": "demos/integrations/mlx/contracts/logsumexp.dispatch.json",
+        "content_identity": module.MLX_LOGSUMEXP_DISPATCH_CONTENT_IDENTITY,
+        "workload_count": len(module.MLX_LOGSUMEXP_DISPATCH_VARIANTS),
+        "workgroup_sizes": [
+            variant["workgroupSize"]
+            for variant in module.MLX_LOGSUMEXP_DISPATCH_VARIANTS.values()
+        ],
+        "subgroup_width": 32,
+    }
+    assert opengl_logsumexp["project_translation"] == {
+        "unit_count": 1,
+        "artifact_count": 2,
+        "translated_count": 2,
+        "failed_count": 0,
+        "project_diagnostic_count": 0,
+        "entry_point": "block_logsumexp_float32",
+        "target_entry_point": "main",
+    }
+    assert opengl_logsumexp["toolchain_validation"]["status"] == "passed"
+    assert opengl_logsumexp["toolchain_validation"]["compiled_artifact_count"] == 2
+    assert opengl_logsumexp["toolchain_validation"]["validated_artifact_count"] == 2
+    assert opengl_logsumexp["runtime_compatibility"] == {
+        "adapter_preflight_included": True,
+        "compatible_width_device_test": 4,
+        "logsumexp_required_width": 32,
+        "logsumexp_runtime_execution_attempted": False,
+        "blocked_by": "https://github.com/CrossGL/crosstl/issues/1894",
+    }
+    assert opengl_logsumexp["runtime_integration_included"] is False
+    assert opengl_logsumexp["numerical_parity_claimed"] is False
+    assert opengl_logsumexp["runtime_parity_claimed"] is False
+
     opengl_quantized = expected_gaps["opengl_quantized_frontier_status"]
     assert opengl_quantized == module.MLX_OPENGL_QUANTIZED_FRONTIER_EVIDENCE
     assert opengl_quantized["artifact_emitted"] is True
@@ -9452,7 +9490,7 @@ def test_gemv_directx_gap_records_full_compiler_coverage_without_runtime_claims(
         readme
     )
     assert "This establishes exact workgroup-size specialization" in readme
-    assert "It does not establish wave semantics" in readme
+    assert "does not establish wave semantics" in readme
 
 
 def test_gemv_opengl_gap_records_strict_expected_frontier():
@@ -9534,7 +9572,8 @@ def test_gemv_opengl_gap_records_strict_expected_frontier():
     assert "all 225 specializations materialized" in readme
     assert "the base offset is in `[0, 14]`" in readme
     assert "at most element `14` of the 16-element backing" in readme
-    assert "target subgroup-width contract is also not established" in readme
+    assert "does not configure the exact subgroup width" in readme
+    assert "can now gate execution on a device reporting width 32" in readme
     assert "attempts no native compiler" in readme
     assert "does not claim an emitted or runnable GEMV artifact" in readme
 

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -2240,7 +2240,10 @@ def test_expected_gaps_tracks_current_frontier_and_runtime_fixture_counts():
     assert opengl_logsumexp["toolchain_validation"]["validated_artifact_count"] == 2
     assert opengl_logsumexp["runtime_compatibility"] == {
         "adapter_preflight_included": True,
-        "compatible_width_device_test": 4,
+        "compatible_width_device_test": {
+            "artifact_specialized_to_reported_width": True,
+            "width_source": "GL_SUBGROUP_SIZE_KHR",
+        },
         "logsumexp_required_width": 32,
         "logsumexp_runtime_execution_attempted": False,
         "blocked_by": "https://github.com/CrossGL/crosstl/issues/1894",

--- a/tests/test_support_matrix.py
+++ b/tests/test_support_matrix.py
@@ -387,7 +387,7 @@ def test_project_subgroup_width_specialization_support_is_target_scoped():
         backend_id
         for backend_id, support in feature["support"].items()
         if support["status"] == "supported"
-    } == {"directx"}
+    } == {"directx", "opengl"}
 
     directx = feature["support"]["directx"]
     assert "[project.subgroup_width_rules]" in directx["notes"]
@@ -404,16 +404,25 @@ def test_project_subgroup_width_specialization_support_is_target_scoped():
     ) in directx["evidence"]
 
     opengl = feature["support"]["opengl"]
-    assert opengl["status"] == "validated_rejection"
-    assert "opengl-enforcement-unavailable" in opengl["notes"]
-    assert "no GLSL artifact is emitted" in opengl["notes"]
+    assert opengl["status"] == "supported"
+    assert "CROSSTL_REQUIRED_SUBGROUP_WIDTH" in opengl["notes"]
+    assert "GL_SUBGROUP_SIZE_KHR pre-dispatch query" in opengl["notes"]
+    assert "reject an incompatible device before shader compilation" in opengl["notes"]
+    assert (
+        "tests/test_translator/test_project_subgroup_width_rules.py::def "
+        "test_subgroup_width_rules_emit_guarded_opengl_contracts"
+    ) in opengl["evidence"]
+    assert (
+        "tests/test_translator/test_mlx_logsumexp_native_loader.py::def "
+        "test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts"
+    ) in opengl["evidence"]
 
     for backend_id, support in feature["support"].items():
         assert "shader/kernel artifact" in support["notes"]
         assert "runtime execution and numerical parity are not established" in (
             support["notes"]
         )
-        if backend_id == "directx":
+        if backend_id in {"directx", "opengl"}:
             assert support["status"] == "supported"
         else:
             assert support["status"] == "validated_rejection"

--- a/tests/test_translator/test_codegen/test_GLSL_codegen.py
+++ b/tests/test_translator/test_codegen/test_GLSL_codegen.py
@@ -60,6 +60,7 @@ from crosstl.translator.codegen.GLSL_codegen import (
     OpenGLSpecializationConstantError,
     OpenGLStoragePointerError,
     OpenGLStructConstructionError,
+    OpenGLSubgroupWidthError,
     OpenGLTrailingZeroBuiltinError,
     OpenGLWorkgroupPointerError,
     OpenGLWorkgroupSizeError,
@@ -19938,6 +19939,68 @@ def test_glsl_subgroup_builtin_inputs_request_basic_extension(tmp_path):
         spirv_target="spirv1.3",
         validate_spirv=True,
     )
+
+
+@pytest.mark.parametrize("subgroup_width", [4, 32])
+def test_glsl_exact_subgroup_width_emits_guarded_compute_artifact(
+    subgroup_width, tmp_path
+):
+    code = f"""
+    shader GLSLExactSubgroupWidth {{
+        compute {{
+            void main() @ WaveSize({subgroup_width}) {{
+                uint value = gl_LocalInvocationID.x;
+            }}
+        }}
+    }}
+    """
+
+    generated = generate_code(parse_code(tokenize_code(code)))
+
+    marker = f"#define CROSSTL_REQUIRED_SUBGROUP_WIDTH {subgroup_width}u"
+    guard = "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)"
+    assert generated.count("#extension GL_KHR_shader_subgroup_basic : require") == 1
+    assert generated.count(marker) == 1
+    assert generated.count(guard) == 1
+    assert generated.index(guard) < generated.index(
+        "uint value = gl_LocalInvocationID.x;"
+    )
+    assert_glsl_compute_validates_if_available(
+        generated,
+        tmp_path,
+        f"exact_subgroup_width_{subgroup_width}",
+        spirv_target="spirv1.3",
+        validate_spirv=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("stage", "attribute", "reason"),
+    [
+        ("compute", "WaveSize", "source-metadata-not-exact"),
+        ("compute", "WaveSize(4, 8)", "source-metadata-not-exact"),
+        ("compute", "WaveSize(3)", "target-width-unsupported"),
+        ("fragment", "WaveSize(32)", "stage-unsupported"),
+    ],
+)
+def test_glsl_exact_subgroup_width_rejects_invalid_contracts(stage, attribute, reason):
+    return_type = "void" if stage == "compute" else "vec4"
+    body = "" if stage == "compute" else "return vec4(1.0);"
+    semantic = "" if stage == "compute" else " @ SV_Target"
+    code = f"""
+    shader GLSLInvalidExactSubgroupWidth {{
+        {stage} {{
+            {return_type} main() @ {attribute}{semantic} {{
+                {body}
+            }}
+        }}
+    }}
+    """
+
+    with pytest.raises(OpenGLSubgroupWidthError) as raised:
+        generate_code(parse_code(tokenize_code(code)))
+
+    assert raised.value.reason == reason
 
 
 def test_glsl_wave_intrinsics_lower_to_khr_subgroup_builtins():

--- a/tests/test_translator/test_mlx_logsumexp_native_loader.py
+++ b/tests/test_translator/test_mlx_logsumexp_native_loader.py
@@ -24,6 +24,7 @@ from crosstl.project import (
     build_runtime_package,
     load_project_config,
     translate_project,
+    validate_project_report,
 )
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -40,15 +41,18 @@ MLX_LOGSUMEXP_DISPATCH_CONTRACT = (
     ROOT / "demos" / "integrations" / "mlx" / "contracts" / "logsumexp.dispatch.json"
 )
 REQUIRE_PROOF_ENV = "CROSTL_REQUIRE_MLX_LOGSUMEXP_DIRECTX_NATIVE_LOADER"
+REQUIRE_OPENGL_PROOF_ENV = "CROSTL_REQUIRE_MLX_LOGSUMEXP_OPENGL_TOOLCHAIN"
 
 
-def _project_config(*, output_dir: str, dispatch_contract: str) -> str:
+def _project_config(
+    *, output_dir: str, dispatch_contract: str, target: str = "directx"
+) -> str:
     return textwrap.dedent(f"""
         [project]
         source_roots = ["mlx/backend/metal/kernels"]
         include = ["{MLX_LOGSUMEXP_SOURCE}"]
         include_dirs = ["."]
-        targets = ["directx"]
+        targets = ["{target}"]
         output_dir = "{output_dir}"
         dispatch_contracts = ["{dispatch_contract}"]
 
@@ -106,7 +110,10 @@ def _assert_directx_runtime_requirements(source_path: Path, work_dir: Path) -> N
 def _pinned_mlx_root() -> Path:
     root_value = os.environ.get("CROSTL_MLX_ROOT")
     if not root_value:
-        if os.environ.get(REQUIRE_PROOF_ENV) == "1":
+        if any(
+            os.environ.get(name) == "1"
+            for name in (REQUIRE_PROOF_ENV, REQUIRE_OPENGL_PROOF_ENV)
+        ):
             pytest.fail("CROSTL_MLX_ROOT is not configured")
         pytest.skip("CROSTL_MLX_ROOT is not configured")
 
@@ -125,6 +132,90 @@ def _pinned_mlx_root() -> Path:
     assert checkout_commit == MLX_COMMIT
     assert hashlib.sha256(source_path.read_bytes()).hexdigest() == MLX_LOGSUMEXP_SHA256
     return mlx_root
+
+
+def test_pinned_mlx_logsumexp_translates_to_guarded_opengl_artifacts():
+    mlx_root = _pinned_mlx_root()
+    with tempfile.TemporaryDirectory(
+        prefix=".crosstl-logsumexp-opengl-toolchain-",
+        dir=mlx_root,
+    ) as temporary_directory:
+        work_dir = Path(temporary_directory)
+        contract_path = work_dir / "logsumexp.dispatch.json"
+        shutil.copyfile(MLX_LOGSUMEXP_DISPATCH_CONTRACT, contract_path)
+        output_dir = work_dir / "out"
+        config_path = work_dir / "crosstl.toml"
+        config_path.write_text(
+            _project_config(
+                output_dir=output_dir.relative_to(mlx_root).as_posix(),
+                dispatch_contract=contract_path.relative_to(mlx_root).as_posix(),
+                target="opengl",
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        report = translate_project(
+            load_project_config(mlx_root, config_path),
+            targets=("opengl",),
+            output_dir=output_dir.relative_to(mlx_root).as_posix(),
+            format_output=False,
+            validate=True,
+            run_toolchains=True,
+        )
+        payload = report.to_json()
+
+        assert payload["summary"]["unitCount"] == 1
+        assert payload["summary"]["translatedCount"] == 2
+        assert payload["summary"]["failedCount"] == 0
+        artifacts = payload["artifacts"]
+        assert {
+            tuple(artifact["execution"]["entryPoints"][0]["workgroupSize"])
+            for artifact in artifacts
+        } == {(32, 1, 1), (288, 1, 1)}
+        for artifact in artifacts:
+            assert artifact["entryPoint"] == {
+                "source": MLX_LOGSUMEXP_ENTRY,
+                "target": "main",
+                "stage": "compute",
+            }
+            entry = artifact["execution"]["entryPoints"][0]
+            assert entry["subgroupWidth"] == 32
+            assert artifact["execution"]["subgroupWidthEnforcement"] == {
+                "mechanism": "glsl-subgroup-size-guard",
+                "shaderExtension": "GL_KHR_shader_subgroup_basic",
+                "hostExtension": "GL_KHR_shader_subgroup",
+                "hostQuery": "GL_SUBGROUP_SIZE_KHR",
+                "artifactMarker": "CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+                "mismatchBehavior": "reject-before-dispatch",
+            }
+            generated = (mlx_root / artifact["path"]).read_text(encoding="utf-8")
+            assert "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 32u" in generated
+            assert (
+                "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)" in generated
+            )
+            assert "subgroupMax" in generated
+            assert "subgroupAdd" in generated
+
+        toolchain_runs = payload["validation"]["toolchainRuns"]
+        assert len(toolchain_runs) == 2
+        assert {run["status"] for run in toolchain_runs} == {"ok"}
+        assert {run["target"] for run in toolchain_runs} == {"opengl"}
+
+        report_path = work_dir / "opengl-portability-report.json"
+        report.write_json(report_path)
+        assert validate_project_report(report_path)["success"] is True
+        runtime_artifacts = build_runtime_artifact_manifest(report_path)
+        assert runtime_artifacts["success"] is True
+        assert runtime_artifacts["summary"]["artifactCount"] == 2
+        for artifact in runtime_artifacts["artifacts"]:
+            entry_point = artifact["hostInterface"]["entryPoints"][0]
+            assert entry_point["name"] == "main"
+            assert entry_point["executionConfig"]["subgroupWidth"] == 32
+            assert entry_point["executionConfig"]["local_size"] in (
+                [32, 1, 1],
+                [288, 1, 1],
+            )
 
 
 def _expected_scalar_layouts() -> dict[str, dict]:

--- a/tests/test_translator/test_native_opengl_adapter.py
+++ b/tests/test_translator/test_native_opengl_adapter.py
@@ -17,6 +17,7 @@ from crosstl.project.native_opengl_adapter import (
 
 _SHADER_SOURCE = (
     b"#version 430 core\n"
+    b"#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 4u\n"
     b"layout(local_size_x=1, local_size_y=1, local_size_z=1) in;\n"
     b"void main() {}\n"
 )
@@ -210,6 +211,10 @@ def test_generated_opengl_adapter_encodes_platform_and_execution_contracts():
         "CROSSTL_OPENGL43_STATUS_HASH_MISMATCH",
         "CROSSTL_OPENGL43_STATUS_ARTIFACT_PATH_UNSAFE",
         "CROSSTL_OPENGL43_STATUS_SPIRV_CAPABILITY_UNSUPPORTED",
+        "CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_CONTRACT_INVALID",
+        "CROSSTL_OPENGL43_STATUS_SUBGROUP_CAPABILITY_UNSUPPORTED",
+        "CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_MISMATCH",
+        "CROSSTL_OPENGL43_SUBGROUP_SIZE_KHR",
         "CROSSTL_OPENGL43_STATUS_SPECIALIZATION_UNSUPPORTED",
         "CROSSTL_OPENGL43_STATUS_RESOURCE_SET_UNSUPPORTED",
         "CROSSTL_OPENGL43_STATUS_RESOURCE_KIND_UNSUPPORTED",
@@ -289,6 +294,7 @@ def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle(
             static CrossTLOpenGL43UInt fake_uniform_buffer = 4u;
             static CrossTLOpenGL43UInt fake_base_bindings[8] = {6u, 7u};
             static CrossTLOpenGL43UInt fake_current_program = 44u;
+            static CrossTLOpenGL43Int fake_subgroup_width = 4;
             static int fake_compile_success = 1;
             static int fake_link_success = 1;
             static int fake_create_shader_count = 0;
@@ -329,6 +335,8 @@ def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle(
                 } else if (token == CROSSTL_OPENGL43_CURRENT_PROGRAM) {
                     *value = static_cast<CrossTLOpenGL43Int>(
                         fake_current_program);
+                } else if (token == CROSSTL_OPENGL43_SUBGROUP_SIZE_KHR) {
+                    *value = fake_subgroup_width;
                 } else if (
                     token ==
                     CROSSTL_OPENGL43_SHADER_STORAGE_BUFFER_BINDING) {
@@ -788,6 +796,19 @@ def test_generated_opengl_adapter_runs_execution_abi_and_enforces_lifecycle(
                     const char replacement = '#';
                     artifact_file.write(&replacement, 1);
                 }
+
+                fake_subgroup_width = 8;
+                result = EXECUTE_SYMBOL(&request, &adapter);
+                if (result.succeeded ||
+                    result.error.phase !=
+                        CROSSTL_NATIVE_LOADER_PHASE_CREATE_PIPELINE ||
+                    result.error.adapter_status !=
+                        CROSSTL_OPENGL43_STATUS_SUBGROUP_WIDTH_MISMATCH ||
+                    fake_create_shader_count != 0 ||
+                    fake_dispatch_count != 0) {
+                    return 24;
+                }
+                fake_subgroup_width = 4;
 
                 fake_compile_success = 0;
                 state.last_message.clear();

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -4327,74 +4327,86 @@ def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device(tmp_path
     if not sys.platform.startswith("linux"):
         pytest.fail("Exact-width OpenGL subgroup runtime proof requires Linux")
     try:
-        __import__("moderngl")
+        moderngl = __import__("moderngl")
         __import__("OpenGL.GL")
     except ImportError as exc:
         pytest.fail(f"OpenGL subgroup runtime dependency is unavailable: {exc}")
 
-    source = textwrap.dedent("""
-        shader OpenGLExactSubgroupRuntime {
-            compute {
+    context = moderngl.create_standalone_context(require=430, backend="egl")
+    runtime = OpenGLComputeRuntime(
+        context_factory=lambda _moderngl: context,
+        release_context=False,
+    )
+    try:
+        subgroup_width = runtime._query_context_subgroup_width(context)
+        source = textwrap.dedent(f"""
+        shader OpenGLExactSubgroupRuntime {{
+            compute {{
                 void main(
                     RWStructuredBuffer<uint> outputValues @buffer(0),
                     uint localIndex @gl_LocalInvocationIndex
-                ) @ WaveSize(4) {
+                ) @ WaveSize({subgroup_width}) {{
                     outputValues[localIndex] = WaveGetLaneCount();
-                }
+                }}
+            }}
+        }}
+        """)
+        ast = Parser(Lexer(source).get_tokens()).parse()
+        next(iter(ast.stages.values())).execution_config = {
+            "numthreads": (subgroup_width, 1, 1)
+        }
+        generated = GLSLCodeGen().generate(ast)
+        artifact_path = tmp_path / "exact-subgroup-width.comp"
+        artifact_path.write_text(generated, encoding="utf-8")
+        assert f"#define CROSSTL_REQUIRED_SUBGROUP_WIDTH {subgroup_width}u" in generated
+        assert "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)" in generated
+
+        request = NativeRuntimeDispatchRequest(
+            target="opengl",
+            artifact={"target": "opengl"},
+            artifact_path=artifact_path,
+            module_path=artifact_path,
+            loaded_artifact=generated,
+            buffers={
+                "output_values": NativeRuntimeBufferBinding(
+                    name="output_values",
+                    binding=RuntimeResourceBinding(
+                        name="output_values",
+                        kind="storage-buffer",
+                        set=0,
+                        binding=0,
+                        access="write",
+                    ),
+                    source="expectedOutput",
+                    dtype="uint32",
+                    shape=(subgroup_width,),
+                    metadata={"runtimeValueName": "subgroup_width"},
+                )
+            },
+            constants={},
+            dispatch=RuntimeDispatchGeometry(
+                entry_point="main",
+                workgroup_size=(subgroup_width, 1, 1),
+                workgroup_count=(1, 1, 1),
+            ),
+            entry_point="main",
+            execution_config={
+                "local_size": [subgroup_width, 1, 1],
+                "subgroupWidth": subgroup_width,
+            },
+        )
+
+        outputs = runtime.dispatch(None, None, request)
+
+        assert outputs == {
+            "subgroup_width": {
+                "dtype": "uint32",
+                "shape": [subgroup_width],
+                "values": [subgroup_width] * subgroup_width,
             }
         }
-        """)
-    ast = Parser(Lexer(source).get_tokens()).parse()
-    next(iter(ast.stages.values())).execution_config = {"numthreads": (4, 1, 1)}
-    generated = GLSLCodeGen().generate(ast)
-    artifact_path = tmp_path / "exact-subgroup-width.comp"
-    artifact_path.write_text(generated, encoding="utf-8")
-    assert "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 4u" in generated
-    assert "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)" in generated
-
-    request = NativeRuntimeDispatchRequest(
-        target="opengl",
-        artifact={"target": "opengl"},
-        artifact_path=artifact_path,
-        module_path=artifact_path,
-        loaded_artifact=generated,
-        buffers={
-            "output_values": NativeRuntimeBufferBinding(
-                name="output_values",
-                binding=RuntimeResourceBinding(
-                    name="output_values",
-                    kind="storage-buffer",
-                    set=0,
-                    binding=0,
-                    access="write",
-                ),
-                source="expectedOutput",
-                dtype="uint32",
-                shape=(4,),
-                metadata={"runtimeValueName": "subgroup_width"},
-            )
-        },
-        constants={},
-        dispatch=RuntimeDispatchGeometry(
-            entry_point="main",
-            workgroup_size=(4, 1, 1),
-            workgroup_count=(1, 1, 1),
-        ),
-        entry_point="main",
-        execution_config={"local_size": [4, 1, 1], "subgroupWidth": 4},
-    )
-
-    outputs = OpenGLComputeRuntime(context_backends=("egl",)).dispatch(
-        None, None, request
-    )
-
-    assert outputs == {
-        "subgroup_width": {
-            "dtype": "uint32",
-            "shape": [4],
-            "values": [4, 4, 4, 4],
-        }
-    }
+    finally:
+        context.release()
 
 
 def test_opengl_compute_runtime_executes_bounded_wave_shuffle_and_fill_up_on_device(

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -8,6 +8,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import textwrap
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -2790,6 +2791,76 @@ def test_opengl_compute_runtime_probes_and_releases_headless_context(tmp_path):
     assert context.released is True
 
 
+@pytest.mark.parametrize(
+    ("reported_width", "available"),
+    ((4, True), (8, False)),
+)
+def test_opengl_compute_runtime_probes_exact_subgroup_width(
+    tmp_path, reported_width, available
+):
+    class FakeContext:
+        version_code = 460
+        extensions = {"GL_KHR_shader_subgroup"}
+
+        def __init__(self):
+            self.released = False
+
+        def release(self):
+            self.released = True
+
+    class FakeGL:
+        GL_SUBGROUP_SIZE_KHR = 0x9532
+
+        @staticmethod
+        def glGetIntegerv(token):
+            assert token == FakeGL.GL_SUBGROUP_SIZE_KHR
+            return reported_width
+
+    context = FakeContext()
+
+    def load_module(name):
+        return FakeGL if name == "OpenGL.GL" else object()
+
+    runtime = OpenGLComputeRuntime(
+        module_loader=load_module,
+        context_factory=lambda module: context,
+    )
+    request = RuntimeExecutionRequest(
+        fixture=RuntimeFixture(
+            id="opengl-subgroup-width",
+            selector=RuntimeArtifactSelector(target="opengl"),
+            entry_point="main",
+        ),
+        artifact={"target": "opengl", "path": "out/opengl/width.glsl"},
+        artifact_path=tmp_path / "out" / "opengl" / "width.glsl",
+        project_root=tmp_path,
+        adapter_contract=RuntimeAdapterContract(
+            entry_points=(
+                RuntimeEntryPoint(
+                    name="main",
+                    stage="compute",
+                    execution_config={
+                        "local_size": [4, 1, 1],
+                        "subgroupWidth": 4,
+                    },
+                ),
+            )
+        ),
+    )
+
+    availability = runtime.is_available(None, request)
+
+    assert availability.available is available
+    assert availability.details["requiredSubgroupWidth"] == 4
+    assert availability.details["subgroupWidth"] == reported_width
+    if available:
+        assert availability.details["subgroupWidthQuery"] == ("GL_SUBGROUP_SIZE_KHR")
+    else:
+        assert availability.details["reasonKind"] == "subgroup-width-mismatch"
+        assert availability.details["mismatchBehavior"] == "reject-before-dispatch"
+    assert context.released is True
+
+
 def test_opengl_compute_runtime_probe_preserves_caller_owned_context(tmp_path):
     class FakeContext:
         version_code = 460
@@ -2871,6 +2942,64 @@ def test_opengl_compute_runtime_rechecks_context_version_at_dispatch(tmp_path):
     assert excinfo.value.details["requiredVersionCode"] == 430
     assert excinfo.value.details["versionCode"] == 420
     assert context.released is True
+
+
+def test_opengl_compute_runtime_rejects_subgroup_mismatch_before_setup(tmp_path):
+    events = []
+
+    class FakeContext:
+        version_code = 460
+        extensions = {"GL_KHR_shader_subgroup"}
+
+        def compute_shader(self, source):
+            events.append(("compile", source))
+            raise AssertionError("mismatched subgroup width compiled a shader")
+
+        def buffer(self, **kwargs):
+            events.append(("buffer", kwargs))
+            raise AssertionError("mismatched subgroup width allocated a buffer")
+
+        def release(self):
+            events.append(("release", None))
+
+    class FakeGL:
+        GL_SUBGROUP_SIZE_KHR = 0x9532
+
+        @staticmethod
+        def glGetIntegerv(token):
+            assert token == FakeGL.GL_SUBGROUP_SIZE_KHR
+            events.append(("query", token))
+            return 4
+
+    context = FakeContext()
+
+    def load_module(name):
+        return FakeGL if name == "OpenGL.GL" else object()
+
+    runtime = OpenGLComputeRuntime(
+        module_loader=load_module,
+        context_factory=lambda module: context,
+    )
+    request = _opengl_dispatch_request(tmp_path)
+    request = NativeRuntimeDispatchRequest(
+        **{
+            **request.__dict__,
+            "loaded_artifact": (
+                "#version 450 core\n"
+                "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 32u\n"
+                "void main() {}\n"
+            ),
+            "execution_config": {"local_size": [1, 1, 1], "subgroupWidth": 32},
+        }
+    )
+
+    with pytest.raises(RuntimeAdapterSetupError) as excinfo:
+        runtime.dispatch(None, None, request)
+
+    assert excinfo.value.details["reasonKind"] == "subgroup-width-mismatch"
+    assert excinfo.value.details["requiredSubgroupWidth"] == 32
+    assert excinfo.value.details["subgroupWidth"] == 4
+    assert events == [("query", 0x9532), ("release", None)]
 
 
 def test_opengl_compute_runtime_reports_missing_spirv_extension(tmp_path):
@@ -4187,6 +4316,85 @@ def test_opengl_bounded_wave_shuffle_and_fill_up_translation_and_manifest_plan(
     tmp_path,
 ):
     _prepare_opengl_bounded_wave_shuffle_runtime_fixture(tmp_path)
+
+
+def test_opengl_compute_runtime_executes_exact_subgroup_width_on_device(tmp_path):
+    if os.environ.get("CROSTL_RUN_OPENGL_EXACT_SUBGROUP_DEVICE_TEST") != "1":
+        pytest.skip(
+            "set CROSTL_RUN_OPENGL_EXACT_SUBGROUP_DEVICE_TEST=1 to run the "
+            "exact-width OpenGL subgroup test"
+        )
+    if not sys.platform.startswith("linux"):
+        pytest.fail("Exact-width OpenGL subgroup runtime proof requires Linux")
+    try:
+        __import__("moderngl")
+        __import__("OpenGL.GL")
+    except ImportError as exc:
+        pytest.fail(f"OpenGL subgroup runtime dependency is unavailable: {exc}")
+
+    source = textwrap.dedent("""
+        shader OpenGLExactSubgroupRuntime {
+            compute {
+                void main(
+                    RWStructuredBuffer<uint> outputValues @buffer(0),
+                    uint localIndex @gl_LocalInvocationIndex
+                ) @ WaveSize(4) {
+                    outputValues[localIndex] = WaveGetLaneCount();
+                }
+            }
+        }
+        """)
+    ast = Parser(Lexer(source).get_tokens()).parse()
+    next(iter(ast.stages.values())).execution_config = {"numthreads": (4, 1, 1)}
+    generated = GLSLCodeGen().generate(ast)
+    artifact_path = tmp_path / "exact-subgroup-width.comp"
+    artifact_path.write_text(generated, encoding="utf-8")
+    assert "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 4u" in generated
+    assert "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)" in generated
+
+    request = NativeRuntimeDispatchRequest(
+        target="opengl",
+        artifact={"target": "opengl"},
+        artifact_path=artifact_path,
+        module_path=artifact_path,
+        loaded_artifact=generated,
+        buffers={
+            "output_values": NativeRuntimeBufferBinding(
+                name="output_values",
+                binding=RuntimeResourceBinding(
+                    name="output_values",
+                    kind="storage-buffer",
+                    set=0,
+                    binding=0,
+                    access="write",
+                ),
+                source="expectedOutput",
+                dtype="uint32",
+                shape=(4,),
+                metadata={"runtimeValueName": "subgroup_width"},
+            )
+        },
+        constants={},
+        dispatch=RuntimeDispatchGeometry(
+            entry_point="main",
+            workgroup_size=(4, 1, 1),
+            workgroup_count=(1, 1, 1),
+        ),
+        entry_point="main",
+        execution_config={"local_size": [4, 1, 1], "subgroupWidth": 4},
+    )
+
+    outputs = OpenGLComputeRuntime(context_backends=("egl",)).dispatch(
+        None, None, request
+    )
+
+    assert outputs == {
+        "subgroup_width": {
+            "dtype": "uint32",
+            "shape": [4],
+            "values": [4, 4, 4, 4],
+        }
+    }
 
 
 def test_opengl_compute_runtime_executes_bounded_wave_shuffle_and_fill_up_on_device(

--- a/tests/test_translator/test_project_dispatch_artifact_generation.py
+++ b/tests/test_translator/test_project_dispatch_artifact_generation.py
@@ -5,6 +5,7 @@ import textwrap
 
 import pytest
 
+import crosstl.project.pipeline as project_pipeline
 from crosstl.project import (
     DISPATCH_CONTRACT_KIND,
     DISPATCH_CONTRACT_SCHEMA_VERSION,
@@ -605,7 +606,7 @@ def test_directx_enforces_exact_dispatch_subgroup_width(tmp_path):
     assert "subgroupWidthEnforcement" in invalid_report["message"]
 
 
-def test_opengl_fails_closed_for_exact_dispatch_subgroup_width(tmp_path):
+def test_opengl_enforces_exact_dispatch_subgroup_width(tmp_path):
     root, config = _write_project(tmp_path, subgroup_width=32)
 
     report = translate_project(
@@ -616,37 +617,55 @@ def test_opengl_fails_closed_for_exact_dispatch_subgroup_width(tmp_path):
     )
     payload = report.to_json()
 
-    assert payload["summary"]["translatedCount"] == 1
-    assert payload["summary"]["failedCount"] == 1
+    assert payload["summary"]["translatedCount"] == 2
+    assert payload["summary"]["failedCount"] == 0
     planned_job = payload["project"]["dispatchArtifactPlan"]["artifacts"][0]
     assert planned_job["subgroupWidth"] == 32
     artifact = _artifacts_for(payload, "kernels/planned.cgl", target="opengl")[0]
-    assert artifact["status"] == "failed"
+    assert artifact["status"] == "translated"
     assert artifact["dispatchArtifact"] == planned_job
-    assert not (root / artifact["path"]).exists()
-
-    diagnostic = next(
-        item
-        for item in payload["diagnostics"]
-        if item["code"] == "project.translate.subgroup-width-invalid"
-    )
-    assert diagnostic["message"] == (
-        "The target cannot enforce an exact host dispatch subgroup width."
-    )
-    assert diagnostic["target"] == "opengl"
-    assert diagnostic["checkKind"] == "execution-specialization"
-    assert diagnostic["missingCapabilities"] == [
-        "execution.subgroup-width-specialization"
-    ]
-    assert diagnostic["details"]["executionSpecialization"] == {
-        "reason": "target-not-enforceable",
-        "sourceEntryPoints": ["main"],
-        "subgroupWidth": 32,
+    execution = artifact["execution"]
+    assert execution["entryPoints"][0]["targetEntryPoint"] == "main"
+    assert execution["entryPoints"][0]["workgroupSize"] == [32, 1, 1]
+    assert execution["entryPoints"][0]["subgroupWidth"] == 32
+    assert execution["subgroupWidthEnforcement"] == {
+        "mechanism": "glsl-subgroup-size-guard",
+        "shaderExtension": "GL_KHR_shader_subgroup_basic",
+        "hostExtension": "GL_KHR_shader_subgroup",
+        "hostQuery": "GL_SUBGROUP_SIZE_KHR",
+        "artifactMarker": "CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+        "mismatchBehavior": "reject-before-dispatch",
     }
+    generated_path = root / artifact["path"]
+    generated = generated_path.read_text(encoding="utf-8")
+    assert (
+        "layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;" in generated
+    )
+    assert "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 32u" in generated
+    assert "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)" in generated
 
     report_path = root / "opengl-report.json"
     report.write_json(report_path)
     validation = validate_project_report(report_path)
-    assert "project.validate.invalid-report" not in {
-        item["code"] for item in validation["diagnostics"]
-    }
+    assert validation["success"] is True
+
+    generated_path.write_text(
+        generated.replace(
+            "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 32u",
+            "#define CROSSTL_REQUIRED_SUBGROUP_WIDTH 16u",
+        ),
+        encoding="utf-8",
+    )
+    artifact["generatedHash"] = project_pipeline._source_hash(generated_path)
+    artifact["generatedSizeBytes"] = generated_path.stat().st_size
+    tampered_path = _write_report(root, payload, "opengl-tampered-report.json")
+    tampered_validation = validate_project_report(tampered_path)
+    assert tampered_validation["success"] is False
+    mismatch = next(
+        item
+        for item in tampered_validation["diagnostics"]
+        if item["code"] == "project.validate.subgroup-width-contract-mismatch"
+    )
+    assert mismatch["details"]["executionSpecialization"]["reason"] == (
+        "target-output-mismatch"
+    )

--- a/tests/test_translator/test_project_subgroup_width_rules.py
+++ b/tests/test_translator/test_project_subgroup_width_rules.py
@@ -146,10 +146,60 @@ def test_subgroup_width_rule_join_is_independent_of_record_order(tmp_path, monke
     )
 
 
+@pytest.mark.parametrize("with_workgroup", (False, True))
+def test_subgroup_width_rules_emit_guarded_opengl_contracts(tmp_path, with_workgroup):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_fixture(repo)
+
+    report = project_api.translate_project(
+        _config(repo, targets=("opengl",), with_workgroup=with_workgroup),
+        format_output=False,
+        validate=True,
+    )
+    payload = report.to_json()
+
+    assert payload["summary"]["translatedCount"] == 2
+    assert payload["summary"]["failedCount"] == 0
+    assert len(payload["artifacts"]) == 2
+    assert {artifact["entryPoint"]["source"] for artifact in payload["artifacts"]} == {
+        "wave32",
+        "wave64",
+    }
+    for artifact in payload["artifacts"]:
+        execution = artifact["execution"]
+        assert execution["sourceEntryPoints"] == [artifact["entryPoint"]["source"]]
+        assert len(execution["entryPoints"]) == 1
+        entry = execution["entryPoints"][0]
+        assert entry["targetEntryPoint"] == "main"
+        expected_width = 32 if entry["sourceEntryPoint"] == "wave32" else 64
+        assert entry["subgroupWidth"] == expected_width
+        if with_workgroup:
+            expected_y = 1 if expected_width == 32 else 2
+            assert entry["workgroupSize"] == [expected_width, expected_y, 1]
+        assert execution["subgroupWidthEnforcement"] == {
+            "mechanism": "glsl-subgroup-size-guard",
+            "shaderExtension": "GL_KHR_shader_subgroup_basic",
+            "hostExtension": "GL_KHR_shader_subgroup",
+            "hostQuery": "GL_SUBGROUP_SIZE_KHR",
+            "artifactMarker": "CROSSTL_REQUIRED_SUBGROUP_WIDTH",
+            "mismatchBehavior": "reject-before-dispatch",
+        }
+        generated = (repo / artifact["path"]).read_text(encoding="utf-8")
+        marker = f"#define CROSSTL_REQUIRED_SUBGROUP_WIDTH {expected_width}u"
+        guard = "if (gl_SubgroupSize != CROSSTL_REQUIRED_SUBGROUP_WIDTH)"
+        assert generated.count(marker) == 1
+        assert generated.count(guard) == 1
+        assert generated.index(guard) < generated.index("output_[index] =")
+
+    report_path = repo / "opengl-report.json"
+    report.write_json(report_path)
+    assert project_api.validate_project_report(report_path)["success"] is True
+
+
 @pytest.mark.parametrize(
     ("target", "reason"),
     [
-        ("opengl", "opengl-enforcement-unavailable"),
         ("metal", "target-not-supported"),
         ("vulkan", "target-not-supported"),
         ("cuda", "target-not-supported"),


### PR DESCRIPTION
## Summary
- enforce exact subgroup-width contracts in generated OpenGL compute shaders and project reports
- reject incompatible OpenGL devices before dispatch in the Python and generated C++ runtime adapters
- validate two pinned MLX LogSumExp OpenGL artifacts through glslang and SPIR-V tooling on Linux CI
- execute a reduced width-4 subgroup proof on Mesa Zink/Lavapipe and document the width-32 MLX runtime boundary tracked by #1894

## Validation
- pre-commit run --all-files
- pytest -n auto: 17321 passed, 228 skipped
- support matrix update and consistency check
- support issue synchronization dry run
- native OpenGL software-device execution proof

## Scope
This change proves translation and native toolchain acceptance for the pinned MLX LogSumExp artifacts. Full numerical execution on devices without the required subgroup width remains dependent on the portable fallback tracked by #1894.

Support issue traceability: no issue closed
