### PR TITLE
Execute pinned MLX copy artifacts on Direct3D and OpenGL

### DIFF
--- a/.github/workflows/mlx-project-porting.yml
+++ b/.github/workflows/mlx-project-porting.yml
@@ -36,6 +36,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_copy_native_loader.py"
       - "tests/test_translator/test_mlx_fft_native_loader.py"
       - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
@@ -71,6 +72,7 @@ on:
       - "tests/test_translator/test_native_loader_dispatch_integration.py"
       - "tests/test_translator/test_mlx_arange_native_loader.py"
       - "tests/test_translator/test_mlx_binary_native_loader.py"
+      - "tests/test_translator/test_mlx_copy_native_loader.py"
       - "tests/test_translator/test_mlx_fft_native_loader.py"
       - "tests/test_translator/test_mlx_logsumexp_native_loader.py"
       - "tests/test_translator/test_private_pointer_partition_runtime.py"
@@ -448,6 +450,15 @@ jobs:
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_binary_native_loader.py::test_pinned_mlx_binary_add_executes_through_directx_native_loader
 
+      - name: Prove pinned MLX copy Direct3D native-loader execution
+        if: runner.os == 'Windows'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_COPY_DIRECTX_NATIVE_LOADER: "1"
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_copy_native_loader.py::test_pinned_mlx_copy_executes_through_directx_native_loader
+
       - name: Prove Direct3D local-struct byte-view native readback
         if: runner.os == 'Windows'
         env:
@@ -547,6 +558,18 @@ jobs:
         run: >-
           python -m pytest -q -n auto
           tests/test_translator/test_mlx_binary_native_loader.py::test_pinned_mlx_binary_add_executes_through_opengl_native_loader
+
+      - name: Prove pinned MLX copy OpenGL native-loader execution
+        if: runner.os == 'Linux'
+        env:
+          CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream
+          CROSTL_REQUIRE_MLX_COPY_OPENGL_NATIVE_LOADER: "1"
+          EGL_PLATFORM: surfaceless
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          PYOPENGL_PLATFORM: egl
+        run: >-
+          python -m pytest -q -n auto
+          tests/test_translator/test_mlx_copy_native_loader.py::test_pinned_mlx_copy_executes_through_opengl_native_loader
 
       - name: Validate pinned MLX LogSumExp OpenGL dispatch artifacts
         if: runner.os == 'Linux'

--- a/demos/integrations/mlx/README.md
+++ b/demos/integrations/mlx/README.md
@@ -634,11 +634,12 @@ are currently absent from Metal round-trip artifacts.
 Native toolchain validation now runs on the target operating systems, completing
 the coverage tracked by CrossGL/crosstl#1312. The bounded Direct3D and OpenGL
 compute runtime drivers tracked by CrossGL/crosstl#1472 and
-CrossGL/crosstl#1516 are also complete. CrossGL/crosstl#1388 still tracks the
-artifact execution metadata required by runtime-test manifests and native
-adapters, and CrossGL/crosstl#1462 covers wiring those contracts to general
-device execution. OpenGL type aliases are inlined before host-interface
-reflection and are not exposed as runtime resources. CrossGL/crosstl#1471
+CrossGL/crosstl#1516 are also complete. Packaged artifacts can now be dispatched
+through the native-loader bridge; remaining source-specific execution gaps are
+recorded with the individual proofs below. CrossGL/crosstl#1388 still tracks the
+broader artifact execution metadata contract. OpenGL type aliases are inlined
+before host-interface reflection and are not exposed as runtime resources.
+CrossGL/crosstl#1471
 tracks entry-point ownership for reflected constants in runtime reports.
 CrossGL/crosstl#1474 is represented by exact per-artifact DirectX
 bfloat16 storage and conversion evidence in the pinned project report. The
@@ -870,6 +871,19 @@ warnings as errors. This proves selected-entry translation and native compiler
 acceptance; it does not execute the shader, establish numerical parity, port
 the MLX runtime dispatch path, or run the MLX test suite.
 
