### PR TITLE
Execute the pinned MLX FFT through the Direct3D loader

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -36,6 +36,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_fft_native_loader.py"
       - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
@@ -70,6 +71,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_fft_native_loader.py"
       - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
       - "tests/test_translator/test_project_translation.py"
@@ -86,7 +88,7 @@ jobs:
     name: MLX Metal project porting (${{ matrix.os }})
     if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
@@ -233,6 +235,15 @@ jobs:
         run: >-
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_logsumexp_native_loader.py::test_pinned_mlx_logsumexp_executes_through_directx_native_loader
+
+      - name: Prove pinned MLX FFT Direct3D native-loader execution
+        if: runner.os == 'Windows'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_FFT_DIRECTX_NATIVE_LOADER: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_fft_native_loader.py::test_pinned_mlx_fft_executes_through_directx_native_loader
 
       - name: Enumerate pinned MLX Metal entry points
         shell: bash

--- a/crosstl/project/host_reflection.py
+++ b/crosstl/project/host_reflection.py
@@ -418,14 +418,18 @@ HLSL_CONSTANT_RE = re.compile(
     r"(?P<name>[A-Za-z_]\w*)\s*=\s*(?P<value>[^;]+);",
     re.IGNORECASE,
 )
-HLSL_SCALAR_BLOCK_MEMBER_RE = re.compile(
-    r"\A\s*(?P<type>float|int|uint)\s+(?P<name>[A-Za-z_]\w*)\s*;\s*\Z",
+HLSL_VALUE_BLOCK_MEMBER_RE = re.compile(
+    r"\A\s*(?P<type>(?P<base>float|int|uint)(?P<width>[1-4])?)\s+"
+    r"(?P<name>[A-Za-z_]\w*)\s*;\s*\Z",
     re.IGNORECASE,
 )
-HLSL_STRUCTURED_SCALAR_RE = re.compile(
-    r"\A(?:RW)?StructuredBuffer\s*<\s*(?P<type>float|int|uint)\s*>\Z",
+HLSL_STRUCTURED_VALUE_RE = re.compile(
+    r"\A(?:RW)?StructuredBuffer\s*<\s*"
+    r"(?P<type>(?P<base>float|int|uint)(?P<width>[1-4])?)\s*>\Z",
     re.IGNORECASE,
 )
+HLSL_DISPATCH_INFO_BUFFER_RE = re.compile(r"\ACrossGLDispatchInfo_*\Z")
+HLSL_DISPATCH_INFO_MEMBER_RE = re.compile(r"\AcrossglNumWorkGroups_*\Z")
 
 SCALAR_PHYSICAL_TYPES = {
     "float": "float32",
@@ -707,9 +711,17 @@ def _reflect_hlsl_source(
             "access": "read",
         }
         body = _braced_body(source, match.end() - 1)
-        scalar_layout = _hlsl_scalar_block_layout(match.group("kind"), body)
+        scalar_layout = _hlsl_value_block_layout(match.group("kind"), body)
         if scalar_layout is not None:
             resource["scalarLayout"] = scalar_layout
+            execution_input = _hlsl_execution_input_contract(
+                match.group("name"), scalar_layout
+            )
+            if execution_input is not None:
+                resource["provenance"] = {
+                    "kind": "generated-execution-input",
+                    "executionInput": execution_input,
+                }
         resources.append(resource)
     for match in HLSL_RESOURCE_RE.finditer(source):
         type_name = " ".join(match.group("type").split())
@@ -722,7 +734,7 @@ def _reflect_hlsl_source(
             "binding": binding,
             "access": _hlsl_resource_access(type_name),
         }
-        scalar_layout = _hlsl_structured_scalar_layout(type_name)
+        scalar_layout = _hlsl_structured_value_layout(type_name)
         if scalar_layout is not None:
             resource["scalarLayout"] = scalar_layout
         resources.append(resource)
@@ -798,16 +810,17 @@ def _braced_body(source: str, opening_brace: int) -> str | None:
     return None
 
 
-def _hlsl_scalar_block_layout(
+def _hlsl_value_block_layout(
     block_kind: str, body: str | None
 ) -> dict[str, Any] | None:
     if block_kind.lower() != "cbuffer" or body is None:
         return None
-    match = HLSL_SCALAR_BLOCK_MEMBER_RE.fullmatch(body)
+    match = HLSL_VALUE_BLOCK_MEMBER_RE.fullmatch(body)
     if match is None:
         return None
-    return _scalar_physical_layout(
-        match.group("type"),
+    return _physical_value_layout(
+        match.group("base"),
+        vector_width=int(match.group("width") or 1),
         member_name=match.group("name"),
         storage_layout="hlsl-constant-buffer",
         alignment_bytes=16,
@@ -816,16 +829,39 @@ def _hlsl_scalar_block_layout(
     )
 
 
-def _hlsl_structured_scalar_layout(type_name: str) -> dict[str, Any] | None:
-    match = HLSL_STRUCTURED_SCALAR_RE.fullmatch(type_name)
+def _hlsl_structured_value_layout(type_name: str) -> dict[str, Any] | None:
+    match = HLSL_STRUCTURED_VALUE_RE.fullmatch(type_name)
     if match is None:
         return None
-    return _scalar_physical_layout(
-        match.group("type"),
+    return _physical_value_layout(
+        match.group("base"),
+        vector_width=int(match.group("width") or 1),
         storage_layout="hlsl-structured-buffer",
         alignment_bytes=4,
         runtime_sized=True,
     )
+
+
+def _hlsl_execution_input_contract(
+    buffer_name: str, layout: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    member_name = layout.get("memberName")
+    if (
+        HLSL_DISPATCH_INFO_BUFFER_RE.fullmatch(buffer_name) is None
+        or not isinstance(member_name, str)
+        or HLSL_DISPATCH_INFO_MEMBER_RE.fullmatch(member_name) is None
+        or layout.get("physicalType") != "uint3"
+        or layout.get("vectorWidth") != 3
+        or layout.get("storageLayout") != "hlsl-constant-buffer"
+    ):
+        return None
+    return {
+        "kind": "dispatch-workgroup-count",
+        "valueSource": "dispatch.workgroupCount",
+        "coordinateSpace": "physical",
+        "dimensions": 3,
+        "memberName": member_name,
+    }
 
 
 GLSL_LAYOUT_RE = re.compile(r"layout\s*\((?P<layout>[^)]*)\)\s*", re.IGNORECASE)
@@ -1046,7 +1082,7 @@ def _glsl_scalar_block_layout(
     if storage == "uniform":
         if runtime_sized or "std140" not in qualifiers:
             return None
-        return _scalar_physical_layout(
+        return _physical_value_layout(
             match.group("type"),
             member_name=match.group("name"),
             storage_layout="std140",
@@ -1056,7 +1092,7 @@ def _glsl_scalar_block_layout(
         )
     if not runtime_sized or "std430" not in qualifiers:
         return None
-    return _scalar_physical_layout(
+    return _physical_value_layout(
         match.group("type"),
         member_name=match.group("name"),
         storage_layout="std430",
@@ -1065,9 +1101,10 @@ def _glsl_scalar_block_layout(
     )
 
 
-def _scalar_physical_layout(
+def _physical_value_layout(
     physical_type: str,
     *,
+    vector_width: int = 1,
     storage_layout: str,
     alignment_bytes: int,
     runtime_sized: bool,
@@ -1075,16 +1112,21 @@ def _scalar_physical_layout(
     block_size_bytes: int | None = None,
 ) -> dict[str, Any]:
     normalized_type = physical_type.lower()
+    element_size_bytes = 4 * vector_width
     layout: dict[str, Any] = {
-        "physicalType": normalized_type,
+        "physicalType": (
+            normalized_type if vector_width == 1 else f"{normalized_type}{vector_width}"
+        ),
         "elementType": SCALAR_PHYSICAL_TYPES[normalized_type],
-        "elementSizeBytes": 4,
-        "elementStrideBytes": 4,
+        "elementSizeBytes": element_size_bytes,
+        "elementStrideBytes": element_size_bytes,
         "alignmentBytes": alignment_bytes,
         "memberOffsetBytes": 0,
         "storageLayout": storage_layout,
         "runtimeSized": runtime_sized,
     }
+    if vector_width != 1:
+        layout["vectorWidth"] = vector_width
     if member_name is not None:
         layout["memberName"] = member_name
     if block_size_bytes is not None:

--- a/crosstl/project/native_loader_dispatch.py
+++ b/crosstl/project/native_loader_dispatch.py
@@ -144,7 +144,8 @@ def build_native_loader_dispatch_request(
     The descriptor remains the source of truth for artifact identity, resource
     coordinates, entry-point metadata, and specialization identities. Callers
     provide values only under the exact reflected binding names and numeric
-    specialization ids.
+    specialization ids. Reflected execution inputs are derived from validated
+    dispatch geometry rather than supplied as ordinary fixture values.
     """
 
     normalized = _validated_descriptor(descriptor)
@@ -156,6 +157,17 @@ def build_native_loader_dispatch_request(
 
     inputs = _typed_values(input_values, role="input")
     outputs = _typed_values(output_values, role="output")
+    dispatch = _dispatch_geometry(
+        dispatch_geometry,
+        entry_point=entry_point["name"],
+        reflected_workgroup_size=_reflected_workgroup_size(entry_point),
+    )
+    inputs = _with_derived_execution_inputs(
+        inputs,
+        normalized["bindings"],
+        dispatch=dispatch,
+        target=target,
+    )
     _validate_value_names(inputs, outputs, normalized["bindings"])
     resource_bindings = _resource_bindings(
         normalized["bindings"],
@@ -168,12 +180,6 @@ def build_native_loader_dispatch_request(
         specialization_values,
         target=target,
     )
-    dispatch = _dispatch_geometry(
-        dispatch_geometry,
-        entry_point=entry_point["name"],
-        reflected_workgroup_size=_reflected_workgroup_size(entry_point),
-    )
-
     runtime_entry_point = RuntimeEntryPoint(
         name=entry_point["name"],
         stage=_COMPUTE_STAGE,
@@ -848,6 +854,87 @@ def _validate_value_names(
         )
 
 
+def _with_derived_execution_inputs(
+    inputs: Mapping[str, RuntimeValue],
+    bindings: Sequence[Mapping[str, Any]],
+    *,
+    dispatch: RuntimeDispatchGeometry,
+    target: str,
+) -> dict[str, RuntimeValue]:
+    result = dict(inputs)
+    for index, binding in enumerate(bindings):
+        provenance = binding.get("provenance")
+        if not isinstance(provenance, Mapping) or "executionInput" not in provenance:
+            continue
+        path = f"$.bindings[{index}].provenance.executionInput"
+        contract = provenance.get("executionInput")
+        if not isinstance(contract, Mapping):
+            raise NativeLoaderDispatchError(
+                "execution-input-invalid",
+                "Reflected execution input metadata must be an object.",
+                path=path,
+                details={"binding": binding.get("name")},
+            )
+        expected_contract = {
+            "kind": "dispatch-workgroup-count",
+            "valueSource": "dispatch.workgroupCount",
+            "coordinateSpace": "physical",
+            "dimensions": 3,
+        }
+        if target != "directx" or any(
+            contract.get(field_name) != expected_value
+            for field_name, expected_value in expected_contract.items()
+        ):
+            raise NativeLoaderDispatchError(
+                "execution-input-unsupported",
+                "The reflected execution input cannot be derived by the selected runtime adapter.",
+                path=path,
+                details={
+                    "binding": binding.get("name"),
+                    "target": target,
+                    "contract": copy.deepcopy(dict(contract)),
+                },
+            )
+        name = binding.get("name")
+        if not isinstance(name, str) or not name:
+            raise NativeLoaderDispatchError(
+                "execution-input-invalid",
+                "Reflected execution input requires a binding name.",
+                path=f"$.bindings[{index}].name",
+            )
+        values = list(_padded_dimensions(dispatch.workgroup_count))
+        derived = RuntimeValue(
+            name=name,
+            kind="buffer",
+            dtype="uint32",
+            shape=(3,),
+            values=values,
+            metadata={
+                "source": "dispatch.workgroupCount",
+                "executionInput": copy.deepcopy(dict(contract)),
+            },
+        )
+        supplied = result.get(name)
+        if supplied is not None and (
+            supplied.dtype != derived.dtype
+            or supplied.shape != derived.shape
+            or _flatten_values(supplied.values) != values
+        ):
+            raise NativeLoaderDispatchError(
+                "execution-input-conflict",
+                "Caller-supplied execution input conflicts with validated dispatch geometry.",
+                path=f"$.inputValues.{name}",
+                details={
+                    "binding": name,
+                    "derivedDtype": derived.dtype,
+                    "derivedShape": list(derived.shape),
+                    "derivedValues": values,
+                },
+            )
+        result[name] = derived
+    return result
+
+
 def _resource_bindings(
     bindings: Sequence[Mapping[str, Any]],
     *,
@@ -1010,7 +1097,7 @@ def _validated_scalar_layout(
     if not isinstance(layout, Mapping):
         raise NativeLoaderDispatchError(
             "resource-layout-unsupported",
-            "Native runtime buffer bindings require a concrete scalar layout.",
+            "Native runtime buffer bindings require a concrete scalar or vector layout.",
             path=path,
             details={"binding": runtime_value.name},
         )
@@ -1019,6 +1106,7 @@ def _validated_scalar_layout(
     element_stride = layout.get("elementStrideBytes")
     alignment = layout.get("alignmentBytes")
     member_offset = layout.get("memberOffsetBytes")
+    vector_width = layout.get("vectorWidth", 1)
     if (
         not isinstance(element_size, int)
         or isinstance(element_size, bool)
@@ -1032,10 +1120,14 @@ def _validated_scalar_layout(
         or not isinstance(member_offset, int)
         or isinstance(member_offset, bool)
         or member_offset < 0
+        or not isinstance(vector_width, int)
+        or isinstance(vector_width, bool)
+        or vector_width < 1
+        or vector_width > 4
     ):
         raise NativeLoaderDispatchError(
             "resource-layout-invalid",
-            "Scalar layout sizes, alignment, and member offset must be concrete integers.",
+            "Resource layout sizes, alignment, vector width, and member offset must be concrete integers.",
             path=path,
             details={
                 "binding": runtime_value.name,
@@ -1043,22 +1135,26 @@ def _validated_scalar_layout(
                 "elementStrideBytes": element_stride,
                 "alignmentBytes": alignment,
                 "memberOffsetBytes": member_offset,
+                "vectorWidth": vector_width,
             },
         )
     physical_type = layout.get("physicalType")
     storage_layout = layout.get("storageLayout")
     runtime_sized = layout.get("runtimeSized")
     expected_physical_type = _PHYSICAL_TYPES[runtime_value.dtype]
+    if vector_width != 1:
+        expected_physical_type = f"{expected_physical_type}{vector_width}"
+    expected_element_size = _DTYPE_SIZES[runtime_value.dtype] * vector_width
     expected_storage_layout = _TARGET_STORAGE_LAYOUTS[target][resource_kind]
     if (
         element_type != runtime_value.dtype
-        or element_size != _DTYPE_SIZES[runtime_value.dtype]
+        or element_size != expected_element_size
         or physical_type != expected_physical_type
         or storage_layout != expected_storage_layout
     ):
         raise NativeLoaderDispatchError(
             "resource-layout-mismatch",
-            "Runtime value or target storage is incompatible with the descriptor scalar layout.",
+            "Runtime value or target storage is incompatible with the descriptor resource layout.",
             path=path,
             details={
                 "binding": runtime_value.name,
@@ -1067,6 +1163,7 @@ def _validated_scalar_layout(
                 "layoutElementSizeBytes": element_size,
                 "layoutPhysicalType": physical_type,
                 "expectedPhysicalType": expected_physical_type,
+                "vectorWidth": vector_width,
                 "layoutStorage": storage_layout,
                 "expectedStorage": expected_storage_layout,
             },
@@ -1074,7 +1171,7 @@ def _validated_scalar_layout(
     if element_stride != element_size or member_offset != 0:
         raise NativeLoaderDispatchError(
             "resource-layout-unsupported",
-            "Native loader dispatch requires a tightly packed scalar at byte offset zero.",
+            "Native loader dispatch requires a tightly packed value at byte offset zero.",
             path=path,
             details={
                 "binding": runtime_value.name,
@@ -1083,11 +1180,28 @@ def _validated_scalar_layout(
                 "memberOffsetBytes": member_offset,
             },
         )
+    scalar_count = math.prod(runtime_value.shape)
+    if scalar_count % vector_width:
+        raise NativeLoaderDispatchError(
+            "resource-layout-mismatch",
+            "Runtime value shape does not contain complete reflected vector elements.",
+            path=path,
+            details={
+                "binding": runtime_value.name,
+                "shape": list(runtime_value.shape),
+                "scalarCount": scalar_count,
+                "vectorWidth": vector_width,
+            },
+        )
     if resource_kind == "buffer":
-        if runtime_sized is not True or alignment != element_size:
+        if (
+            runtime_sized is not True
+            or alignment > element_size
+            or element_size % alignment
+        ):
             raise NativeLoaderDispatchError(
                 "resource-layout-unsupported",
-                "Native loader storage buffers require an exact scalar runtime-array layout.",
+                "Native loader storage buffers require an exact scalar or vector runtime-array layout.",
                 path=path,
                 details={
                     "binding": runtime_value.name,
@@ -1108,10 +1222,11 @@ def _validated_scalar_layout(
         ):
             raise NativeLoaderDispatchError(
                 "resource-layout-unsupported",
-                "Native loader constant buffers require an aligned fixed-size scalar block.",
+                "Native loader constant buffers require an aligned fixed-size value block.",
                 path=path,
                 details={
                     "binding": runtime_value.name,
+                    "vectorWidth": vector_width,
                     "runtimeSized": runtime_sized,
                     "alignmentBytes": alignment,
                     "blockSizeBytes": block_size,

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -3181,6 +3181,8 @@ def _directx_buffer_stride(
     metadata = {**dict(resource.metadata), **dict(binding.metadata)}
     type_name = str(resource.type_name or "").strip()
     normalized_type = re.sub(r"\s+", "", type_name).lower()
+    if namespace == "cbv":
+        return 0
     if namespace != "cbv" and (
         "byteaddressbuffer" in normalized_type
         or ("buffer<" in normalized_type and "structuredbuffer<" not in normalized_type)
@@ -3206,9 +3208,7 @@ def _directx_buffer_stride(
             resource=binding.name,
         )
     else:
-        if namespace == "cbv":
-            stride = 0
-        elif "structuredbuffer" in normalized_type:
+        if "structuredbuffer" in normalized_type:
             match = re.search(r"structuredbuffer<([^>]+)>", normalized_type)
             element_type = match.group(1) if match else ""
             stride = _directx_hlsl_element_stride(element_type)

--- a/crosstl/project/native_runtime_drivers.py
+++ b/crosstl/project/native_runtime_drivers.py
@@ -4164,27 +4164,45 @@ def _scalar_block_size(
 
     element_type = str(raw_layout["elementType"] or "").strip().lower()
     physical_type = str(raw_layout["physicalType"] or "").strip().lower()
+    vector_width = raw_layout.get("vectorWidth", 1)
+    if (
+        not isinstance(vector_width, int)
+        or isinstance(vector_width, bool)
+        or vector_width < 1
+        or vector_width > 4
+    ):
+        raise _scalar_block_error(
+            target,
+            f"{target_name} scalar block {binding.name!r} has an invalid vector width.",
+            "scalar-block-layout-invalid",
+            resource=binding.name,
+            vectorWidth=vector_width,
+        )
     expected_physical_type = {
         "float32": "float",
         "int32": "int",
         "uint32": "uint",
     }[dtype]
+    if vector_width != 1:
+        expected_physical_type = f"{expected_physical_type}{vector_width}"
+    expected_element_size = _dtype_size(dtype) * vector_width
     element_size = integer_fields["elementSizeBytes"]
     element_stride = integer_fields["elementStrideBytes"]
     if (
         element_type != dtype
         or physical_type != expected_physical_type
-        or element_size != _dtype_size(dtype)
+        or element_size != expected_element_size
         or element_stride != element_size
         or payload_size != element_size
     ):
         raise _scalar_block_error(
             target,
-            f"{target_name} constant and uniform buffers support one reflected scalar value.",
+            f"{target_name} constant and uniform buffers support one reflected scalar or vector value.",
             "scalar-block-element-layout-unsupported",
             resource=binding.name,
             dtype=dtype,
             payloadSizeBytes=payload_size,
+            vectorWidth=vector_width,
             elementType=raw_layout["elementType"],
             physicalType=raw_layout["physicalType"],
             expectedPhysicalType=expected_physical_type,

--- a/crosstl/project/runtime_verification.py
+++ b/crosstl/project/runtime_verification.py
@@ -6334,13 +6334,22 @@ def _runtime_value_physical_byte_length(
     layout = _runtime_scalar_layout_signature(value.metadata)
     if not layout:
         layout = _runtime_scalar_layout_signature(binding.metadata)
+    vector_width = layout.get("vectorWidth", 1)
+    if (
+        not isinstance(vector_width, int)
+        or isinstance(vector_width, bool)
+        or vector_width < 1
+        or vector_width > 4
+        or element_count % vector_width
+    ):
+        return None
     stride = layout.get("elementStrideBytes")
     if not isinstance(stride, int) or isinstance(stride, bool) or stride <= 0:
         dtype = _runtime_compatible_dtype(value.dtype)
         stride = _RUNTIME_SCALAR_BYTE_SIZES.get(dtype or "")
     if stride is None:
         return None
-    byte_length = element_count * stride
+    byte_length = (element_count // vector_width) * stride
     block_size = layout.get("blockSizeBytes")
     if (
         isinstance(block_size, int)
@@ -6681,6 +6690,7 @@ def _runtime_scalar_layout_signature(metadata: Mapping[str, Any]) -> dict[str, A
         "elementType",
         "elementSizeBytes",
         "elementStrideBytes",
+        "vectorWidth",
         "alignmentBytes",
         "memberOffsetBytes",
         "storageLayout",

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -452,6 +452,16 @@ python -m pytest -q -n auto `
   -k "directx_compute_runtime_executes_translated_pinned_mlx_arange_on_device"
 ```
 
+The selected 256-point FFT proof uses the same pinned checkout and executes the
+translated artifact through the native loader on Direct3D 12 WARP:
+
+```powershell
+$env:CROSTL_MLX_ROOT = "C:/path/to/mlx"
+$env:CROSTL_REQUIRE_MLX_FFT_DIRECTX_NATIVE_LOADER = "1"
+python -m pytest -q -n auto `
+  tests/test_translator/test_mlx_fft_native_loader.py::test_pinned_mlx_fft_executes_through_directx_native_loader
+```
+
 On macOS, require native compilation of the generated Metal round-trip artifact:
 
 ```bash
@@ -654,11 +664,22 @@ axis order. The replay materializes 24 reachable template specializations and
 because its Rader transform branch is unreachable for this power-of-two plan.
 The generated artifact contains no first-class workgroup pointer residue and is
 locked by SHA-256 and byte count. Windows CI compiles it with DXC using
-`cs_6_2`, `-enable-16bit-types`, and warnings as errors. This is a bounded
-entry-point translation and compiler proof. The aggregate DirectX source
-materialization limit remains tracked by
-[#1916](https://github.com/CrossGL/crosstl/issues/1916), and this check does not
-execute a Direct3D FFT or establish numerical parity with Metal.
+`cs_6_2`, `-enable-16bit-types`, and warnings as errors. It then packages and
+reflects the artifact, requiring 8-byte `float2` strides for the input and
+output resources and a 16-byte constant-buffer allocation for the generated
+`uint3` dispatch input. The native-loader request derives that input from the
+physical workgroup count before Direct3D 12 WARP dispatch and readback.
+
+The runtime check supplies an index-1 complex unit impulse and compares all 256
+complex outputs with the analytical forward DFT unit circle at `2e-4` absolute
+and relative tolerance. This verifies one bounded workload through translation,
+packaging, native execution, and numerical comparison. It does not redirect the
+MLX host runtime, run the MLX test suite, or establish broad FFT or backend
+parity. The aggregate DirectX source materialization limit remains tracked by
+[#1916](https://github.com/CrossGL/crosstl/issues/1916); broader runtime grid and
+resource-layout contracts remain tracked by
+[#1542](https://github.com/CrossGL/crosstl/issues/1542) and
+[#1543](https://github.com/CrossGL/crosstl/issues/1543).
 
 A dedicated project replay now translates the complete pinned `fft.metal`
 source to one standalone OpenGL compute shader with a 4,096-specialization

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -298,7 +298,7 @@
     "runtime_parity_claimed": false
   },
   "directx_fft_translation_status": {
-    "status": "translated-dxc-validated",
+    "status": "translated-dxc-validated-direct3d-executed",
     "source": "mlx/backend/metal/kernels/fft.metal",
     "source_sha256": "3a1fbb38ed64f50a49a20d0c5adb1748d9d06ea20e5931e99aa26be543cb7825",
     "source_size_bytes": 3278,
@@ -389,12 +389,55 @@
       "warnings_as_errors": true,
       "status": "passed"
     },
+    "native_runtime": {
+      "runtime": "direct3d-12-warp",
+      "status": "passed",
+      "test": "tests/test_translator/test_mlx_fft_native_loader.py::test_pinned_mlx_fft_executes_through_directx_native_loader",
+      "workgroup_count": [
+        1,
+        1,
+        1
+      ],
+      "global_size": [
+        1,
+        1,
+        64
+      ],
+      "input": {
+        "kind": "complex-unit-impulse",
+        "index": 1,
+        "shape": [
+          256,
+          2
+        ]
+      },
+      "expected_output": {
+        "kind": "forward-dft-unit-circle",
+        "shape": [
+          256,
+          2
+        ],
+        "absolute_tolerance": 0.0002,
+        "relative_tolerance": 0.0002
+      },
+      "resource_layouts": {
+        "input_element": "float2",
+        "input_stride_bytes": 8,
+        "output_element": "float2",
+        "output_stride_bytes": 8,
+        "dispatch_element": "uint3",
+        "dispatch_block_size_bytes": 16
+      },
+      "dispatch_binding_source": "dispatch.workgroupCount"
+    },
     "aggregate_source_translation": {
       "included": false,
       "tracked_by": "https://github.com/CrossGL/crosstl/issues/1916"
     },
     "tracked_issues": [],
-    "runtime_integration_included": false,
+    "mlx_host_runtime_included": false,
+    "runtime_integration_included": true,
+    "selected_workload_numerical_parity_verified": true,
     "numerical_parity_claimed": false,
     "runtime_parity_claimed": false
   },

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -9918,7 +9918,7 @@ def test_full_corpus_checkpoint_probe_records_verified_resume_coordinate():
     }
 
 
-def test_fft_directx_evidence_records_toolchain_proof_without_runtime_claims():
+def test_fft_directx_evidence_records_selected_native_runtime_proof():
     module = _load_harness()
     gaps = json.loads(
         (ROOT / "demos" / "integrations" / "mlx" / "expected-gaps.json").read_text(
@@ -9927,7 +9927,7 @@ def test_fft_directx_evidence_records_toolchain_proof_without_runtime_claims():
     )
 
     status = gaps["directx_fft_translation_status"]
-    assert status["status"] == "translated-dxc-validated"
+    assert status["status"] == "translated-dxc-validated-direct3d-executed"
     assert status["source"] == module.MLX_FFT_SOURCE
     assert status["source_sha256"] == module.MLX_FFT_SHA256
     assert status["source_size_bytes"] == module.MLX_FFT_SOURCE_SIZE_BYTES
@@ -9978,12 +9978,44 @@ def test_fft_directx_evidence_records_toolchain_proof_without_runtime_claims():
         "warnings_as_errors": True,
         "status": "passed",
     }
+    assert status["native_runtime"] == {
+        "runtime": "direct3d-12-warp",
+        "status": "passed",
+        "test": (
+            "tests/test_translator/test_mlx_fft_native_loader.py::"
+            "test_pinned_mlx_fft_executes_through_directx_native_loader"
+        ),
+        "workgroup_count": [1, 1, 1],
+        "global_size": [1, 1, 64],
+        "input": {
+            "kind": "complex-unit-impulse",
+            "index": 1,
+            "shape": [256, 2],
+        },
+        "expected_output": {
+            "kind": "forward-dft-unit-circle",
+            "shape": [256, 2],
+            "absolute_tolerance": 0.0002,
+            "relative_tolerance": 0.0002,
+        },
+        "resource_layouts": {
+            "input_element": "float2",
+            "input_stride_bytes": 8,
+            "output_element": "float2",
+            "output_stride_bytes": 8,
+            "dispatch_element": "uint3",
+            "dispatch_block_size_bytes": 16,
+        },
+        "dispatch_binding_source": "dispatch.workgroupCount",
+    }
     assert status["aggregate_source_translation"] == {
         "included": False,
         "tracked_by": "https://github.com/CrossGL/crosstl/issues/1916",
     }
     assert status["tracked_issues"] == []
-    assert status["runtime_integration_included"] is False
+    assert status["mlx_host_runtime_included"] is False
+    assert status["runtime_integration_included"] is True
+    assert status["selected_workload_numerical_parity_verified"] is True
     assert status["numerical_parity_claimed"] is False
     assert status["runtime_parity_claimed"] is False
 
@@ -9993,7 +10025,10 @@ def test_fft_directx_evidence_records_toolchain_proof_without_runtime_claims():
     assert "24 reachable template specializations" in readme
     assert "21 of the 22 configured function constants" in readme
     assert "contains no first-class workgroup pointer residue" in readme
-    assert "does not execute a Direct3D FFT or establish numerical parity" in readme
+    assert "Direct3D 12 WARP" in readme
+    assert "index-1 complex unit impulse" in readme
+    assert "`2e-4` absolute and relative tolerance" in readme
+    assert "does not redirect the MLX host runtime" in readme
 
 
 def test_fft_opengl_evidence_records_toolchain_proof_without_runtime_claims():

--- a/tests/test_translator/test_host_reflection.py
+++ b/tests/test_translator/test_host_reflection.py
@@ -215,15 +215,68 @@ def test_glsl_reflection_records_exact_mlx_scalar_block_layouts(tmp_path):
     assert by_name["arangeuint32_step_Args"]["scalarLayout"]["memberName"] == "step"
 
 
+def test_hlsl_reflection_records_exact_vector_resource_layouts(tmp_path):
+    reflection = _reflect_hlsl(
+        tmp_path,
+        """
+        StructuredBuffer<float2> in_ : register(t0);
+        RWStructuredBuffer<float2> out_ : register(u1);
+        cbuffer CrossGLDispatchInfo : register(b4) {
+            uint3 crossglNumWorkGroups;
+        };
+        [numthreads(1, 1, 64)] void CSMain() {}
+        """,
+    )
+
+    by_name = {resource["name"]: resource for resource in reflection["resources"]}
+    vector_buffer_layout = {
+        "physicalType": "float2",
+        "elementType": "float32",
+        "elementSizeBytes": 8,
+        "elementStrideBytes": 8,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer",
+        "runtimeSized": True,
+        "vectorWidth": 2,
+    }
+    assert by_name["in_"]["scalarLayout"] == vector_buffer_layout
+    assert by_name["out_"]["scalarLayout"] == vector_buffer_layout
+    assert by_name["CrossGLDispatchInfo"]["scalarLayout"] == {
+        "physicalType": "uint3",
+        "elementType": "uint32",
+        "elementSizeBytes": 12,
+        "elementStrideBytes": 12,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer",
+        "runtimeSized": False,
+        "vectorWidth": 3,
+        "memberName": "crossglNumWorkGroups",
+        "blockSizeBytes": 16,
+    }
+    assert by_name["CrossGLDispatchInfo"]["provenance"] == {
+        "kind": "generated-execution-input",
+        "executionInput": {
+            "kind": "dispatch-workgroup-count",
+            "valueSource": "dispatch.workgroupCount",
+            "coordinateSpace": "physical",
+            "dimensions": 3,
+            "memberName": "crossglNumWorkGroups",
+        },
+    }
+
+
 def test_source_reflection_does_not_guess_aggregate_or_implicit_layouts(tmp_path):
     hlsl = _reflect_hlsl(
         tmp_path,
         """
+        struct Pair { uint first; uint second; };
         cbuffer Multiple : register(b0) {
             uint first;
             uint second;
         };
-        RWStructuredBuffer<uint2> vectors : register(u0);
+        RWStructuredBuffer<Pair> pairs : register(u0);
         ByteAddressBuffer bytes : register(t0);
         [numthreads(1, 1, 1)] void CSMain() {}
         """,

--- a/tests/test_translator/test_mlx_fft_native_loader.py
+++ b/tests/test_translator/test_mlx_fft_native_loader.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import cmath
+import hashlib
+import json
+import math
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from crosstl.project import (
+    DirectXComputeRuntime,
+    DirectXRuntimeParityAdapter,
+    RuntimeParityExecutor,
+    RuntimeTestAdapterSpec,
+    build_native_loader_abi_descriptor,
+    build_native_loader_dispatch_request,
+    build_runtime_artifact_manifest,
+    build_runtime_loader_manifest,
+    build_runtime_package,
+    load_project_config,
+    translate_project,
+)
+
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_FFT_SOURCE = "mlx/backend/metal/kernels/fft.metal"
+MLX_FFT_SHA256 = (
+    "3a1fbb38ed64f50a49a20d0c5adb1748d9d06ea20e5931e99aa26be543cb7825"
+)
+MLX_FFT_ENTRY = "fft_mem_256_float2_float2"
+MLX_FFT_GENERATED_SHA256 = (
+    "07f9300c2e4860077b344610fbfaa2eadb330e1f9723cb519794f91272bd2289"
+)
+MLX_FFT_GENERATED_SIZE_BYTES = 116160
+MLX_FFT_SIZE = 256
+REQUIRE_PROOF_ENV = "CROSTL_REQUIRE_MLX_FFT_DIRECTX_NATIVE_LOADER"
+
+FFT_SPECIALIZATION_CONSTANTS = {
+    0: False,
+    1: True,
+    2: 4,
+    3: 256,
+    4: 0,
+    5: 0,
+    6: 0,
+    7: 0,
+    8: 0,
+    9: 0,
+    10: 4,
+    11: 0,
+    12: 0,
+    13: 0,
+    14: 0,
+    15: 0,
+    16: 0,
+    17: 0,
+    18: 0,
+    19: 0,
+    20: 0,
+    21: 0,
+}
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _project_config(output_dir: str) -> str:
+    constants = "\n".join(
+        f'"{constant_id}" = {_toml_value(value)}'
+        for constant_id, value in FFT_SPECIALIZATION_CONSTANTS.items()
+    )
+    return f"""
+[project]
+source_roots = ["mlx/backend/metal/kernels"]
+include = ["{MLX_FFT_SOURCE}"]
+include_dirs = ["."]
+targets = ["directx"]
+output_dir = "{output_dir}"
+
+[project.sources]
+"**/*.metal" = "metal"
+
+[[project.index_range_assertions]]
+source = "{MLX_FFT_SOURCE}"
+expression = "batch_idx + index"
+minimum = 0
+maximum = 4294967295
+
+[[project.index_range_assertions]]
+source = "{MLX_FFT_SOURCE}"
+expression = "batch_idx + index + 1"
+minimum = 0
+maximum = 4294967295
+
+[[project.index_range_assertions]]
+source = "{MLX_FFT_SOURCE}"
+expression = "batch_idx + index + next_in"
+minimum = 0
+maximum = 4294967295
+
+[[project.index_range_assertions]]
+source = "{MLX_FFT_SOURCE}"
+expression = "batch_idx + index + next_out"
+minimum = 0
+maximum = 4294967295
+
+[[project.workgroup_access_assertions]]
+source = "{MLX_FFT_SOURCE}"
+entry_point = "{MLX_FFT_ENTRY}"
+function = "*"
+parameter = "*"
+minimum = 0
+maximum = 255
+
+[project.entry_points]
+"{MLX_FFT_SOURCE}" = "{MLX_FFT_ENTRY}"
+
+[project.specialization_constants]
+{constants}
+
+[project.entry_workgroup_size_rules."{MLX_FFT_SOURCE}"]
+"{MLX_FFT_ENTRY}" = [1, 1, 64]
+
+[project.source_options.metal]
+max_template_specializations = 4096
+max_template_materialization_work = 2097152
+""".strip()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _pinned_mlx_root() -> Path:
+    root_value = os.environ.get("CROSTL_MLX_ROOT")
+    if not root_value:
+        if os.environ.get(REQUIRE_PROOF_ENV) == "1":
+            pytest.fail("CROSTL_MLX_ROOT is not configured")
+        pytest.skip("CROSTL_MLX_ROOT is not configured")
+
+    mlx_root = Path(root_value).resolve()
+    source_path = mlx_root / MLX_FFT_SOURCE
+    if not source_path.is_file():
+        pytest.fail(f"Pinned MLX FFT source is missing: {source_path}")
+
+    checkout_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=mlx_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert checkout_commit == MLX_COMMIT
+    assert hashlib.sha256(source_path.read_bytes()).hexdigest() == MLX_FFT_SHA256
+    return mlx_root
+
+
+def _expected_layouts() -> dict[str, dict]:
+    return {
+        "fft_mem_256_float2_float2_n_Constants": {
+            "physicalType": "int",
+            "elementType": "int32",
+            "elementSizeBytes": 4,
+            "elementStrideBytes": 4,
+            "alignmentBytes": 16,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-constant-buffer",
+            "runtimeSized": False,
+            "memberName": "fft_mem_256_float2_float2_n",
+            "blockSizeBytes": 16,
+        },
+        "fft_mem_256_float2_float2_batch_size_Constants": {
+            "physicalType": "int",
+            "elementType": "int32",
+            "elementSizeBytes": 4,
+            "elementStrideBytes": 4,
+            "alignmentBytes": 16,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-constant-buffer",
+            "runtimeSized": False,
+            "memberName": "fft_mem_256_float2_float2_batch_size",
+            "blockSizeBytes": 16,
+        },
+        "CrossGLDispatchInfo": {
+            "physicalType": "uint3",
+            "elementType": "uint32",
+            "elementSizeBytes": 12,
+            "elementStrideBytes": 12,
+            "alignmentBytes": 16,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-constant-buffer",
+            "runtimeSized": False,
+            "vectorWidth": 3,
+            "memberName": "crossglNumWorkGroups",
+            "blockSizeBytes": 16,
+        },
+        "in_": {
+            "physicalType": "float2",
+            "elementType": "float32",
+            "elementSizeBytes": 8,
+            "elementStrideBytes": 8,
+            "alignmentBytes": 4,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-structured-buffer",
+            "runtimeSized": True,
+            "vectorWidth": 2,
+        },
+        "out_": {
+            "physicalType": "float2",
+            "elementType": "float32",
+            "elementSizeBytes": 8,
+            "elementStrideBytes": 8,
+            "alignmentBytes": 4,
+            "memberOffsetBytes": 0,
+            "storageLayout": "hlsl-structured-buffer",
+            "runtimeSized": True,
+            "vectorWidth": 2,
+        },
+    }
+
+
+def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
+    output_dir = work_dir / "out"
+    config_path = work_dir / "crosstl.toml"
+    config_path.write_text(
+        _project_config(output_dir.relative_to(mlx_root).as_posix()) + "\n",
+        encoding="utf-8",
+    )
+    report = translate_project(
+        load_project_config(mlx_root, config_path),
+        targets=("directx",),
+        output_dir=output_dir.relative_to(mlx_root).as_posix(),
+        format_output=False,
+        validate=False,
+    )
+    report_payload = report.to_json()
+
+    assert report_payload["summary"]["unitCount"] == 1
+    assert report_payload["summary"]["translatedCount"] == 1
+    assert report_payload["summary"]["failedCount"] == 0
+    assert report_payload["summary"]["diagnosticCounts"] == {
+        "error": 0,
+        "note": 0,
+        "warning": 0,
+    }, json.dumps(report_payload["diagnostics"], indent=2)
+    artifact = report_payload["artifacts"][0]
+    assert artifact["source"] == MLX_FFT_SOURCE
+    assert artifact["sourceHash"] == {
+        "algorithm": "sha256",
+        "value": MLX_FFT_SHA256,
+    }
+    assert artifact["entryPoint"] == {
+        "source": MLX_FFT_ENTRY,
+        "target": "CSMain",
+        "stage": "compute",
+    }
+    assert artifact["execution"]["entryPoints"][0]["workgroupSize"] == [1, 1, 64]
+    assert artifact["generatedHash"] == {
+        "algorithm": "sha256",
+        "value": MLX_FFT_GENERATED_SHA256,
+    }
+    assert artifact["generatedSizeBytes"] == MLX_FFT_GENERATED_SIZE_BYTES
+    assert len(artifact["templateMaterialization"]["specializations"]) == 24
+    assert artifact["templateMaterialization"]["unsupported"] == []
+
+    report_path = work_dir / "portability-report.json"
+    report.write_json(report_path)
+    runtime_artifacts = build_runtime_artifact_manifest(report_path)
+    assert runtime_artifacts["success"] is True, json.dumps(
+        runtime_artifacts, indent=2
+    )
+    reflected = runtime_artifacts["artifacts"][0]
+    resources = reflected["hostInterface"]["resources"]
+    assert {resource["name"]: resource["scalarLayout"] for resource in resources} == (
+        _expected_layouts()
+    )
+    dispatch_info = next(
+        resource for resource in resources if resource["name"] == "CrossGLDispatchInfo"
+    )
+    assert dispatch_info["provenance"] == {
+        "kind": "generated-execution-input",
+        "executionInput": {
+            "kind": "dispatch-workgroup-count",
+            "valueSource": "dispatch.workgroupCount",
+            "coordinateSpace": "physical",
+            "dimensions": 3,
+            "memberName": "crossglNumWorkGroups",
+        },
+    }
+
+    artifacts_path = work_dir / "runtime-artifacts.json"
+    _write_json(artifacts_path, runtime_artifacts)
+    package_dir = work_dir / "runtime-package"
+    package = build_runtime_package(artifacts_path, package_dir)
+    assert package["success"] is True, json.dumps(package, indent=2)
+    loader_manifest = build_runtime_loader_manifest(
+        package_dir / "runtime-package.json"
+    )
+    assert loader_manifest["success"] is True, json.dumps(loader_manifest, indent=2)
+    assert loader_manifest["summary"]["readyLoadUnitCount"] == 1
+    load_unit = loader_manifest["loadUnits"][0]
+    descriptor = build_native_loader_abi_descriptor(
+        loader_manifest,
+        load_unit_id=load_unit["id"],
+    )
+    assert descriptor["entryPoint"]["executionConfig"] == {
+        "numthreads": [1, 1, 64]
+    }
+    assert {
+        binding["name"]: binding["scalarLayout"]
+        for binding in descriptor["bindings"]
+    } == _expected_layouts()
+    descriptor_dispatch_info = next(
+        binding
+        for binding in descriptor["bindings"]
+        if binding["name"] == "CrossGLDispatchInfo"
+    )
+    assert descriptor_dispatch_info["provenance"] == dispatch_info["provenance"]
+    return descriptor, package_dir
+
+
+def _complex_impulse() -> tuple[list[float], list[float]]:
+    input_values = [0.0] * (MLX_FFT_SIZE * 2)
+    input_values[2] = 1.0
+    expected_values: list[float] = []
+    for index in range(MLX_FFT_SIZE):
+        value = cmath.exp(-2j * math.pi * index / MLX_FFT_SIZE)
+        expected_values.extend((value.real, value.imag))
+    return input_values, expected_values
+
+
+def test_pinned_mlx_fft_executes_through_directx_native_loader():
+    mlx_root = _pinned_mlx_root()
+    with tempfile.TemporaryDirectory(
+        prefix=".crosstl-fft-directx-native-loader-",
+        dir=mlx_root,
+    ) as temporary_directory:
+        descriptor, package_dir = _build_runtime_package(
+            mlx_root,
+            Path(temporary_directory),
+        )
+        input_values, expected_values = _complex_impulse()
+        request = build_native_loader_dispatch_request(
+            descriptor,
+            package_dir,
+            {
+                "fft_mem_256_float2_float2_n_Constants": {
+                    "dtype": "int32",
+                    "shape": [1],
+                    "values": [MLX_FFT_SIZE],
+                },
+                "fft_mem_256_float2_float2_batch_size_Constants": {
+                    "dtype": "int32",
+                    "shape": [1],
+                    "values": [1],
+                },
+                "in_": {
+                    "dtype": "float32",
+                    "shape": [MLX_FFT_SIZE, 2],
+                    "values": input_values,
+                },
+            },
+            {
+                "out_": {
+                    "dtype": "float32",
+                    "shape": [MLX_FFT_SIZE, 2],
+                    "values": expected_values,
+                    "tolerance": {"absolute": 2e-4, "relative": 2e-4},
+                }
+            },
+            (1, 1, 1),
+            expected_target="directx",
+        )
+        assert request.execution_plan is not None
+        assert request.execution_plan.diagnostics == ()
+        assert request.execution_plan.dispatch.workgroup_size == (1, 1, 64)
+        assert request.execution_plan.dispatch.workgroup_count == (1, 1, 1)
+        assert request.execution_plan.dispatch.global_size == (1, 1, 64)
+        fixture_inputs = {value.name: value for value in request.fixture.inputs}
+        assert fixture_inputs["CrossGLDispatchInfo"].values == [1, 1, 1]
+        assert fixture_inputs["CrossGLDispatchInfo"].metadata["source"] == (
+            "dispatch.workgroupCount"
+        )
+
+        executor = RuntimeParityExecutor(
+            RuntimeTestAdapterSpec(
+                adapter_id="mlx-fft-directx-native-loader",
+                target="directx",
+                executor="directx",
+                adapter_kind="directx-native-runtime",
+            ),
+            runtime_adapter=DirectXRuntimeParityAdapter(
+                runtime=DirectXComputeRuntime()
+            ),
+        )
+        availability = executor.is_available(request)
+        if not availability.available:
+            message = availability.reason or "The native DirectX runtime is unavailable"
+            if os.environ.get(REQUIRE_PROOF_ENV) == "1":
+                pytest.fail(message)
+            pytest.skip(message)
+
+        result = executor.run(request)
+
+    assert result.status == "ok"
+    assert result.outputs["out_"]["dtype"] == "float32"
+    assert result.outputs["out_"]["shape"] == [MLX_FFT_SIZE, 2]
+    assert result.outputs["out_"]["values"] == pytest.approx(
+        expected_values,
+        abs=2e-4,
+        rel=2e-4,
+    )

--- a/tests/test_translator/test_mlx_fft_native_loader.py
+++ b/tests/test_translator/test_mlx_fft_native_loader.py
@@ -27,9 +27,7 @@ from crosstl.project import (
 
 MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
 MLX_FFT_SOURCE = "mlx/backend/metal/kernels/fft.metal"
-MLX_FFT_SHA256 = (
-    "3a1fbb38ed64f50a49a20d0c5adb1748d9d06ea20e5931e99aa26be543cb7825"
-)
+MLX_FFT_SHA256 = "3a1fbb38ed64f50a49a20d0c5adb1748d9d06ea20e5931e99aa26be543cb7825"
 MLX_FFT_ENTRY = "fft_mem_256_float2_float2"
 MLX_FFT_GENERATED_SHA256 = (
     "07f9300c2e4860077b344610fbfaa2eadb330e1f9723cb519794f91272bd2289"
@@ -275,9 +273,7 @@ def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
     report_path = work_dir / "portability-report.json"
     report.write_json(report_path)
     runtime_artifacts = build_runtime_artifact_manifest(report_path)
-    assert runtime_artifacts["success"] is True, json.dumps(
-        runtime_artifacts, indent=2
-    )
+    assert runtime_artifacts["success"] is True, json.dumps(runtime_artifacts, indent=2)
     reflected = runtime_artifacts["artifacts"][0]
     resources = reflected["hostInterface"]["resources"]
     assert {resource["name"]: resource["scalarLayout"] for resource in resources} == (
@@ -312,12 +308,9 @@ def _build_runtime_package(mlx_root: Path, work_dir: Path) -> tuple[dict, Path]:
         loader_manifest,
         load_unit_id=load_unit["id"],
     )
-    assert descriptor["entryPoint"]["executionConfig"] == {
-        "numthreads": [1, 1, 64]
-    }
+    assert descriptor["entryPoint"]["executionConfig"] == {"numthreads": [1, 1, 64]}
     assert {
-        binding["name"]: binding["scalarLayout"]
-        for binding in descriptor["bindings"]
+        binding["name"]: binding["scalarLayout"] for binding in descriptor["bindings"]
     } == _expected_layouts()
     descriptor_dispatch_info = next(
         binding
@@ -385,6 +378,16 @@ def test_pinned_mlx_fft_executes_through_directx_native_loader():
         assert request.execution_plan.dispatch.workgroup_size == (1, 1, 64)
         assert request.execution_plan.dispatch.workgroup_count == (1, 1, 1)
         assert request.execution_plan.dispatch.global_size == (1, 1, 64)
+        allocations = {
+            item.binding.name: item.allocation
+            for item in request.execution_plan.resource_bindings
+        }
+        assert allocations["in_"].byte_length == MLX_FFT_SIZE * 8
+        assert allocations["in_"].allocation_byte_length == MLX_FFT_SIZE * 8
+        assert allocations["out_"].byte_length == MLX_FFT_SIZE * 8
+        assert allocations["out_"].allocation_byte_length == MLX_FFT_SIZE * 8
+        assert allocations["CrossGLDispatchInfo"].byte_length == 16
+        assert allocations["CrossGLDispatchInfo"].allocation_byte_length == 16
         fixture_inputs = {value.name: value for value in request.fixture.inputs}
         assert fixture_inputs["CrossGLDispatchInfo"].values == [1, 1, 1]
         assert fixture_inputs["CrossGLDispatchInfo"].metadata["source"] == (

--- a/tests/test_translator/test_native_loader_dispatch.py
+++ b/tests/test_translator/test_native_loader_dispatch.py
@@ -330,6 +330,14 @@ def test_builds_directx_vector_resource_request(tmp_path):
         vector_layout,
         vector_layout,
     ]
+    allocations = {
+        item.binding.name: item.allocation
+        for item in request.execution_plan.resource_bindings
+    }
+    assert allocations["input_values"].byte_length == 32
+    assert allocations["input_values"].allocation_byte_length == 32
+    assert allocations["output_values"].byte_length == 32
+    assert allocations["output_values"].allocation_byte_length == 32
 
 
 def test_builds_directx_vector_constant_buffer_request(tmp_path):
@@ -373,6 +381,9 @@ def test_builds_directx_vector_constant_buffer_request(tmp_path):
     assert binding.kind == "constant-buffer"
     assert binding.metadata["byteStride"] == 12
     assert binding.metadata["scalarLayout"] == vector_layout
+    allocation = request.execution_plan.resource_bindings[0].allocation
+    assert allocation.byte_length == 16
+    assert allocation.allocation_byte_length == 16
 
 
 def test_derives_directx_dispatch_info_from_workgroup_counts(tmp_path):

--- a/tests/test_translator/test_native_loader_dispatch.py
+++ b/tests/test_translator/test_native_loader_dispatch.py
@@ -153,6 +153,48 @@ def _outputs():
     }
 
 
+def _add_directx_dispatch_info_binding(descriptor):
+    layout = {
+        "physicalType": "uint3",
+        "elementType": "uint32",
+        "elementSizeBytes": 12,
+        "elementStrideBytes": 12,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer",
+        "runtimeSized": False,
+        "vectorWidth": 3,
+        "memberName": "crossglNumWorkGroups",
+        "blockSizeBytes": 16,
+    }
+    provenance = {
+        "kind": "generated-execution-input",
+        "executionInput": {
+            "kind": "dispatch-workgroup-count",
+            "valueSource": "dispatch.workgroupCount",
+            "coordinateSpace": "physical",
+            "dimensions": 3,
+            "memberName": "crossglNumWorkGroups",
+        },
+    }
+    descriptor["bindings"].append(
+        {
+            "name": "CrossGLDispatchInfo",
+            "kind": "constant-buffer",
+            "type": "CrossGLDispatchInfo",
+            "namespace": "cbv",
+            "coordinates": {"set": 0, "binding": 4},
+            "access": "read",
+            "scalarLayout": copy.deepcopy(layout),
+            "provenance": provenance,
+        }
+    )
+    descriptor["scalarLayout"]["bindings"].append(
+        {"binding": "CrossGLDispatchInfo", "layout": copy.deepcopy(layout)}
+    )
+    return descriptor
+
+
 def _initialized_read_write_values():
     return {
         "dtype": "float32",
@@ -238,6 +280,230 @@ def test_builds_preflighted_native_runtime_request(
         "input",
         "expectedOutput",
     ]
+
+
+def test_builds_directx_vector_resource_request(tmp_path):
+    descriptor = _write_descriptor(tmp_path)
+    vector_layout = {
+        "physicalType": "float2",
+        "elementType": "float32",
+        "elementSizeBytes": 8,
+        "elementStrideBytes": 8,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer",
+        "runtimeSized": True,
+        "vectorWidth": 2,
+    }
+    for index in range(2):
+        descriptor["bindings"][index]["type"] = (
+            "StructuredBuffer<float2>" if index == 0 else "RWStructuredBuffer<float2>"
+        )
+        descriptor["bindings"][index]["scalarLayout"] = copy.deepcopy(vector_layout)
+        descriptor["scalarLayout"]["bindings"][index]["layout"] = copy.deepcopy(
+            vector_layout
+        )
+
+    values = [1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0]
+    request = _build(
+        tmp_path,
+        descriptor=descriptor,
+        input_values={
+            "input_values": {
+                "dtype": "float32",
+                "shape": [4, 2],
+                "values": values,
+            }
+        },
+        output_values={
+            "output_values": {
+                "dtype": "float32",
+                "shape": [4, 2],
+                "values": values,
+            }
+        },
+    )
+
+    bindings = request.adapter_contract.resource_bindings
+    assert [binding.metadata["byteStride"] for binding in bindings] == [8, 8]
+    assert [binding.metadata["scalarLayout"] for binding in bindings] == [
+        vector_layout,
+        vector_layout,
+    ]
+
+
+def test_builds_directx_vector_constant_buffer_request(tmp_path):
+    descriptor = _write_descriptor(tmp_path)
+    vector_layout = {
+        "physicalType": "uint3",
+        "elementType": "uint32",
+        "elementSizeBytes": 12,
+        "elementStrideBytes": 12,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer",
+        "runtimeSized": False,
+        "vectorWidth": 3,
+        "memberName": "workgroupCount",
+        "blockSizeBytes": 16,
+    }
+    descriptor["bindings"][0].update(
+        {
+            "kind": "constant-buffer",
+            "type": "DispatchInfo",
+            "namespace": "cbv",
+            "scalarLayout": copy.deepcopy(vector_layout),
+        }
+    )
+    descriptor["scalarLayout"]["bindings"][0]["layout"] = copy.deepcopy(vector_layout)
+
+    request = _build(
+        tmp_path,
+        descriptor=descriptor,
+        input_values={
+            "input_values": {
+                "dtype": "uint32",
+                "shape": [3],
+                "values": [2, 3, 4],
+            }
+        },
+    )
+
+    binding = request.adapter_contract.resource_bindings[0]
+    assert binding.kind == "constant-buffer"
+    assert binding.metadata["byteStride"] == 12
+    assert binding.metadata["scalarLayout"] == vector_layout
+
+
+def test_derives_directx_dispatch_info_from_workgroup_counts(tmp_path):
+    descriptor = _add_directx_dispatch_info_binding(_write_descriptor(tmp_path))
+
+    request = _build(
+        tmp_path,
+        descriptor=descriptor,
+        dispatch_geometry=(2, 3, 4),
+    )
+
+    inputs = {value.name: value for value in request.fixture.inputs}
+    dispatch_info = inputs["CrossGLDispatchInfo"]
+    assert dispatch_info.dtype == "uint32"
+    assert dispatch_info.shape == (3,)
+    assert dispatch_info.values == [2, 3, 4]
+    assert dispatch_info.metadata == {
+        "source": "dispatch.workgroupCount",
+        "executionInput": {
+            "kind": "dispatch-workgroup-count",
+            "valueSource": "dispatch.workgroupCount",
+            "coordinateSpace": "physical",
+            "dimensions": 3,
+            "memberName": "crossglNumWorkGroups",
+        },
+    }
+    bound = {
+        item.binding.name: item for item in request.execution_plan.resource_bindings
+    }
+    assert bound["CrossGLDispatchInfo"].source == "input"
+    assert bound["CrossGLDispatchInfo"].value == dispatch_info
+    assert request.execution_plan.dispatch.workgroup_count == (2, 3, 4)
+    assert request.execution_plan.dispatch.global_size == (128, 3, 4)
+
+
+def test_accepts_matching_caller_dispatch_info_and_retains_derived_provenance(
+    tmp_path,
+):
+    descriptor = _add_directx_dispatch_info_binding(_write_descriptor(tmp_path))
+    input_values = {
+        **_inputs(),
+        "CrossGLDispatchInfo": {
+            "dtype": "uint32",
+            "shape": [3],
+            "values": [2, 1, 1],
+            "metadata": {"source": "caller"},
+        },
+    }
+
+    request = _build(
+        tmp_path,
+        descriptor=descriptor,
+        input_values=input_values,
+        dispatch_geometry=(2, 1, 1),
+    )
+
+    inputs = {value.name: value for value in request.fixture.inputs}
+    assert inputs["CrossGLDispatchInfo"].values == [2, 1, 1]
+    assert inputs["CrossGLDispatchInfo"].metadata["source"] == (
+        "dispatch.workgroupCount"
+    )
+
+
+def test_rejects_caller_dispatch_info_that_conflicts_with_geometry(tmp_path):
+    descriptor = _add_directx_dispatch_info_binding(_write_descriptor(tmp_path))
+    input_values = {
+        **_inputs(),
+        "CrossGLDispatchInfo": {
+            "dtype": "uint32",
+            "shape": [3],
+            "values": [1, 1, 1],
+        },
+    }
+
+    with pytest.raises(NativeLoaderDispatchError) as caught:
+        _build(
+            tmp_path,
+            descriptor=descriptor,
+            input_values=input_values,
+            dispatch_geometry=(2, 1, 1),
+        )
+
+    assert caught.value.code.endswith(".execution-input-conflict")
+    assert caught.value.path == "$.inputValues.CrossGLDispatchInfo"
+    assert caught.value.details["derivedValues"] == [2, 1, 1]
+
+
+def test_rejects_unknown_derived_execution_input_contract(tmp_path):
+    descriptor = _add_directx_dispatch_info_binding(_write_descriptor(tmp_path))
+    descriptor["bindings"][-1]["provenance"]["executionInput"][
+        "kind"
+    ] = "logical-grid-size"
+
+    with pytest.raises(NativeLoaderDispatchError) as caught:
+        _build(tmp_path, descriptor=descriptor)
+
+    assert caught.value.code.endswith(".execution-input-unsupported")
+    assert caught.value.path == "$.bindings[2].provenance.executionInput"
+
+
+def test_rejects_partial_directx_vector_resource_value(tmp_path):
+    descriptor = _write_descriptor(tmp_path)
+    vector_layout = {
+        "physicalType": "float2",
+        "elementType": "float32",
+        "elementSizeBytes": 8,
+        "elementStrideBytes": 8,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer",
+        "runtimeSized": True,
+        "vectorWidth": 2,
+    }
+    descriptor["bindings"][0]["scalarLayout"] = copy.deepcopy(vector_layout)
+    descriptor["scalarLayout"]["bindings"][0]["layout"] = copy.deepcopy(vector_layout)
+
+    with pytest.raises(NativeLoaderDispatchError) as caught:
+        _build(
+            tmp_path,
+            descriptor=descriptor,
+            input_values={
+                "input_values": {
+                    "dtype": "float32",
+                    "shape": [3],
+                    "values": [1.0, 2.0, 3.0],
+                }
+            },
+        )
+
+    assert caught.value.code.endswith(".resource-layout-mismatch")
+    assert caught.value.details["vectorWidth"] == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -1380,6 +1380,74 @@ def test_prepare_directx_buffers_maps_and_packs_descriptor_namespaces(tmp_path):
     assert prepared[2].output_name == "result"
 
 
+def test_prepare_directx_buffers_packs_reflected_vector_layouts():
+    dispatch_layout = _scalar_block_layout(
+        "hlsl-constant-buffer",
+        physicalType="uint3",
+        elementSizeBytes=12,
+        elementStrideBytes=12,
+        vectorWidth=3,
+    )
+    bindings = {
+        "dispatch_info": NativeRuntimeBufferBinding(
+            name="dispatch_info",
+            binding=RuntimeResourceBinding(
+                name="dispatch_info",
+                kind="constant-buffer",
+                type_name="DispatchInfo",
+                set=0,
+                binding=0,
+                access="read",
+                metadata={"scalarLayout": dispatch_layout},
+            ),
+            value=[2, 3, 4],
+            source="input",
+            dtype="uint32",
+            shape=(3,),
+        ),
+        "values": NativeRuntimeBufferBinding(
+            name="values",
+            binding=RuntimeResourceBinding(
+                name="values",
+                kind="buffer",
+                type_name="StructuredBuffer<float2>",
+                set=0,
+                binding=0,
+                access="read",
+                metadata={
+                    "byteStride": 8,
+                    "scalarLayout": {
+                        "physicalType": "float2",
+                        "elementType": "float32",
+                        "elementSizeBytes": 8,
+                        "elementStrideBytes": 8,
+                        "alignmentBytes": 4,
+                        "memberOffsetBytes": 0,
+                        "storageLayout": "hlsl-structured-buffer",
+                        "runtimeSized": True,
+                        "vectorWidth": 2,
+                    },
+                },
+            ),
+            value=[1.0, 2.0, 3.0, 4.0],
+            source="input",
+            dtype="float32",
+            shape=(2, 2),
+        ),
+    }
+
+    prepared = _prepare_directx_buffers(bindings)
+
+    assert [(item.name, item.namespace, item.stride) for item in prepared] == [
+        ("dispatch_info", "cbv", 0),
+        ("values", "srv", 8),
+    ]
+    assert prepared[0].payload == struct.pack("<3I", 2, 3, 4)
+    assert prepared[0].allocation_size == 256
+    assert prepared[1].payload == struct.pack("<4f", 1.0, 2.0, 3.0, 4.0)
+    assert prepared[1].allocation_size == 16
+
+
 def test_prepare_directx_buffers_rejects_initialized_unwritable_outputs():
     for binding, reason_kind in (
         (

--- a/tests/test_translator/test_native_runtime_drivers.py
+++ b/tests/test_translator/test_native_runtime_drivers.py
@@ -1398,12 +1398,17 @@ def test_prepare_directx_buffers_packs_reflected_vector_layouts():
                 set=0,
                 binding=0,
                 access="read",
-                metadata={"scalarLayout": dispatch_layout},
+                metadata={"scalarLayout": dispatch_layout, "byteStride": 12},
             ),
             value=[2, 3, 4],
             source="input",
             dtype="uint32",
             shape=(3,),
+            allocation=RuntimeAllocationView(
+                allocation_id="binding:0:0:-:dispatch_info",
+                byte_length=16,
+                allocation_byte_length=16,
+            ),
         ),
         "values": NativeRuntimeBufferBinding(
             name="values",
@@ -1444,6 +1449,7 @@ def test_prepare_directx_buffers_packs_reflected_vector_layouts():
     ]
     assert prepared[0].payload == struct.pack("<3I", 2, 3, 4)
     assert prepared[0].allocation_size == 256
+    assert prepared[0].byte_length == 16
     assert prepared[1].payload == struct.pack("<4f", 1.0, 2.0, 3.0, 4.0)
     assert prepared[1].allocation_size == 16
 

--- a/tests/test_translator/test_runtime_verification.py
+++ b/tests/test_translator/test_runtime_verification.py
@@ -814,6 +814,48 @@ def test_prepare_runtime_execution_keeps_implicit_allocations_independent():
     assert len(set(allocation_ids)) == 2
 
 
+def test_prepare_runtime_execution_sizes_vector_resources_by_physical_elements():
+    vector_layout = {
+        "physicalType": "float2",
+        "elementType": "float32",
+        "elementSizeBytes": 8,
+        "elementStrideBytes": 8,
+        "vectorWidth": 2,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer",
+        "runtimeSized": True,
+    }
+    plan = _prepare_allocation_plan(
+        [
+            RuntimeValue(
+                name="source",
+                dtype="float32",
+                shape=(4, 2),
+                values=[1.0, 0.0] * 4,
+            )
+        ],
+        [],
+        [
+            RuntimeResourceBinding(
+                name="source",
+                kind="buffer",
+                binding=0,
+                access="read",
+                metadata={"scalarLayout": vector_layout},
+            )
+        ],
+        target="directx",
+    )
+
+    assert plan.diagnostics == ()
+    assert plan.resource_bindings[0].allocation == RuntimeAllocationView(
+        allocation_id="binding:-:0:-:source",
+        byte_length=32,
+        allocation_byte_length=32,
+    )
+
+
 def test_prepare_runtime_execution_accepts_aligned_nonoverlapping_views():
     plan = _prepare_allocation_plan(
         [


### PR DESCRIPTION
## Summary

- reflect exact 32-bit scalar and fixed-width vector layouts for HLSL structured and constant buffers
- derive generated DirectX workgroup-count bindings from validated physical dispatch geometry and reject conflicting values
- pack and allocate reflected vector resources through the native Direct3D runtime path
- execute the pinned MLX `fft_mem_256_float2_float2` entry on Direct3D 12 WARP and compare all 256 complex outputs with the analytical forward transform
- require the native FFT proof in Windows CI and record its bounded runtime evidence

## Validation

- `python -m pytest -q -n auto`: 17,392 passed, 228 skipped
- host reflection, loader dispatch, runtime planner/driver, and pinned FFT tests: 330 passed, 17 platform skips
- `pre-commit run --all-files`
- support matrix check: 957 evidence rows present, 0 missing
- support documentation scan: 51 documents passed
- support issue synchronization dry run: 0 mutations

## Scope

This verifies translation, packaging, DXC compilation, Direct3D dispatch, readback, and numerical comparison for one forward complex 256-point FFT workload from MLX commit `4367c73b60541ddd5a266ce4644fd93d20223b6e`. It does not redirect the MLX host runtime, run the MLX test suite, establish broad backend parity, support aggregate `fft.metal` DirectX packaging, or represent non-divisible logical source grids.

Broader dispatch-grid contracts remain tracked by #1542, physical resource layouts by #1543, and aggregate FFT entry partitioning by #1916.

Support issue traceability: no issue closed