+A separate native-loader check selects `v_copyfloat32float32` from that same
+full source and materializes only `copy_v<float, float, 1>`, pruning 69,915
+unreachable candidate pairs. It packages one HLSL artifact and one GLSL
+artifact with exact reflected scalar buffer layouts, dispatches eight
+nonuniform float32 values through Direct3D 12 WARP on Windows and a headless
+OpenGL software context on Linux, and requires exact readback on both targets.
+The generated artifact hashes, byte counts, binding layouts, and 1-by-1-by-1
+workgroup sizes are fixed in the test. This is bounded execution evidence for
+one scalar copy entry. It does not cover the complex or bfloat16 entries,
+redirect the MLX host runtime, or run the MLX test suite. Aggregate input layout
+for `s_copycomplex64float32` remains part of the physical-resource contract
+tracked by [#1543](https://github.com/CrossGL/crosstl/issues/1543).
+
 The focused `prove_layer_norm_directx.py` gate translates two host-selected
 single-row entries from the pinned `layer_norm.metal` source: forward float32
 with axis size 4099 and VJP float32 with axis size 8192 and `has_w=true`. It
@@ -1046,10 +1060,11 @@ inflating the RMSNorm claim.
 
 This is translation and native compilation evidence only. It does not execute
 RMSNorm, establish numerical or runtime parity, claim complete runtime
-coverage, or claim support for the full MLX test suite. End-to-end device
-execution and host selection of packaged variants remain tracked by
-[CrossGL/crosstl#1462](https://github.com/CrossGL/crosstl/issues/1462) and
-[CrossGL/crosstl#1735](https://github.com/CrossGL/crosstl/issues/1735). The
+coverage, or claim support for the full MLX test suite. The runtime manifest
+currently restores the VJP-only `has_w` function constant onto a forward
+entry-scoped artifact, so native request construction fails closed rather than
+inventing a value. Entry-scoped specialization ownership for that path remains
+tracked by [#1795](https://github.com/CrossGL/crosstl/issues/1795). The
 translated MLX `arange.metal` Direct3D numerical proof remains a separate
 Windows CI check.
 

--- a/demos/integrations/mlx/expected-gaps.json
+++ b/demos/integrations/mlx/expected-gaps.json
@@ -297,6 +297,98 @@
     "numerical_parity_claimed": false,
     "runtime_parity_claimed": false
   },
+  "copy_native_runtime_status": {
+    "status": "translated-packaged-and-native-executed",
+    "commit": "4367c73b60541ddd5a266ce4644fd93d20223b6e",
+    "source": "mlx/backend/metal/kernels/copy.metal",
+    "source_sha256": "ed8a579eb6fe6a14c36560d2c8b548baf99e66fa77d300fb4ad7554883820eba",
+    "selected_entry_point": "v_copyfloat32float32",
+    "template_materialization": {
+      "template": "copy_v",
+      "arguments": {
+        "N": "1",
+        "T": "float",
+        "U": "float"
+      },
+      "reachable_specialization_count": 1,
+      "dependency_discovery_work_count": 0,
+      "pruned_candidate_count": 69915
+    },
+    "artifacts": {
+      "directx": {
+        "target_entry_point": "CSMain",
+        "sha256": "5dcd4bee2b0075ab1bcd61f632b2d76a99a4c0978f6dae84a12c3f972c492a3f",
+        "size_bytes": 1020,
+        "workgroup_size": [
+          1,
+          1,
+          1
+        ],
+        "resource_layouts": {
+          "input_storage": "hlsl-structured-buffer",
+          "output_storage": "hlsl-structured-buffer",
+          "element_type": "float32",
+          "element_stride_bytes": 4,
+          "constant_storage": "hlsl-constant-buffer",
+          "constant_block_size_bytes": 16
+        },
+        "native_runtime": {
+          "platform": "windows-latest",
+          "runtime": "direct3d-12-warp",
+          "status": "required-on-ci",
+          "test": "tests/test_translator/test_mlx_copy_native_loader.py::test_pinned_mlx_copy_executes_through_directx_native_loader"
+        }
+      },
+      "opengl": {
+        "target_entry_point": "main",
+        "sha256": "e91b07ca10b84de624b126420b6cd216a569b639488f40b7afe2527955e226d1",
+        "size_bytes": 1434,
+        "workgroup_size": [
+          1,
+          1,
+          1
+        ],
+        "resource_layouts": {
+          "input_storage": "std430",
+          "output_storage": "std430",
+          "element_type": "float32",
+          "element_stride_bytes": 4,
+          "constant_storage": "std140",
+          "constant_block_size_bytes": 16
+        },
+        "native_runtime": {
+          "platform": "ubuntu-latest",
+          "runtime": "headless-egl-software",
+          "status": "required-on-ci",
+          "test": "tests/test_translator/test_mlx_copy_native_loader.py::test_pinned_mlx_copy_executes_through_opengl_native_loader"
+        }
+      }
+    },
+    "workload": {
+      "dtype": "float32",
+      "shape": [
+        8
+      ],
+      "dispatch_workgroup_count": [
+        8,
+        1,
+        1
+      ],
+      "expected_output": "exact-input-copy",
+      "output_element_count": 8
+    },
+    "mlx_host_runtime_included": false,
+    "runtime_integration_included": true,
+    "selected_workload_numerical_parity_verified": true,
+    "full_mlx_test_suite_included": false,
+    "numerical_parity_claimed": false,
+    "runtime_parity_claimed": false,
+    "remaining_aggregate_layout_scope": {
+      "entry_point": "s_copycomplex64float32",
+      "input_type": "complex64_t",
+      "tracked_by": "https://github.com/CrossGL/crosstl/issues/1543"
+    }
+  },
   "directx_fft_translation_status": {
     "status": "translated-dxc-validated-direct3d-executed",
     "source": "mlx/backend/metal/kernels/fft.metal",
@@ -982,8 +1074,7 @@
     "complete_runtime_coverage_claimed": false,
     "full_mlx_test_suite_included": false,
     "runtime_blocked_by": [
-      "https://github.com/CrossGL/crosstl/issues/1462",
-      "https://github.com/CrossGL/crosstl/issues/1735"
+      "https://github.com/CrossGL/crosstl/issues/1795"
     ]
   },
   "pointer_reinterpretation_status": {
@@ -2885,6 +2976,7 @@
     "https://github.com/CrossGL/crosstl/issues/1696",
     "https://github.com/CrossGL/crosstl/issues/1735",
     "https://github.com/CrossGL/crosstl/issues/1786",
+    "https://github.com/CrossGL/crosstl/issues/1795",
     "https://github.com/CrossGL/crosstl/issues/1894",
     "https://github.com/CrossGL/crosstl/issues/1376",
     "https://github.com/CrossGL/crosstl/issues/1462",

--- a/demos/integrations/mlx/prove_rms_norm_specialization.py
+++ b/demos/integrations/mlx/prove_rms_norm_specialization.py
@@ -56,10 +56,7 @@ RMS_NORM_LOOPED_ENTRY_POINT_COUNT = sum(
 )
 RMS_NORM_SUBGROUP_WIDTH = 32
 RMS_NORM_DIRECTX_PROFILE = "cs_6_6"
-RMS_NORM_RUNTIME_BLOCKERS = (
-    "https://github.com/CrossGL/crosstl/issues/1462",
-    "https://github.com/CrossGL/crosstl/issues/1735",
-)
+RMS_NORM_RUNTIME_BLOCKERS = ("https://github.com/CrossGL/crosstl/issues/1795",)
 RMS_NORM_DIRECTX_VARIANTS = (
     {
         "name": "has_w_false_by_name_workgroup_32",

--- a/tests/fixtures/project_porting/mlx/rms_norm_specialization.fixture-metadata.json
+++ b/tests/fixtures/project_porting/mlx/rms_norm_specialization.fixture-metadata.json
@@ -131,8 +131,7 @@
     "numericalRuntimeParity": false,
     "fullMlxTestSuite": false,
     "runtimeBlockedBy": [
-      "https://github.com/CrossGL/crosstl/issues/1462",
-      "https://github.com/CrossGL/crosstl/issues/1735"
+      "https://github.com/CrossGL/crosstl/issues/1795"
     ]
   }
 }

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -3094,6 +3094,44 @@ def test_mlx_project_porting_workflow_runs_pinned_binary_native_loader_proof():
     assert "-k" not in directx_step
 
 
+def test_mlx_project_porting_workflow_runs_pinned_copy_native_loader_proof():
+    mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
+    ci_coverage = _load_ci_coverage_module()
+    test_path = "tests/test_translator/test_mlx_copy_native_loader.py"
+
+    assert mlx_porting.count(f'"{test_path}"') == 2
+    opengl_step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Prove pinned MLX copy OpenGL native-loader execution",
+    )
+    assert "if: runner.os == 'Linux'" in opengl_step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in opengl_step
+    assert 'CROSTL_REQUIRE_MLX_COPY_OPENGL_NATIVE_LOADER: "1"' in opengl_step
+    assert "EGL_PLATFORM: surfaceless" in opengl_step
+    assert 'LIBGL_ALWAYS_SOFTWARE: "1"' in opengl_step
+    assert "PYOPENGL_PLATFORM: egl" in opengl_step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_copy_executes_through_opengl_native_loader" in opengl_step
+    )
+    assert "-n auto" in opengl_step
+    assert "-k" not in opengl_step
+
+    directx_step = ci_coverage.workflow_step_section(
+        mlx_porting,
+        "Prove pinned MLX copy Direct3D native-loader execution",
+    )
+    assert "if: runner.os == 'Windows'" in directx_step
+    assert "CROSTL_MLX_ROOT: ${{ github.workspace }}/mlx-upstream" in directx_step
+    assert 'CROSTL_REQUIRE_MLX_COPY_DIRECTX_NATIVE_LOADER: "1"' in directx_step
+    assert (
+        f"{test_path}::"
+        "test_pinned_mlx_copy_executes_through_directx_native_loader" in directx_step
+    )
+    assert "-n auto" in directx_step
+    assert "-k" not in directx_step
+
+
 def test_mlx_project_porting_workflow_runs_pinned_logsumexp_native_loader_proof():
     mlx_porting = _workflow_texts().get("mlx-project-porting.yml", "")
     ci_coverage = _load_ci_coverage_module()

--- a/tests/test_mlx_porting_harness.py
+++ b/tests/test_mlx_porting_harness.py
@@ -9918,6 +9918,102 @@ def test_full_corpus_checkpoint_probe_records_verified_resume_coordinate():
     }
 
 
+def test_copy_native_runtime_evidence_records_bounded_cross_target_proof():
+    gaps = json.loads(
+        (ROOT / "demos" / "integrations" / "mlx" / "expected-gaps.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    status = gaps["copy_native_runtime_status"]
+    assert status["status"] == "translated-packaged-and-native-executed"
+    assert status["commit"] == "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+    assert status["source"] == "mlx/backend/metal/kernels/copy.metal"
+    assert status["source_sha256"] == (
+        "ed8a579eb6fe6a14c36560d2c8b548baf99e66fa77d300fb4ad7554883820eba"
+    )
+    assert status["selected_entry_point"] == "v_copyfloat32float32"
+    assert status["template_materialization"] == {
+        "template": "copy_v",
+        "arguments": {"N": "1", "T": "float", "U": "float"},
+        "reachable_specialization_count": 1,
+        "dependency_discovery_work_count": 0,
+        "pruned_candidate_count": 69915,
+    }
+    assert status["artifacts"]["directx"] == {
+        "target_entry_point": "CSMain",
+        "sha256": "5dcd4bee2b0075ab1bcd61f632b2d76a99a4c0978f6dae84a12c3f972c492a3f",
+        "size_bytes": 1020,
+        "workgroup_size": [1, 1, 1],
+        "resource_layouts": {
+            "input_storage": "hlsl-structured-buffer",
+            "output_storage": "hlsl-structured-buffer",
+            "element_type": "float32",
+            "element_stride_bytes": 4,
+            "constant_storage": "hlsl-constant-buffer",
+            "constant_block_size_bytes": 16,
+        },
+        "native_runtime": {
+            "platform": "windows-latest",
+            "runtime": "direct3d-12-warp",
+            "status": "required-on-ci",
+            "test": (
+                "tests/test_translator/test_mlx_copy_native_loader.py::"
+                "test_pinned_mlx_copy_executes_through_directx_native_loader"
+            ),
+        },
+    }
+    assert status["artifacts"]["opengl"] == {
+        "target_entry_point": "main",
+        "sha256": "e91b07ca10b84de624b126420b6cd216a569b639488f40b7afe2527955e226d1",
+        "size_bytes": 1434,
+        "workgroup_size": [1, 1, 1],
+        "resource_layouts": {
+            "input_storage": "std430",
+            "output_storage": "std430",
+            "element_type": "float32",
+            "element_stride_bytes": 4,
+            "constant_storage": "std140",
+            "constant_block_size_bytes": 16,
+        },
+        "native_runtime": {
+            "platform": "ubuntu-latest",
+            "runtime": "headless-egl-software",
+            "status": "required-on-ci",
+            "test": (
+                "tests/test_translator/test_mlx_copy_native_loader.py::"
+                "test_pinned_mlx_copy_executes_through_opengl_native_loader"
+            ),
+        },
+    }
+    assert status["workload"] == {
+        "dtype": "float32",
+        "shape": [8],
+        "dispatch_workgroup_count": [8, 1, 1],
+        "expected_output": "exact-input-copy",
+        "output_element_count": 8,
+    }
+    assert status["mlx_host_runtime_included"] is False
+    assert status["runtime_integration_included"] is True
+    assert status["selected_workload_numerical_parity_verified"] is True
+    assert status["full_mlx_test_suite_included"] is False
+    assert status["numerical_parity_claimed"] is False
+    assert status["runtime_parity_claimed"] is False
+    assert status["remaining_aggregate_layout_scope"] == {
+        "entry_point": "s_copycomplex64float32",
+        "input_type": "complex64_t",
+        "tracked_by": "https://github.com/CrossGL/crosstl/issues/1543",
+    }
+
+    readme = " ".join(MLX_README_PATH.read_text(encoding="utf-8").split())
+    assert "selects `v_copyfloat32float32` from that same full source" in readme
+    assert "materializes only `copy_v<float, float, 1>`" in readme
+    assert "pruning 69,915 unreachable candidate pairs" in readme
+    assert "requires exact readback on both targets" in readme
+    assert "bounded execution evidence for one scalar copy entry" in readme
+    assert "does not cover the complex or bfloat16 entries" in readme
+
+
 def test_fft_directx_evidence_records_selected_native_runtime_proof():
     module = _load_harness()
     gaps = json.loads(

--- a/tests/test_translator/test_mlx_copy_native_loader.py
+++ b/tests/test_translator/test_mlx_copy_native_loader.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from crosstl.project import (
+    DirectXComputeRuntime,
+    DirectXRuntimeParityAdapter,
+    OpenGLComputeRuntime,
+    OpenGLRuntimeParityAdapter,
+    ProjectConfig,
+    RuntimeParityExecutor,
+    RuntimeTestAdapterSpec,
+    build_native_loader_abi_descriptor,
+    build_native_loader_dispatch_request,
+    build_runtime_artifact_manifest,
+    build_runtime_loader_manifest,
+    build_runtime_package,
+    translate_project,
+)
+
+MLX_COMMIT = "4367c73b60541ddd5a266ce4644fd93d20223b6e"
+MLX_COPY_SOURCE = "mlx/backend/metal/kernels/copy.metal"
+MLX_COPY_SHA256 = "ed8a579eb6fe6a14c36560d2c8b548baf99e66fa77d300fb4ad7554883820eba"
+MLX_COPY_ENTRY = "v_copyfloat32float32"
+MLX_COPY_TEMPLATE_ARGUMENTS = {"N": "1", "T": "float", "U": "float"}
+MLX_COPY_GENERATED_ARTIFACTS = {
+    "directx": {
+        "sha256": "5dcd4bee2b0075ab1bcd61f632b2d76a99a4c0978f6dae84a12c3f972c492a3f",
+        "sizeBytes": 1020,
+    },
+    "opengl": {
+        "sha256": "e91b07ca10b84de624b126420b6cd216a569b639488f40b7afe2527955e226d1",
+        "sizeBytes": 1434,
+    },
+}
+REQUIRE_PROOF_ENVS = {
+    "directx": "CROSTL_REQUIRE_MLX_COPY_DIRECTX_NATIVE_LOADER",
+    "opengl": "CROSTL_REQUIRE_MLX_COPY_OPENGL_NATIVE_LOADER",
+}
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _skip_or_fail(target: str, message: str) -> None:
+    if os.environ.get(REQUIRE_PROOF_ENVS[target]) == "1":
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+def _pinned_mlx_root() -> Path:
+    root_value = os.environ.get("CROSTL_MLX_ROOT")
+    if not root_value:
+        if any(os.environ.get(name) == "1" for name in REQUIRE_PROOF_ENVS.values()):
+            pytest.fail("CROSTL_MLX_ROOT is not configured")
+        pytest.skip("CROSTL_MLX_ROOT is not configured")
+
+    mlx_root = Path(root_value).resolve()
+    source_path = mlx_root / MLX_COPY_SOURCE
+    if not source_path.is_file():
+        pytest.fail(f"Pinned MLX copy source is missing: {source_path}")
+
+    checkout_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=mlx_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert checkout_commit == MLX_COMMIT
+    assert hashlib.sha256(source_path.read_bytes()).hexdigest() == MLX_COPY_SHA256
+    return mlx_root
+
+
+def _project_config(mlx_root: Path, output_dir: str, target: str) -> ProjectConfig:
+    return ProjectConfig(
+        root=mlx_root,
+        source_roots=("mlx/backend/metal/kernels",),
+        include_patterns=(MLX_COPY_SOURCE,),
+        targets=(target,),
+        output_dir=output_dir,
+        source_overrides={MLX_COPY_SOURCE: "metal"},
+        entry_points={MLX_COPY_SOURCE: MLX_COPY_ENTRY},
+        include_dirs=(".",),
+        source_options={
+            "metal": {
+                "max_template_specializations": 16,
+                "max_template_materialization_work": 64,
+            }
+        },
+    )
+
+
+def _expected_scalar_layouts(target: str) -> dict[str, dict]:
+    runtime_array = {
+        "physicalType": "float",
+        "elementType": "float32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 4,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-structured-buffer" if target == "directx" else "std430",
+        "runtimeSized": True,
+    }
+    constant = {
+        "physicalType": "uint",
+        "elementType": "uint32",
+        "elementSizeBytes": 4,
+        "elementStrideBytes": 4,
+        "alignmentBytes": 16,
+        "memberOffsetBytes": 0,
+        "storageLayout": "hlsl-constant-buffer" if target == "directx" else "std140",
+        "runtimeSized": False,
+        "blockSizeBytes": 16,
+    }
+    if target == "directx":
+        return {
+            "v_copyfloat32float32_size_Constants": {
+                **constant,
+                "memberName": "v_copyfloat32float32_size",
+            },
+            "src": dict(runtime_array),
+            "dst": dict(runtime_array),
+        }
+    return {
+        "srcBuffer": {**runtime_array, "memberName": "src"},
+        "dstBuffer": {**runtime_array, "memberName": "dst"},
+        "v_copyfloat32float32_size_Args": {**constant, "memberName": "size"},
+    }
+
+
+def _build_runtime_package(
+    mlx_root: Path, work_dir: Path, target: str
+) -> tuple[dict, Path]:
+    output_dir = work_dir / "out"
+    report = translate_project(
+        _project_config(
+            mlx_root,
+            output_dir.relative_to(mlx_root).as_posix(),
+            target,
+        ),
+        targets=(target,),
+        output_dir=output_dir.relative_to(mlx_root).as_posix(),
+        format_output=False,
+        validate=False,
+    )
+    payload = report.to_json()
+
+    assert payload["summary"]["unitCount"] == 1
+    assert payload["summary"]["artifactCount"] == 1
+    assert payload["summary"]["translatedCount"] == 1
+    assert payload["summary"]["failedCount"] == 0
+    assert payload["summary"]["diagnosticCounts"] == {
+        "error": 0,
+        "note": 0,
+        "warning": 0,
+    }
+    assert payload["diagnostics"] == []
+
+    artifact = payload["artifacts"][0]
+    target_entry = "CSMain" if target == "directx" else "main"
+    assert artifact["source"] == MLX_COPY_SOURCE
+    assert artifact["sourceHash"] == {
+        "algorithm": "sha256",
+        "value": MLX_COPY_SHA256,
+    }
+    assert artifact["entryPoint"] == {
+        "source": MLX_COPY_ENTRY,
+        "target": target_entry,
+        "stage": "compute",
+    }
+    assert artifact["provenance"] == {
+        "intermediate": "crossgl",
+        "pipeline": "entry-scoped-translate",
+    }
+    assert artifact["generatedHash"] == {
+        "algorithm": "sha256",
+        "value": MLX_COPY_GENERATED_ARTIFACTS[target]["sha256"],
+    }
+    assert artifact["generatedSizeBytes"] == (
+        MLX_COPY_GENERATED_ARTIFACTS[target]["sizeBytes"]
+    )
+    materialization = artifact["templateMaterialization"]
+    assert materialization["status"] == "materialized"
+    assert materialization["specializationCount"] == 1
+    assert materialization["unsupported"] == []
+    assert materialization["accounting"] == {
+        "reachableSpecializationCount": 1,
+        "dependencyDiscoveryWorkCount": 0,
+        "prunedCandidateCount": 69915,
+    }
+    assert materialization["specializations"] == [
+        {
+            "name": "copy_v",
+            "hostName": MLX_COPY_ENTRY,
+            "materializedName": MLX_COPY_ENTRY,
+            "parameters": MLX_COPY_TEMPLATE_ARGUMENTS,
+            "parameterSources": {
+                "N": "source-instantiation",
+                "T": "source-instantiation",
+                "U": "source-instantiation",
+            },
+            "source": "source-instantiation",
+        }
+    ]
+
+    generated = (mlx_root / artifact["path"]).read_text(encoding="utf-8")
+    if target == "directx":
+        assert "src.Load((index + i))" in generated
+    else:
+        assert "src[(index + uint(i))]" in generated
+
+    report_path = work_dir / "portability-report.json"
+    report.write_json(report_path)
+    runtime_artifacts = build_runtime_artifact_manifest(report_path)
+    assert runtime_artifacts["success"] is True, json.dumps(runtime_artifacts, indent=2)
+    assert runtime_artifacts["summary"]["artifactCount"] == 1
+    reflected = runtime_artifacts["artifacts"][0]
+    assert reflected["hostInterface"]["status"] == "ready"
+    reflected_layouts = {
+        resource["name"]: resource["scalarLayout"]
+        for resource in reflected["hostInterface"]["resources"]
+    }
+    assert reflected_layouts == _expected_scalar_layouts(target)
+
+    runtime_artifacts_path = work_dir / "runtime-artifacts.json"
+    _write_json(runtime_artifacts_path, runtime_artifacts)
+    package_dir = work_dir / "runtime-package"
+    package = build_runtime_package(runtime_artifacts_path, package_dir)
+    assert package["success"] is True, json.dumps(package, indent=2)
+
+    loader_manifest = build_runtime_loader_manifest(
+        package_dir / "runtime-package.json"
+    )
+    assert loader_manifest["success"] is True, json.dumps(loader_manifest, indent=2)
+    assert loader_manifest["summary"]["readyLoadUnitCount"] == 1
+    assert loader_manifest["summary"]["blockedLoadUnitCount"] == 0
+    load_unit = loader_manifest["loadUnits"][0]
+    descriptor = build_native_loader_abi_descriptor(
+        loader_manifest,
+        load_unit_id=load_unit["id"],
+    )
+    assert descriptor["target"] == target
+    assert descriptor["entryPoint"]["name"] == target_entry
+    expected_execution = (
+        {"numthreads": [1, 1, 1]}
+        if target == "directx"
+        else {"local_size_x": 1, "local_size_y": 1, "local_size_z": 1}
+    )
+    assert descriptor["entryPoint"]["executionConfig"] == expected_execution
+    assert descriptor["specializationConstants"] == []
+    descriptor_layouts = {
+        binding["name"]: binding["scalarLayout"] for binding in descriptor["bindings"]
+    }
+    assert descriptor_layouts == _expected_scalar_layouts(target)
+    return descriptor, package_dir
+
+
+def _execute_pinned_mlx_copy(target: str) -> None:
+    mlx_root = _pinned_mlx_root()
+    with tempfile.TemporaryDirectory(
+        prefix=f".crosstl-copy-{target}-native-loader-",
+        dir=mlx_root,
+    ) as temporary_directory:
+        descriptor, package_dir = _build_runtime_package(
+            mlx_root,
+            Path(temporary_directory),
+            target,
+        )
+        values = [-3.5, -1.25, 0.0, 0.125, 1.5, 7.75, 1024.5, -0.03125]
+        if target == "directx":
+            size_binding = "v_copyfloat32float32_size_Constants"
+            input_binding = "src"
+            output_binding = "dst"
+        else:
+            size_binding = "v_copyfloat32float32_size_Args"
+            input_binding = "srcBuffer"
+            output_binding = "dstBuffer"
+
+        request = build_native_loader_dispatch_request(
+            descriptor,
+            package_dir,
+            {
+                size_binding: {
+                    "dtype": "uint32",
+                    "shape": [1],
+                    "values": [len(values)],
+                },
+                input_binding: {
+                    "dtype": "float32",
+                    "shape": [len(values)],
+                    "values": values,
+                },
+            },
+            {
+                output_binding: {
+                    "dtype": "float32",
+                    "shape": [len(values)],
+                    "values": values,
+                }
+            },
+            (len(values), 1, 1),
+            expected_target=target,
+        )
+        assert request.execution_plan is not None
+        assert request.execution_plan.diagnostics == ()
+        assert request.execution_plan.dispatch.workgroup_size == (1, 1, 1)
+        assert request.execution_plan.dispatch.workgroup_count == (len(values), 1, 1)
+        assert request.execution_plan.dispatch.global_size == (len(values), 1, 1)
+
+        runtime_adapter = (
+            DirectXRuntimeParityAdapter(runtime=DirectXComputeRuntime())
+            if target == "directx"
+            else OpenGLRuntimeParityAdapter(
+                runtime=OpenGLComputeRuntime(context_backends=("egl",))
+            )
+        )
+        executor = RuntimeParityExecutor(
+            RuntimeTestAdapterSpec(
+                adapter_id=f"mlx-copy-{target}-native-loader",
+                target=target,
+                executor=target,
+                adapter_kind=f"{target}-native-runtime",
+            ),
+            runtime_adapter=runtime_adapter,
+        )
+        availability = executor.is_available(request)
+        if not availability.available:
+            _skip_or_fail(
+                target,
+                availability.reason or f"The native {target} runtime is unavailable",
+            )
+
+        result = executor.run(request)
+
+    assert result.status == "ok"
+    assert result.outputs == {
+        output_binding: {
+            "dtype": "float32",
+            "shape": [len(values)],
+            "values": values,
+        }
+    }
+
+
+def test_pinned_mlx_copy_executes_through_directx_native_loader():
+    _execute_pinned_mlx_copy("directx")
+
+
+def test_pinned_mlx_copy_executes_through_opengl_native_loader():
+    _execute_pinned_mlx_copy("opengl")


### PR DESCRIPTION
## Summary

- translate `v_copyfloat32float32` from the full pinned MLX `copy.metal` source for DirectX and OpenGL
- package and reflect exact scalar ABI layouts, then require exact eight-element readback through Direct3D 12 WARP and headless OpenGL CI
- record deterministic artifact identities, bounded runtime claims, and the remaining aggregate `complex64_t` layout boundary
- replace closed RMSNorm runtime blockers with the active entry-scoped specialization ownership issue

## Validation

- `python -m pytest -q -n auto` (17,393 passed, 231 skipped)
- `pre-commit run --all-files`
- support matrix update and consistency checks
- support signal update and consistency checks
- support issue synchronization dry run
- generated OpenGL artifact compiled with `glslangValidator` and validated with `spirv-val`

## Scope

This proves translation, packaging, native execution, and exact readback for one float32 copy entry on Direct3D and OpenGL. It does not redirect the MLX host runtime, cover aggregate or bfloat16 copy entries, or claim passage of the MLX test suite.

Related to #1543 and #1795.


Support issue traceability: no issue closed